### PR TITLE
map: add a search bar

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -25,6 +25,7 @@ import {defaultMapRegionForZones, ZoneMap} from 'components/content/ZoneMap';
 import {Center, HStack, View, VStack} from 'components/core';
 import {DangerScale} from 'components/DangerScale';
 import {TravelAdvice} from 'components/helpers/travelAdvice';
+import {PlacesSearchBar} from 'components/map/PlacesSearchBar';
 import {Body, BodySmSemibold, Caption1, Caption1Black, Title3Black} from 'components/text';
 import {MapViewZone, useMapViewZones} from 'hooks/useMapViewZones';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -109,6 +110,8 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
               });
             }}>
             <View height={12} />
+            <PlacesSearchBar px={24} />
+            <View height={8} />
             <DangerScale px={4} width="100%" />
           </VStack>
         </View>

--- a/components/map/PlacesSearchBar.tsx
+++ b/components/map/PlacesSearchBar.tsx
@@ -1,0 +1,45 @@
+import {AntDesign} from '@expo/vector-icons';
+import {Center, HStack, View} from 'components/core';
+import {BodySm} from 'components/text';
+import {useGooglePlacesAPIKey} from 'hooks/useGooglePlacesAPIKey';
+import React from 'react';
+import {GooglePlacesAutocomplete} from 'react-native-google-places-autocomplete';
+import {colorLookup} from 'theme';
+
+export type PlacesSearchBarProps = Omit<React.ComponentProps<typeof View>, 'children'>;
+
+export const PlacesSearchBar: React.FunctionComponent<PlacesSearchBarProps> = props => {
+  const apiKey = useGooglePlacesAPIKey();
+  return (
+    <View {...props}>
+      <HStack backgroundColor="#FFFFFF" borderRadius={12} px={12} py={4} justifyContent="space-between" alignItems="center" alignContent="flex-start">
+        <AntDesign name="search1" size={25} color={colorLookup('text.secondary')} />
+        <GooglePlacesAutocomplete
+          textInputProps={{
+            placeholderTextColor: colorLookup('text.secondary'),
+          }}
+          styles={{
+            textInput: {
+              height: 40,
+              paddingVertical: 0,
+              paddingHorizontal: 4,
+              marginBottom: 0,
+              backgroundColor: 'clear',
+            },
+          }}
+          placeholder={'Search for location...'}
+          enablePoweredByContainer={false}
+          query={{key: apiKey}}
+          onPress={data => console.log(`press details: ${JSON.stringify(data)}`)}
+          onNotFound={() => console.log(`no results found`)}
+          onFail={error => console.log(`query error: ${JSON.stringify(error)}`)}
+          listEmptyComponent={() => (
+            <Center>
+              <BodySm>No results were found.</BodySm>
+            </Center>
+          )}
+        />
+      </HStack>
+    </View>
+  );
+};

--- a/hooks/useGooglePlacesAPIKey.ts
+++ b/hooks/useGooglePlacesAPIKey.ts
@@ -1,0 +1,18 @@
+import Constants from 'expo-constants';
+import {Platform} from 'react-native';
+
+export const useGooglePlacesAPIKey = () => {
+  const platform = Platform.OS;
+  switch (platform) {
+    case 'ios':
+      return Constants.expoConfig.ios.config.googleMapsApiKey;
+    case 'android':
+      return Constants.expoConfig.android.config.googleMaps.apiKey;
+    case 'macos':
+    case 'windows':
+    case 'web':
+      throw new Error(`No Google Places API key exists for platform: ${platform}`);
+  }
+  const invalid: never = platform;
+  throw new Error(`Unknown platform: ${invalid}`);
+};

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-native": "0.70.5",
     "react-native-collapsible": "^1.6.0",
     "react-native-gesture-handler": "~2.8.0",
+    "react-native-google-places-autocomplete": "^2.5.1",
     "react-native-maps": "1.3.2",
     "react-native-reanimated": "~2.12.0",
     "react-native-render-html": "^6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11541,6 +11541,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
+qs@~6.9.1:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
+
 query-string@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
@@ -11663,6 +11668,15 @@ react-native-gesture-handler@~2.8.0:
     invariant "^2.2.4"
     lodash "^4.17.21"
     prop-types "^15.7.2"
+
+react-native-google-places-autocomplete@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/react-native-google-places-autocomplete/-/react-native-google-places-autocomplete-2.5.1.tgz#93d5ac3e34e3e8f594aae5349f9e2d3e0b87484e"
+  integrity sha512-2FZZomogB18mLSC/N39UcpiVoJn/fFIpud1M2KZMom/pJhSMgfqV4qLjHuzaDyYIl7KBz/zpGDcbYgmtvvpkHQ==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    prop-types "^15.7.2"
+    qs "~6.9.1"
 
 react-native-gradle-plugin@^0.70.3:
   version "0.70.3"


### PR DESCRIPTION
@floatplane currently stuck on how to get this to work in Expo Go for us - our API keys are restricted for use only by our "real" app - and this library (the only one ...) chooses not to use the normal SDKs, so whatever magic Expo Go does to make the map work, is not applied here by default. Will need to figure that out, or get a dev token ...