### PR TITLE
Looking into setting up mixpanel for app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -78,7 +78,7 @@ if(ExpoMixpanelAnalytics != null)
   const mixpanel_token = Constants.expoConfig.extra!.mixpanel;
   logger.info('Mixpanel is initializing.');
   // Only initialize Mixpanel if we can find the correct env setup
-  if (mixpanel_token === 'LOADED_FROM_ENVIRONMENT') {
+  if (mixpanel_token === 'LOADED_FROM_ENVIRONMENT' || mixpanel_token == null) {
     logger.warn('Mixpanel integration not configured, check your environment');
   }
   else

--- a/App.tsx
+++ b/App.tsx
@@ -56,6 +56,8 @@ import axios, {AxiosRequestConfig} from 'axios';
 import {createLogger, stdSerializers} from 'browser-bunyan';
 import {ConsoleFormattedStream} from 'logging/consoleFormattedStream';
 
+import ExpoMixpanelAnalytics from '@bothrs/expo-mixpanel-analytics';
+
 // we're reading a field that was previously defined in app.json, so we know it's non-null:
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const logLevel = Constants.expoConfig.extra!.log_level;
@@ -68,6 +70,24 @@ const logger = createLogger({
 });
 
 logger.info('App starting.');
+
+if(ExpoMixpanelAnalytics != null)
+{
+  // we're reading a field that was previously defined in app.json, so we know it's non-null:
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const mixpanel_token = Constants.expoConfig.extra!.mixpanel;
+  logger.info('MIXPANEL');
+  logger.info(mixpanel_token);
+  // Only initialize Mixpanel if we can find the correct env setup
+  if (mixpanel_token === 'LOADED_FROM_ENVIRONMENT') {
+    logger.warn('Mixpanel integration not configured, check your environment');
+  }
+  else
+  {
+    const analytics = new ExpoMixpanelAnalytics(mixpanel_token);
+    analytics.track("App starting.");
+  }
+}
 
 const encodeParams = params => {
   return Object.entries(params)

--- a/App.tsx
+++ b/App.tsx
@@ -76,8 +76,7 @@ if(ExpoMixpanelAnalytics != null)
   // we're reading a field that was previously defined in app.json, so we know it's non-null:
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const mixpanel_token = Constants.expoConfig.extra!.mixpanel;
-  logger.info('MIXPANEL');
-  logger.info(mixpanel_token);
+  logger.info('Mixpanel is initializing.');
   // Only initialize Mixpanel if we can find the correct env setup
   if (mixpanel_token === 'LOADED_FROM_ENVIRONMENT') {
     logger.warn('Mixpanel integration not configured, check your environment');

--- a/app.config.ts
+++ b/app.config.ts
@@ -12,6 +12,7 @@ export default ({config}: ConfigContext): Partial<ExpoConfig> => {
   config.android!.config!.googleMaps!.apiKey = process.env.ANDROID_GOOGLE_MAPS_API_KEY;
   config.hooks!.postPublish![0]!.config!.authToken = process.env.SENTRY_API_TOKEN;
   config.extra!.sentry_dsn = process.env.SENTRY_DSN;
+  config.extra!.mixpanel = process.env.MIXPANEL_TOKEN;
   config.extra!.log_level = process.env.LOG_LEVEL != null ? process.env.LOG_LEVEL : 'info';
 
   return config;

--- a/app.json
+++ b/app.json
@@ -70,7 +70,8 @@
       },
       "sentry_dsn": "LOADED_FROM_ENVIRONMENT",
       "avalanche_center": "NWAC",
-      "log_level": "info"
+      "log_level": "info",
+      "mixpanel": "LOADED_FROM_ENVIRONMENT"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@bothrs/expo-mixpanel-analytics": "^2.0.3",
     "@browser-bunyan/console-formatted-stream": "^1.8.0",
     "@browser-bunyan/console-raw-stream": "^1.8.0",
     "@browser-bunyan/levels": "^1.8.0",


### PR DESCRIPTION
Found this implementation: https://www.npmjs.com/package/@bothrs/expo-mixpanel-analytics, added and tested it to send an event on when app starts (via expo on IOS, havent tried Android yet) The package I am using is basically wrapping around simple http calls, I'd say it likely makes sense once we have a better idea of what we want to track to just build our own vs taking a dependency (https://developer.mixpanel.com/reference/import-events)

Since the expected path seems to not work for expo (tried it and it comes back null on IOS, havent dug too much into it but likely due to some specific platform setting) 
https://github.com/mixpanel/mixpanel-react-native

Error I got when I tried mixpanel-react-native (possible that this error only happens in expo go and wouldnt happen in Test Flight, may be worth checking)
![image](https://github.com/stevekuznetsov/avalanche-forecast/assets/9418602/dc02cb8b-8ae0-4961-97fc-7e4529352c3b)


test event that this PR produces can be seen [here](https://mixpanel.com/project/3000673/view/3519389/app/events). 

p.s. added the Mixpanel token to our expo secrets. 