### PR TITLE
Fix android dark mode weirdness

### DIFF
--- a/components/form/SwitchField.tsx
+++ b/components/form/SwitchField.tsx
@@ -37,6 +37,7 @@ export function SwitchField<T>({name, label, items, ...props}: SwitchFieldProps<
             field.onChange(value);
           }
         }}
+        appearance="light"
       />
     </VStack>
   );


### PR DESCRIPTION
It seems like the SegmentedControl needs to have its `appearance` property set explicitly - it's not aware of the Expo `userInterfaceStyle` property set in app.json.

I'd show you screenshots but getting them off my android device and onto my mac will probably take me about 30 minutes. I pasted them into an email in gmail and tried to send it, and this is what arrived:

<img width="953" alt="image" src="https://github.com/NWACus/avy/assets/101196/db206a1f-1fdd-4c7f-8a01-f2e6d22f9038">

Android is...sigh