### PR TITLE
Add more info to date formatting errors

### DIFF
--- a/utils/date.test.ts
+++ b/utils/date.test.ts
@@ -9,6 +9,10 @@ describe('Dates', () => {
       const d = new Date('2023-01-19T02:00:00Z');
       expect(apiDateString(d)).toEqual('2023-01-19');
     });
+
+    it('throws a useful error when given an invalid date', () => {
+      expect(() => apiDateString(new Date('2023-01-32'))).toThrow('Failed to format date: Invalid time value, Invalid Date, yyyy-MM-dd, UTC');
+    });
   });
 
   describe('utcDateToLocalTimeString', () => {

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,5 +1,13 @@
 import {add, isAfter} from 'date-fns';
-import {format, formatInTimeZone, toDate} from 'date-fns-tz';
+import {format, formatInTimeZone as formatInTimeZoneDateFnsTz, toDate} from 'date-fns-tz';
+
+const formatInTimeZone = (date: string | number | Date, timeZone: string, formatString: string) => {
+  try {
+    return formatInTimeZoneDateFnsTz(date, timeZone, formatString);
+  } catch (e: unknown) {
+    throw new Error(`Failed to format date: ${(e as Error).message}, ${date.toString()}, ${formatString}, ${timeZone}`, {cause: e});
+  }
+};
 
 export const toISOStringUTC = (date: Date) => formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm:ssXXX');
 


### PR DESCRIPTION
We're getting a bunch of `RangeError`s thrown by `formatInTimeZone` that are showing up in Sentry. I suspect they're spurious but want to know more. This just puts a wrapper around the function and rethrows any exception with a more detailed message.