### PR TITLE
Fix "The following actions uses node12 which is deprecated and will be forced to run on node16"

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: 🏗 Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
         cache: yarn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup
       - name: 🎨 Run prettier
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup
       - name: 🧹 Run eslint
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup
       - name: 🎨 Run typescript compiler (tsc)
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup
       - name: 🕵️‍♀️  Run tests
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup
       - name: 👩‍⚕️ Expo Doctor

--- a/.github/workflows/publish-build.yaml
+++ b/.github/workflows/publish-build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -22,7 +22,7 @@ jobs:
       SENTRY_AUTH_TOKEN: $ {{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Publish EAS update
         uses: ./.github/actions/expo/update

--- a/.github/workflows/pull_request_closed.yaml
+++ b/.github/workflows/pull_request_closed.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Clean up PR channel
         uses: ./.github/actions/expo/channel/delete


### PR DESCRIPTION
fixes https://github.com/NWACus/avy/issues/8. Just needed to update actions/checkout@v2->v3 and ctions/setup-node@v2 -> v3, based on documentation that is where node 16 is supported. Tried on the update and seemed to not break anything. 

https://github.com/NWACus/avy/actions/runs/6294661816 -> no more warnings :D