### PR TITLE
Add drop shadow to InfoTooltip modal

### DIFF
--- a/components/content/InfoTooltip.tsx
+++ b/components/content/InfoTooltip.tsx
@@ -57,7 +57,25 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
           <View position="absolute" top={0} bottom={0} left={0} right={0}>
             <SafeAreaView>
               <Center width="100%" height="100%">
-                <VStack alignItems="center" bg="white" borderRadius={16} px={12} py={24} m={12} space={8}>
+                <VStack
+                  alignItems="center"
+                  bg="white"
+                  borderRadius={16}
+                  px={12}
+                  py={24}
+                  m={12}
+                  space={8}
+                  style={{
+                    shadowColor: '#000',
+                    shadowOffset: {
+                      width: 0,
+                      height: 2,
+                    },
+                    shadowOpacity: 0.25,
+                    shadowRadius: 3.84,
+
+                    elevation: 5,
+                  }}>
                   <AntDesign name={solidIcon} color={colorLookup('primary')} size={30} />
                   <Title3Semibold>{title}</Title3Semibold>
                   <HTMLRendererConfig baseStyle={finalHtmlStyle}>


### PR DESCRIPTION
Fixes #388. Shadow style courtesy of https://ethercreative.github.io/react-native-shadow-generator/

![simulator_screenshot_DD3616AA-BBFC-44AC-B54B-DA7A3C5891B7](https://github.com/NWACus/avy/assets/101196/b9a5aee4-b849-4ff2-899c-aaebf71389ad)
