### PR TITLE
Making logging to file work again

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -45,6 +45,7 @@ import {useAppState} from 'hooks/useAppState';
 import ImageCache, {queryKeyPrefix} from 'hooks/useCachedImageURI';
 import {useOnlineManager} from 'hooks/useOnlineManager';
 import {IntlProvider} from 'intl';
+import {getLogger} from 'logger';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {prefetchAllActiveForecasts} from 'network/prefetchAllActiveForecasts';
 import Toast, {ToastConfigParams} from 'react-native-toast-message';
@@ -54,10 +55,8 @@ import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
 require('date-time-format-timezone');
 
 import axios, {AxiosRequestConfig} from 'axios';
-import {createLogger, stdSerializers} from 'browser-bunyan';
 import {QUERY_CACHE_ASYNC_STORAGE_KEY} from 'data/asyncStorageKeys';
 import * as FileSystem from 'expo-file-system';
-import {ConsoleFormattedStream} from 'logging/consoleFormattedStream';
 import {PreferencesProvider, usePreferences} from 'Preferences';
 // eslint-disable-next-line no-restricted-imports
 import {TamaguiProvider, Theme} from 'tamagui';
@@ -67,14 +66,7 @@ import {formatRequestedTime, RequestedTime} from 'utils/date';
 
 import * as messages from 'compiled-lang/en.json';
 
-const logLevel = (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO';
-
-const logger = createLogger({
-  name: 'avalanche-forecast',
-  level: logLevel,
-  serializers: stdSerializers,
-  stream: new ConsoleFormattedStream(),
-});
+const logger = getLogger();
 
 logger.info('App starting.');
 

--- a/App.tsx
+++ b/App.tsx
@@ -45,7 +45,7 @@ import {useAppState} from 'hooks/useAppState';
 import ImageCache, {queryKeyPrefix} from 'hooks/useCachedImageURI';
 import {useOnlineManager} from 'hooks/useOnlineManager';
 import {IntlProvider} from 'intl';
-import {getLogger} from 'logger';
+import {logger} from 'logger';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {prefetchAllActiveForecasts} from 'network/prefetchAllActiveForecasts';
 import Toast, {ToastConfigParams} from 'react-native-toast-message';
@@ -65,8 +65,6 @@ import {NotFoundError} from 'types/requests';
 import {formatRequestedTime, RequestedTime} from 'utils/date';
 
 import * as messages from 'compiled-lang/en.json';
-
-const logger = getLogger();
 
 logger.info('App starting.');
 

--- a/App.tsx
+++ b/App.tsx
@@ -45,7 +45,7 @@ import {useAppState} from 'hooks/useAppState';
 import ImageCache, {queryKeyPrefix} from 'hooks/useCachedImageURI';
 import {useOnlineManager} from 'hooks/useOnlineManager';
 import {IntlProvider} from 'intl';
-import {logger} from 'logger';
+import {logFilePath, logger} from 'logger';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {prefetchAllActiveForecasts} from 'network/prefetchAllActiveForecasts';
 import Toast, {ToastConfigParams} from 'react-native-toast-message';
@@ -117,6 +117,14 @@ if (Sentry?.init) {
       dsn,
       enableInExpoDevelopment: Boolean(process.env.EXPO_PUBLIC_SENTRY_IN_DEV),
       enableWatchdogTerminationTracking: true,
+      beforeSend: async (event, hint) => {
+        const {exists} = await FileSystem.getInfoAsync(logFilePath);
+        if (exists) {
+          const data = await FileSystem.readAsStringAsync(logFilePath);
+          hint.attachments = [{filename: 'log.json', data, contentType: 'application/json'}];
+        }
+        return event;
+      },
     });
   }
 }

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -207,7 +207,15 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                           disabled={Platform.OS === 'ios'}
                           onPress={() => {
                             void (async () => {
-                              if (!(await sendMail({to: 'developer+app-logs@nwac.us', subject: 'NWAC app log files', attachments: [logFilePath], logger}))) {
+                              if (
+                                !(await sendMail({
+                                  to: 'developer+app-logs@nwac.us',
+                                  subject: 'NWAC app log files',
+                                  body: `\n\n---\n\nRun \`yarn bunyan ${logFilePath.split('/').slice(-1)[0]}\` to view.\nRun \`yarn bunyan --help\` for additional options.`,
+                                  attachments: [logFilePath],
+                                  logger,
+                                }))
+                              ) {
                                 Toast.show({
                                   type: 'error',
                                   text1: 'Email is not configured!',

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -201,9 +201,10 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                         />
                         <Button
                           buttonStyle="normal"
-                          // log files aren't being written so let's disable this for now
-                          // https://github.com/NWACus/avy/issues/383 tracks fixing this
-                          disabled
+                          // this is disabled on iOS and enabled on Android,
+                          // since we don't have proper attachment support on iOS
+                          // https://github.com/expo/expo/issues/24613
+                          disabled={Platform.OS === 'ios'}
                           onPress={() => {
                             void (async () => {
                               if (!(await sendMail({to: 'developer+app-logs@nwac.us', subject: 'NWAC app log files', attachments: [logFilePath], logger}))) {

--- a/logger.ts
+++ b/logger.ts
@@ -1,6 +1,7 @@
-import {Logger, createLogger, stdSerializers} from 'browser-bunyan';
+import {StreamOptions, createLogger, stdSerializers} from 'browser-bunyan';
 import Constants from 'expo-constants';
 import * as FileSystem from 'expo-file-system';
+import * as Updates from 'expo-updates';
 import {ConsoleFormattedStream} from 'logging/consoleFormattedStream';
 import {FileStream} from 'logging/fileStream';
 import {LogBox} from 'react-native';
@@ -20,25 +21,23 @@ if (process.env.EXPO_PUBLIC_DISABLE_LOGBOX) {
   LogBox.ignoreAllLogs(true);
 }
 
-let theLogger: Logger | undefined = undefined;
+const streams: StreamOptions[] = [
+  {
+    level: (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO',
+    stream: new ConsoleFormattedStream(),
+  },
+];
 
-// Get the singleton logger for the app. Will create the object if it doesn't exist.
-export const getLogger = (): Logger => {
-  if (!theLogger) {
-    theLogger = createLogger({
-      name: 'avy',
-      serializers: stdSerializers,
-      streams: [
-        {
-          level: (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO',
-          stream: new ConsoleFormattedStream(),
-        },
-        {
-          level: 'DEBUG',
-          stream: new FileStream(logFilePath),
-        },
-      ],
-    });
-  }
-  return theLogger;
-};
+// Log to file in preview and development channels
+if (Updates.channel !== 'release') {
+  streams.push({
+    level: 'DEBUG',
+    stream: new FileStream(logFilePath),
+  });
+}
+
+export const logger = createLogger({
+  name: 'avy',
+  serializers: stdSerializers,
+  streams,
+});

--- a/logger.ts
+++ b/logger.ts
@@ -1,8 +1,12 @@
+import {Logger, createLogger, stdSerializers} from 'browser-bunyan';
+import Constants from 'expo-constants';
 import * as FileSystem from 'expo-file-system';
+import {ConsoleFormattedStream} from 'logging/consoleFormattedStream';
+import {FileStream} from 'logging/fileStream';
 import {LogBox} from 'react-native';
 
 // react-native-logs always logs to FS.documentDirectory
-const LOG_PATH = 'log.txt';
+const LOG_PATH = 'log.json';
 export const logFilePath = String(FileSystem.documentDirectory) + LOG_PATH;
 
 // Always delete the log file on startup
@@ -15,3 +19,26 @@ if (process.env.NODE_ENV !== 'test') {
 if (process.env.EXPO_PUBLIC_DISABLE_LOGBOX) {
   LogBox.ignoreAllLogs(true);
 }
+
+let theLogger: Logger | undefined = undefined;
+
+// Get the singleton logger for the app. Will create the object if it doesn't exist.
+export const getLogger = (): Logger => {
+  if (!theLogger) {
+    theLogger = createLogger({
+      name: 'avy',
+      serializers: stdSerializers,
+      streams: [
+        {
+          level: (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO',
+          stream: new ConsoleFormattedStream(),
+        },
+        {
+          level: 'DEBUG',
+          stream: new FileStream(logFilePath),
+        },
+      ],
+    });
+  }
+  return theLogger;
+};

--- a/loggerContext.ts
+++ b/loggerContext.ts
@@ -1,5 +1,5 @@
 import {Logger} from 'browser-bunyan';
-import {getLogger} from 'logger';
+import {logger} from 'logger';
 import React, {Context} from 'react';
 
 export interface LoggerProps {
@@ -7,5 +7,5 @@ export interface LoggerProps {
 }
 
 export const LoggerContext: Context<LoggerProps> = React.createContext<LoggerProps>({
-  logger: getLogger(),
+  logger,
 });

--- a/loggerContext.ts
+++ b/loggerContext.ts
@@ -1,4 +1,5 @@
-import {createLogger, Logger, stdSerializers} from 'browser-bunyan';
+import {Logger} from 'browser-bunyan';
+import {getLogger} from 'logger';
 import React, {Context} from 'react';
 
 export interface LoggerProps {
@@ -6,8 +7,5 @@ export interface LoggerProps {
 }
 
 export const LoggerContext: Context<LoggerProps> = React.createContext<LoggerProps>({
-  logger: createLogger({
-    name: 'avalanche-forecast',
-    serializers: stdSerializers,
-  }),
+  logger: getLogger(),
 });

--- a/logging/fileStream.ts
+++ b/logging/fileStream.ts
@@ -1,0 +1,36 @@
+import {LogStream} from 'browser-bunyan';
+import * as FileSystem from 'expo-file-system';
+import {debounce} from 'lodash';
+
+export class FileStream implements LogStream {
+  private readonly filePath: string;
+  private buffer: string[];
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+    this.buffer = [];
+    void FileSystem.writeAsStringAsync(this.filePath, '');
+  }
+
+  private FLUSH_INTERVAL_MS = 1000;
+
+  // Flush the buffer to disk, but only once per second
+  // Yes, there's no way to append to a file in a managed Expo app :(
+  private flush = debounce(async (): Promise<void> => {
+    const buffer = this.buffer;
+    this.buffer = [];
+    const contents = await FileSystem.readAsStringAsync(this.filePath);
+    return await FileSystem.writeAsStringAsync(this.filePath, contents + buffer.join('\n') + '\n');
+  }, this.FLUSH_INTERVAL_MS);
+
+  write(record: object): void {
+    const recordString = JSON.stringify({
+      // the bunyan command line tool can't format these records correctly without a pid and hostname field
+      pid: 0,
+      hostname: 'localhost',
+      ...record,
+    });
+    this.buffer.push(recordString);
+    void this.flush();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "add": "^2.0.6",
     "babel-plugin-formatjs": "^10.5.6",
     "babel-plugin-module-resolver": "^4.1.0",
+    "bunyan": "^1.8.15",
     "eslint": "^8.49.0",
     "eslint-plugin-absolute-imports": "^0.0.3",
     "eslint-plugin-import": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6797,6 +6797,16 @@ builtins@^1.0.3:
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==
 
+bunyan@^1.8.15:
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.19.3"
+    mv "~2"
+    safe-json-stringify "~1"
+
 busboy@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
@@ -8275,6 +8285,13 @@ dset@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.2.tgz#89c436ca6450398396dc6538ea00abc0c54cd45a"
   integrity sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==
+
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
 
 duplexer3@^0.1.4:
   version "0.1.5"
@@ -12407,6 +12424,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.19.3:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -12444,6 +12466,11 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
+
+nan@^2.14.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
+  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
 
 nanoid@^3.1.23:
   version "3.3.4"


### PR DESCRIPTION
~~Putting up as a draft but I think I should make at least one more change: not logging to file in release builds.~~

Logging to file in this implementation is stupidly expensive, because AFAICT you can only write whole files with the [Expo FileSystem API](https://docs.expo.dev/versions/latest/sdk/filesystem). I don't really want to keep all log lines in memory but maybe that would actually be better? At least then I wouldn't need to read the whole file before writing 🤷. Anyway, I try to minimize the badness by buffering up writes and flushing at most once per second. I'm guessing that our old logging package was doing something similar but I don't know.

The other change I made was to centralize creation of the logger object and make it a singleton.

Now, the good news: you can get badass views of these log files. Here's one showing filtering by log level, colored output and nice object formatting:

<img width="818" alt="image" src="https://github.com/NWACus/avy/assets/101196/bbe66972-325d-4ad0-8aa5-0309e81f5b46">

This PR will resolve #383, but emailing log files on iOS won't be supported until #382 is resolved.