### PR TITLE
Get the current git hash into apps from EAS build

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -9,6 +9,13 @@
       "distribution": "internal",
       "channel": "main"
     },
+    "simulator": {
+      "distribution": "internal",
+      "channel": "main",
+      "ios": {
+        "simulator": true
+      }
+    },
     "preview": {
       "channel": "preview",
       "autoIncrement": true

--- a/eas_build_and_submit.sh
+++ b/eas_build_and_submit.sh
@@ -38,5 +38,5 @@ jq  < eas.json.tmpl > eas.json \
   '.submit.release.ios={appleId:$IOS_USER_ID,appleTeamId:$IOS_TEAM_ID,ascAppId:$IOS_APP_ID} | .submit.preview.ios=.submit.release.ios'
 
 set -o xtrace
-EXPO_PUBLIC_GIT_REVISION=$(git rev-parse --short HEAD) eas build --non-interactive --platform "${PLATFORM}" --profile "${PROFILE}" --auto-submit
+eas build --non-interactive --platform "${PLATFORM}" --profile "${PROFILE}" --auto-submit
 set +o xtrace

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ci:eslint": "scripts/eslint.sh",
     "ci:prettier": "scripts/ci-prettier.sh",
     "ci:tsc": "scripts/ci-tsc.sh",
+    "eas-build-pre-install": "set-env EXPO_PUBLIC_GIT_REVISION $EAS_BUILD_GIT_COMMIT_HASH",
     "gen-openapi": "scripts/gen-openapi.sh",
     "graphql:codegen": "graphql codegen",
     "graphql:schema": "get-graphql-schema https://api.avalanche.org/obs/v1/public/graphql > types/observations-schema.graphql",


### PR DESCRIPTION
EAS Build doesn't do everything in a single step - it's more of an orchestrator that invokes a series of build steps, and it's very specific about the environment that those build steps see. This means that if you try to pass an environment variable through it, like so:

`FOO=bar eas build ...`

the substeps won't see `FOO`. 

However, you can call `set-env` from one of the build hooks that's supplied and that works great. So with this PR we now have the git revision showing up in the about screen of all the apps. This screenshot is from a local build installed on the simulator:

<img width="420" alt="image" src="https://github.com/NWACus/avy/assets/101196/9cca4150-fa2b-4b97-8466-3330113a0afe">

I added some quick notes on how to build locally and install the build on a simulator in https://github.com/NWACus/avy/wiki/Local-builds.