### PR TITLE
App header

### DIFF
--- a/components/content/NavigationHeader.tsx
+++ b/components/content/NavigationHeader.tsx
@@ -1,30 +1,43 @@
 import {AntDesign} from '@expo/vector-icons';
 import {getHeaderTitle} from '@react-navigation/elements';
 import {NativeStackHeaderProps} from '@react-navigation/native-stack/lib/typescript/src/types';
-import {HStack} from 'components/core';
-import {Title3Black} from 'components/text';
+import {AvalancheCenterLogo} from 'components/AvalancheCenterLogo';
+import {HStack, View} from 'components/core';
+import {Title1Black, Title3Black} from 'components/text';
 import React from 'react';
 import {SafeAreaView} from 'react-native';
 import {colorLookup} from 'theme';
+import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
 
-export const NavigationHeader: React.FunctionComponent<NativeStackHeaderProps> = ({navigation, route, options, back}) => {
+export const NavigationHeader: React.FunctionComponent<
+  NativeStackHeaderProps & {
+    center_id: AvalancheCenterID;
+    large?: boolean;
+  }
+> = ({navigation, route, options, back, center_id, large}) => {
   const title = getHeaderTitle(options, route.name);
+  const TextComponent = large ? Title1Black : Title3Black;
 
   return (
     <SafeAreaView style={{width: '100%', backgroundColor: 'white'}}>
-      <HStack justifyContent="flex-start" pb={8} style={options.headerStyle}>
-        {back && (
+      <HStack justifyContent="space-between" pb={8} style={options.headerStyle} space={8} pl={3} pr={16}>
+        {back ? (
           <AntDesign.Button
             size={24}
             color={colorLookup('text')}
             name="arrowleft"
             backgroundColor="white"
-            iconStyle={{marginLeft: 0, marginRight: 8}}
-            style={{textAlign: 'center'}}
+            iconStyle={{marginLeft: 0, marginRight: 0}}
+            style={{textAlign: 'center', borderColor: 'transparent', borderWidth: 1}}
             onPress={() => navigation.goBack()}
           />
+        ) : (
+          <View width={42} />
         )}
-        <Title3Black>{title}</Title3Black>
+        <TextComponent textAlign="center" style={{flex: 1, borderColor: 'transparent', borderWidth: 1}}>
+          {title}
+        </TextComponent>
+        <AvalancheCenterLogo style={{height: 32, width: 32, resizeMode: 'contain', flex: 0, flexGrow: 0}} avalancheCenterId={center_id} />
       </HStack>
     </SafeAreaView>
   );

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -12,7 +12,7 @@ const AvalancheCenterStack = createNativeStackNavigator<HomeStackParamList>();
 export const HomeTabScreen = ({route}: NativeStackScreenProps<TabNavigatorParamList, 'Home'>) => {
   const {center_id, requestedTime} = route.params;
   return (
-    <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter" screenOptions={{header: props => <NavigationHeader {...props} />}}>
+    <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter" screenOptions={{header: props => <NavigationHeader center_id={center_id} {...props} />}}>
       <AvalancheCenterStack.Screen
         name="avalancheCenter"
         component={MapScreen}
@@ -20,7 +20,11 @@ export const HomeTabScreen = ({route}: NativeStackScreenProps<TabNavigatorParamL
         options={{headerShown: false}}
       />
       <AvalancheCenterStack.Screen name="forecast" component={ForecastScreen} initialParams={{center_id: center_id, requestedTime: requestedTime}} options={{headerShown: false}} />
-      <AvalancheCenterStack.Screen name="stationDetail" component={StationDetailScreen} options={{headerShown: false}} />
+      <AvalancheCenterStack.Screen
+        name="stationDetail"
+        component={StationDetailScreen}
+        options={{title: 'Weather Station', header: props => <NavigationHeader center_id={center_id} {...props} />}}
+      />
       <AvalancheCenterStack.Screen
         name="observation"
         component={ObservationScreen}

--- a/components/screens/ObservationsScreen.tsx
+++ b/components/screens/ObservationsScreen.tsx
@@ -17,7 +17,7 @@ export const ObservationsTabScreen = ({route}: NativeStackScreenProps<TabNavigat
     <ObservationsStack.Navigator
       initialRouteName="observationsPortal"
       screenOptions={{
-        header: props => <NavigationHeader {...props} />,
+        header: props => <NavigationHeader center_id={center_id} {...props} />,
       }}>
       <ObservationsStack.Screen
         name="observationsPortal"

--- a/components/screens/WeatherScreen.tsx
+++ b/components/screens/WeatherScreen.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {NavigationHeader} from 'components/content/NavigationHeader';
-import {HStack, View, VStack} from 'components/core';
-import {Title1Black} from 'components/text';
+import {View, VStack} from 'components/core';
 import {WeatherStationDetail} from 'components/weather_data/WeatherStationDetail';
 import {WeatherStationList} from 'components/weather_data/WeatherStationList';
 import {StyleSheet} from 'react-native';
@@ -18,9 +17,14 @@ export const WeatherScreen = ({route}: NativeStackScreenProps<TabNavigatorParamL
     <WeatherStack.Navigator
       initialRouteName="stationList"
       screenOptions={{
-        header: props => <NavigationHeader {...props} />,
+        header: props => <NavigationHeader center_id={center_id} {...props} />,
       }}>
-      <WeatherStack.Screen name="stationList" component={StationListScreen} initialParams={{center_id: center_id, requestedTime}} options={{headerShown: false}} />
+      <WeatherStack.Screen
+        name="stationList"
+        component={StationListScreen}
+        options={{title: 'Weather Stations', header: props => <NavigationHeader center_id={center_id} {...props} large />}}
+        initialParams={{center_id: center_id, requestedTime}}
+      />
       <WeatherStack.Screen name="stationDetail" component={StationDetailScreen} options={{title: 'Weather Station'}} />
     </WeatherStack.Navigator>
   );
@@ -30,11 +34,8 @@ const StationListScreen = ({route}: NativeStackScreenProps<WeatherStackParamList
   return (
     <View style={{...StyleSheet.absoluteFillObject}} bg="white">
       {/* SafeAreaView shouldn't inset from bottom edge because TabNavigator is sitting there */}
-      <SafeAreaView edges={['top', 'left', 'right']} style={{height: '100%', width: '100%'}}>
+      <SafeAreaView edges={['left', 'right']} style={{height: '100%', width: '100%'}}>
         <VStack width="100%" height="100%" justifyContent="space-between" alignItems="stretch" bg="background.base">
-          <HStack width="100%" py={8} px={16} bg="white">
-            <Title1Black>Weather Stations</Title1Black>
-          </HStack>
           <WeatherStationList {...route.params} />
         </VStack>
       </SafeAreaView>

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -44,7 +44,7 @@ export const useNACObservations = (center_id: AvalancheCenterID, endDate: Reques
       if (new Date(lastPage.startDate) > lookbackWindowStart) {
         return lastPage.startDate;
       } else {
-        thisLogger.debug('nac getNextPageParam', 'no more data available in window!', lastPage.startDate, lookbackWindowStart, window);
+        thisLogger.debug('nac getNextPageParam', 'no more data available in window!', lastPage.startDate, lookbackWindowStart, endDate);
         return undefined;
       }
     },

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -42,7 +42,7 @@ export const useNWACObservations = (center_id: AvalancheCenterID, endDate: Reque
       if (lastPage.meta.next) {
         return lastPage.meta.offset + lastPage.meta.limit;
       } else {
-        thisLogger.debug('nwac getNextPageParam', 'no more data available in window!', key, lastPage.meta, lookbackWindowStart, window);
+        thisLogger.debug('nwac getNextPageParam', 'no more data available in window!', key, lastPage.meta, lookbackWindowStart, endDate);
         return undefined;
       }
     },


### PR DESCRIPTION
This takes a pass at solving the problem of “A User should be able to tell at any given point which avalanche center they are viewing for” by updating the navigation headers to include the current center icon. Many screen shots follow. Fixes #401 as well.

Also fixes a problem where the obs queries were trying to log the global root object `window`, with predictably bad results :D 

---
# NWAC

&nbsp; | &nbsp;
--- | ---
![simulator_screenshot_D3577519-71B4-45F5-A67B-D75F75D1AC9E](https://github.com/NWACus/avy/assets/101196/35b71955-7bc8-433e-82bb-491b7fd98648) | ![simulator_screenshot_ECEDF6AB-0B2D-43B3-9464-763A85BA52EA](https://github.com/NWACus/avy/assets/101196/664f6397-6a33-47dc-b12b-f32ce34e4780)
![simulator_screenshot_B06CF57C-E3BC-4E41-9E8C-645AE6608A04](https://github.com/NWACus/avy/assets/101196/d9a3f753-c9ad-4126-bb0a-3b4c65dd1327) | ![simulator_screenshot_B7923BBD-F5A6-4FFF-BBCC-C93EDDE7D59A](https://github.com/NWACus/avy/assets/101196/005bac55-c515-406d-867c-53651a5ee669)


---
# SNFAC
not much to see here yet

&nbsp; | &nbsp;
--- | ---
![simulator_screenshot_6A1B2678-F3E6-4215-9058-0A0B93BC7963](https://github.com/NWACus/avy/assets/101196/e14167b1-84ae-4d25-b3f0-c7b4445a796f) | ![simulator_screenshot_5400732A-830A-45B9-AA54-C769FF4A06E2](https://github.com/NWACus/avy/assets/101196/85b5a785-28f7-4238-9bda-f6b37141cdb7)


