### PR TITLE
Fix unintentional void-ing of callback methods

### DIFF
--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -251,7 +251,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         }}
         ListEmptyComponent={<NotFound inline terminal what={[new NotFoundError('no observations found', 'any matching observations')]} />}
         style={{backgroundColor: colorLookup('background.base'), width: '100%', height: '100%'}}
-        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={void refresh} />}
+        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={() => void refresh()} />}
         data={displayedObservations}
         getItemLayout={(data, index) => ({length: OBSERVATION_SUMMARY_CARD_HEIGHT, offset: OBSERVATION_SUMMARY_CARD_HEIGHT * index, index})}
         renderItem={renderItem}

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -439,7 +439,7 @@ export const SimpleForm: React.FC<{
                           )}
                         />
                       )}
-                      <Button buttonStyle="normal" onPress={void pickImage} disabled={images.length === maxImageCount}>
+                      <Button buttonStyle="normal" onPress={() => void pickImage()} disabled={images.length === maxImageCount}>
                         <BodyBlack>Select an image</BodyBlack>
                       </Button>
                     </VStack>

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "expo-mail-composer": "~12.3.0",
     "expo-splash-screen": "~0.20.5",
     "expo-status-bar": "~1.6.0",
-    "expo-updates": "~0.18.13",
+    "expo-updates": "~0.18.14",
     "expo-web-browser": "~12.3.2",
     "get-graphql-schema": "^2.1.2",
     "global": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9043,10 +9043,10 @@ expo-updates-interface@~0.10.0:
   resolved "https://registry.yarnpkg.com/expo-updates-interface/-/expo-updates-interface-0.10.1.tgz#cab075641cd381718ccd9264bf133dc393430a44"
   integrity sha512-I6JMR7EgjXwckrydDmrkBEX/iw750dcqpzQVsjznYWfi0HTEOxajLHB90fBFqQkUV5i5s4Fd3hYQ1Cn0oMzUbA==
 
-expo-updates@~0.18.13:
-  version "0.18.13"
-  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.18.13.tgz#c61d4239e8a8ef5b85455cbca033d70eeff79975"
-  integrity sha512-+6Z3C38EAptYbY1/J4JIWChJKtdaEJSSfTxrSqdG6ES4RnBqSdpdH4513YiOezpE1WhCqPtQHfJW2Lsu7O1odA==
+expo-updates@~0.18.14:
+  version "0.18.14"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.18.14.tgz#dd67ef729a1d81ab5ca551a47dd2bf6254a49ce3"
+  integrity sha512-RHlo44Xo4mgXrLqhDK52s0xE1nOFdf0FAMfuQD5O5+uKLk6vbNqwwX8FejiIbrVLhlYTkldUPBPlTsp0G9vB8A==
   dependencies:
     "@expo/code-signing-certificates" "0.0.5"
     "@expo/config" "~8.1.0"


### PR DESCRIPTION
@stevekuznetsov I'm guessing this got changed in the great Typescript tightening of the summer, in an attempt to suppress warnings about ignoring promise resolutions. 

An expression like this:

```
onPress={pickImage}
```

sets `onPress` to  the value of the function `pickImage`, while an expression like this:

```
onPress={void pickImage}
```

sets `onPress` to `undefined` - not what was intended. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void

I found this when looking at #404, then searched for `{void` to see if I could find any others - hopefully these are the only two instances.