### PR TITLE
Observation upload improvements

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -51,3 +51,8 @@ IOS_GOOGLE_MAPS_API_KEY=
 # Set this to enable the weather station map for non-NWAC centers.
 #
 # EXPO_PUBLIC_ENABLE_WEATHER_MAP=1
+
+#
+# Set this to enable one-click creation of fake observations.
+#
+EXPO_PUBLIC_AUTOFILL_FAKE_OBSERVATION=1

--- a/App.tsx
+++ b/App.tsx
@@ -35,7 +35,6 @@ import {PersistQueryClientProvider} from '@tanstack/react-query-persist-client';
 
 import {ClientContext, ClientProps, productionHosts, stagingHosts} from 'clientContext';
 import {ActionToast, ErrorToast, InfoToast, SuccessToast, WarningToast} from 'components/content/Toast';
-import {clearUploadCache} from 'components/observations/submitObservation';
 import {HomeTabScreen} from 'components/screens/HomeScreen';
 import {MenuStackScreen} from 'components/screens/MenuScreen';
 import {ObservationsTabScreen} from 'components/screens/ObservationsScreen';
@@ -217,8 +216,6 @@ const asyncStoragePersister = createAsyncStoragePersister({
   storage: AsyncStorage,
   key: QUERY_CACHE_ASYNC_STORAGE_KEY,
 });
-
-void clearUploadCache();
 
 const TabNavigator = createBottomTabNavigator<TabNavigatorParamList>();
 

--- a/App.tsx
+++ b/App.tsx
@@ -74,6 +74,8 @@ const encodeParams = (params: {[s: string]: string}) => {
     .join('&');
 };
 
+// Sometimes we're sending very large data params like base64-encoded images.
+// Let's not log those, eh?
 const filterBigStrings = (params: unknown): unknown => {
   if (!params || (typeof params !== 'object' && typeof params !== 'string')) {
     return params;
@@ -81,6 +83,10 @@ const filterBigStrings = (params: unknown): unknown => {
 
   if (typeof params === 'string') {
     return params.length > 100 ? params.substring(0, 100) + '...' : params;
+  }
+
+  if (Array.isArray(params)) {
+    return params.map(filterBigStrings);
   }
 
   return Object.fromEntries(

--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -37,82 +37,85 @@ const locationPointSchema = z.object(
 );
 export type LocationPoint = z.infer<typeof locationPointSchema>;
 
-// For the form, we have specific rules that we require for any new observations
-// we create, thus we don't reuse the existing observationSchema
-export const simpleObservationFormSchema = z
-  .object({
-    activity: z.array(z.nativeEnum(Activity)).min(1, 'You must select at least one activity.'),
-    avalanches_summary: z.string().optional(),
-    email: z.string({required_error: required}).email("That doesn't look like an email address."),
-    instability: z.object({
-      avalanches_observed: z.boolean(),
-      avalanches_triggered: z.boolean(),
-      avalanches_caught: z.boolean(),
-      cracking: z.boolean(),
-      cracking_description: z.nativeEnum(InstabilityDistribution).optional(),
-      collapsing: z.boolean(),
-      collapsing_description: z.nativeEnum(InstabilityDistribution).optional(),
-    }),
-    location_name: z.string({required_error: required}).max(256, tooLong),
-    location_point: locationPointSchema,
-    name: z.string({required_error: required}).max(50, tooLong),
-    observation_summary: z.string({required_error: required}).max(1024, tooLong),
-    photoUsage: z.nativeEnum(MediaUsage, {required_error: required}),
-    private: z.boolean(),
-    start_date: z.date({required_error: required}),
-  })
-  .superRefine((arg, ctx) => {
-    // Some more complex validations to apply here
+// This schema captures all of the data fields that we upload in order to create a new observation.
+// This schema can be used to persist an observation to disk and later parse it, for resuming uploads when we're offline.
+export const simpleObservationFormSchema = z.object({
+  activity: z.array(z.nativeEnum(Activity)).min(1, 'You must select at least one activity.'),
+  avalanches_summary: z.string().optional(),
+  email: z.string({required_error: required}).email("That doesn't look like an email address."),
+  instability: z.object({
+    avalanches_observed: z.boolean(),
+    avalanches_triggered: z.boolean(),
+    avalanches_caught: z.boolean(),
+    cracking: z.boolean(),
+    cracking_description: z.nativeEnum(InstabilityDistribution).optional(),
+    collapsing: z.boolean(),
+    collapsing_description: z.nativeEnum(InstabilityDistribution).optional(),
+  }),
+  location_name: z.string({required_error: required}).max(256, tooLong),
+  location_point: locationPointSchema,
+  name: z.string({required_error: required}).max(50, tooLong),
+  observation_summary: z.string({required_error: required}).max(1024, tooLong),
+  photoUsage: z.nativeEnum(MediaUsage, {required_error: required}),
+  private: z.boolean(),
+  start_date: z.date({required_error: required}),
+});
 
-    // if instability.avalanches_observed, then we'll want avalanches_summary to exist
-    if (arg.instability?.avalanches_observed) {
-      const {avalanches_summary} = arg;
-      if (!avalanches_summary || avalanches_summary.length === 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: required,
-          path: ['avalanches_summary'],
-        });
-      } else if (avalanches_summary.length > 1024) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: tooLong,
-          path: ['avalanches_summary'],
-        });
-      }
+// For the form, we have specific validation rules that we require for any new observations
+// we create, rules that can't be captured via simpleObservationFormSchema. Note that the result of `superRefine`
+// can't be converted to a TS type via infer. This is only used for form validation.
+export const simpleObservationFormSchemaWithValidations = simpleObservationFormSchema.superRefine((arg, ctx) => {
+  // Some more complex validations to apply here
+
+  // if instability.avalanches_observed, then we'll want avalanches_summary to exist
+  if (arg.instability?.avalanches_observed) {
+    const {avalanches_summary} = arg;
+    if (!avalanches_summary || avalanches_summary.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: required,
+        path: ['avalanches_summary'],
+      });
+    } else if (avalanches_summary.length > 1024) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: tooLong,
+        path: ['avalanches_summary'],
+      });
     }
+  }
 
-    // if instability.cracking, then we'll want cracking_description to be set
-    // cracking_description is an enum, so no max length validation is required -
-    // it just needs to be set
-    if (arg.instability?.cracking) {
-      const {cracking_description} = arg.instability;
-      if (!cracking_description || cracking_description.length === 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: required,
-          path: ['instability', 'cracking_description'],
-        });
-      }
+  // if instability.cracking, then we'll want cracking_description to be set
+  // cracking_description is an enum, so no max length validation is required -
+  // it just needs to be set
+  if (arg.instability?.cracking) {
+    const {cracking_description} = arg.instability;
+    if (!cracking_description || cracking_description.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: required,
+        path: ['instability', 'cracking_description'],
+      });
     }
+  }
 
-    // if instability.collapsing, then we'll want collapsing_description to be set
-    // collapsing_description is an enum, so no max length validation is required -
-    // it just needs to be set
-    if (arg.instability?.collapsing) {
-      const {collapsing_description} = arg.instability;
-      if (!collapsing_description || collapsing_description.length === 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: required,
-          path: ['instability', 'collapsing_description'],
-        });
-      }
+  // if instability.collapsing, then we'll want collapsing_description to be set
+  // collapsing_description is an enum, so no max length validation is required -
+  // it just needs to be set
+  if (arg.instability?.collapsing) {
+    const {collapsing_description} = arg.instability;
+    if (!collapsing_description || collapsing_description.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: required,
+        path: ['instability', 'collapsing_description'],
+      });
     }
+  }
 
-    return z.NEVER;
-  });
+  return z.NEVER;
+});
 
-export interface ObservationFormData extends z.infer<typeof simpleObservationFormSchema> {
+export interface ObservationFormData extends z.infer<typeof simpleObservationFormSchemaWithValidations> {
   images: ImagePickerAsset[];
 }

--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -50,85 +50,83 @@ const locationPointSchema = z.object(
 );
 export type LocationPoint = z.infer<typeof locationPointSchema>;
 
-// This schema captures all of the data fields that we upload in order to create a new observation.
-// This schema can be used to persist an observation to disk and later parse it, for resuming uploads when we're offline.
-export const simpleObservationFormSchema = z.object({
-  activity: z.array(z.nativeEnum(Activity)).min(1, 'You must select at least one activity.'),
-  avalanches_summary: z.string().optional(),
-  email: z.string({required_error: required}).email("That doesn't look like an email address."),
-  instability: z.object({
-    avalanches_observed: z.boolean(),
-    avalanches_triggered: z.boolean(),
-    avalanches_caught: z.boolean(),
-    cracking: z.boolean(),
-    cracking_description: z.nativeEnum(InstabilityDistribution).optional(),
-    collapsing: z.boolean(),
-    collapsing_description: z.nativeEnum(InstabilityDistribution).optional(),
-  }),
-  location_name: z.string({required_error: required}).max(256, tooLong),
-  location_point: locationPointSchema,
-  name: z.string({required_error: required}).max(50, tooLong),
-  observation_summary: z.string({required_error: required}).max(1024, tooLong),
-  photoUsage: z.nativeEnum(MediaUsage, {required_error: required}),
-  private: z.boolean(),
-  start_date: z.date({required_error: required}),
-});
+// For the form, we have specific rules that we require for any new observations
+// we create, thus we don't reuse the existing observationSchema
+export const simpleObservationFormSchema = z
+  .object({
+    activity: z.array(z.nativeEnum(Activity)).min(1, 'You must select at least one activity.'),
+    avalanches_summary: z.string().optional(),
+    email: z.string({required_error: required}).email("That doesn't look like an email address."),
+    instability: z.object({
+      avalanches_observed: z.boolean(),
+      avalanches_triggered: z.boolean(),
+      avalanches_caught: z.boolean(),
+      cracking: z.boolean(),
+      cracking_description: z.nativeEnum(InstabilityDistribution).optional(),
+      collapsing: z.boolean(),
+      collapsing_description: z.nativeEnum(InstabilityDistribution).optional(),
+    }),
+    location_name: z.string({required_error: required}).max(256, tooLong),
+    location_point: locationPointSchema,
+    name: z.string({required_error: required}).max(50, tooLong),
+    observation_summary: z.string({required_error: required}).max(1024, tooLong),
+    photoUsage: z.nativeEnum(MediaUsage, {required_error: required}),
+    private: z.boolean(),
+    // Using `coerce` allows us to transparently round-trip a Date object to JSON and back
+    start_date: z.coerce.date({required_error: required}),
+  })
+  .superRefine((arg, ctx) => {
+    // Some more complex validations to apply here
 
-// For the form, we have specific validation rules that we require for any new observations
-// we create, rules that can't be captured via simpleObservationFormSchema. Note that the result of `superRefine`
-// can't be converted to a TS type via infer. This is only used for form validation.
-export const simpleObservationFormSchemaWithValidations = simpleObservationFormSchema.superRefine((arg, ctx) => {
-  // Some more complex validations to apply here
-
-  // if instability.avalanches_observed, then we'll want avalanches_summary to exist
-  if (arg.instability?.avalanches_observed) {
-    const {avalanches_summary} = arg;
-    if (!avalanches_summary || avalanches_summary.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: required,
-        path: ['avalanches_summary'],
-      });
-    } else if (avalanches_summary.length > 1024) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: tooLong,
-        path: ['avalanches_summary'],
-      });
+    // if instability.avalanches_observed, then we'll want avalanches_summary to exist
+    if (arg.instability?.avalanches_observed) {
+      const {avalanches_summary} = arg;
+      if (!avalanches_summary || avalanches_summary.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: required,
+          path: ['avalanches_summary'],
+        });
+      } else if (avalanches_summary.length > 1024) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: tooLong,
+          path: ['avalanches_summary'],
+        });
+      }
     }
-  }
 
-  // if instability.cracking, then we'll want cracking_description to be set
-  // cracking_description is an enum, so no max length validation is required -
-  // it just needs to be set
-  if (arg.instability?.cracking) {
-    const {cracking_description} = arg.instability;
-    if (!cracking_description || cracking_description.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: required,
-        path: ['instability', 'cracking_description'],
-      });
+    // if instability.cracking, then we'll want cracking_description to be set
+    // cracking_description is an enum, so no max length validation is required -
+    // it just needs to be set
+    if (arg.instability?.cracking) {
+      const {cracking_description} = arg.instability;
+      if (!cracking_description || cracking_description.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: required,
+          path: ['instability', 'cracking_description'],
+        });
+      }
     }
-  }
 
-  // if instability.collapsing, then we'll want collapsing_description to be set
-  // collapsing_description is an enum, so no max length validation is required -
-  // it just needs to be set
-  if (arg.instability?.collapsing) {
-    const {collapsing_description} = arg.instability;
-    if (!collapsing_description || collapsing_description.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: required,
-        path: ['instability', 'collapsing_description'],
-      });
+    // if instability.collapsing, then we'll want collapsing_description to be set
+    // collapsing_description is an enum, so no max length validation is required -
+    // it just needs to be set
+    if (arg.instability?.collapsing) {
+      const {collapsing_description} = arg.instability;
+      if (!collapsing_description || collapsing_description.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: required,
+          path: ['instability', 'collapsing_description'],
+        });
+      }
     }
-  }
 
-  return z.NEVER;
-});
+    return z.NEVER;
+  });
 
-export interface ObservationFormData extends z.infer<typeof simpleObservationFormSchemaWithValidations> {
+export interface ObservationFormData extends z.infer<typeof simpleObservationFormSchema> {
   images: ImagePickerAsset[];
 }

--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -4,6 +4,18 @@ import {z} from 'zod';
 
 import {Activity, InstabilityDistribution, MediaUsage, PartnerType} from 'types/nationalAvalancheCenter';
 
+const FAKE_OBSERVATION_DATA: Partial<ObservationFormData> = {
+  activity: ['skiing_snowboarding'],
+  location_point: {
+    lat: 47.6062,
+    lng: -122.3321,
+  },
+  email: 'brian@nwac.us',
+  name: 'Brian',
+  observation_summary: 'This is a test observation.',
+  location_name: 'at my kitchen table',
+};
+
 export const defaultObservationFormData = (initialValues: Partial<ObservationFormData> | null = null): Partial<ObservationFormData> =>
   merge(
     {
@@ -23,6 +35,7 @@ export const defaultObservationFormData = (initialValues: Partial<ObservationFor
       status: 'published',
       images: [],
     },
+    process.env.EXPO_PUBLIC_AUTOFILL_FAKE_OBSERVATION ? FAKE_OBSERVATION_DATA : {},
     initialValues,
   );
 const required = 'This field is required.';

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -372,11 +372,11 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
 
 export const matchesZone = (mapLayer: MapLayer, lat: number | null | undefined, long: number | null | undefined): string => {
   if (!lat || !long) {
-    return 'Not in any Forecast Zone';
+    return 'Unknown Zone';
   }
   const matchingFeatures = mapLayer.features.filter(feature => geoContains(feature.geometry, [long, lat])).map(feature => feature.properties.name);
   if (matchingFeatures.length === 0) {
-    return 'Not in any Forecast Zone';
+    return 'Unknown Zone';
   } else if (matchingFeatures.length > 1) {
     // TODO: this happens almost 100% ... why?
     // also, seems like the widget is naming things with more specificity than just the forecast zones? e.g. teton village

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -21,7 +21,7 @@ import {LocationField} from 'components/form/LocationField';
 import {SelectField} from 'components/form/SelectField';
 import {SwitchField} from 'components/form/SwitchField';
 import {TextField} from 'components/form/TextField';
-import {ObservationFormData, defaultObservationFormData, simpleObservationFormSchemaWithValidations} from 'components/observations/ObservationFormData';
+import {ObservationFormData, defaultObservationFormData, simpleObservationFormSchema} from 'components/observations/ObservationFormData';
 import {submitObservation} from 'components/observations/submitObservation';
 import {Body, BodyBlack, BodySemibold, Title3Semibold} from 'components/text';
 import {LoggerContext, LoggerProps} from 'loggerContext';
@@ -36,9 +36,9 @@ export const SimpleForm: React.FC<{
 }> = ({center_id, onClose}) => {
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
-  const formContext = useForm({
+  const formContext = useForm<ObservationFormData>({
     defaultValues: defaultObservationFormData(),
-    resolver: zodResolver(simpleObservationFormSchemaWithValidations),
+    resolver: zodResolver(simpleObservationFormSchema),
     mode: 'onBlur',
     shouldFocusError: false,
     shouldUnregister: true,
@@ -63,8 +63,8 @@ export const SimpleForm: React.FC<{
 
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
 
-  const mutation = useMutation<void, AxiosError, Partial<ObservationFormData>>({
-    mutationFn: async (observationFormData: Partial<ObservationFormData>) => {
+  const mutation = useMutation<void, AxiosError, ObservationFormData>({
+    mutationFn: async (observationFormData: ObservationFormData) => {
       logger.info({formValues: observationFormData}, 'submitting observation');
       return submitObservation({center_id, apiPrefix: nationalAvalancheCenterHost, observationFormData});
     },
@@ -93,7 +93,7 @@ export const SimpleForm: React.FC<{
     retry: true,
   });
 
-  const onSubmitHandler = (data: Partial<ObservationFormData>) => {
+  const onSubmitHandler = (data: ObservationFormData) => {
     // Submit button turns into a cancel button
     if (mutation.isLoading) {
       mutation.reset();

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -21,14 +21,14 @@ import {LocationField} from 'components/form/LocationField';
 import {SelectField} from 'components/form/SelectField';
 import {SwitchField} from 'components/form/SwitchField';
 import {TextField} from 'components/form/TextField';
-import {ObservationFormData, defaultObservationFormData, simpleObservationFormSchema} from 'components/observations/ObservationFormData';
+import {ObservationFormData, defaultObservationFormData, simpleObservationFormSchemaWithValidations} from 'components/observations/ObservationFormData';
 import {submitObservation} from 'components/observations/submitObservation';
 import {Body, BodyBlack, BodySemibold, Title3Semibold} from 'components/text';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import Toast from 'react-native-toast-message';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
-import {AvalancheCenterID, ImageMediaItem, InstabilityDistribution, MediaType, Observation} from 'types/nationalAvalancheCenter';
+import {AvalancheCenterID, ImageMediaItem, InstabilityDistribution, MediaType} from 'types/nationalAvalancheCenter';
 
 export const SimpleForm: React.FC<{
   center_id: AvalancheCenterID;
@@ -38,7 +38,7 @@ export const SimpleForm: React.FC<{
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const formContext = useForm({
     defaultValues: defaultObservationFormData(),
-    resolver: zodResolver(simpleObservationFormSchema),
+    resolver: zodResolver(simpleObservationFormSchemaWithValidations),
     mode: 'onBlur',
     shouldFocusError: false,
     shouldUnregister: true,
@@ -63,10 +63,10 @@ export const SimpleForm: React.FC<{
 
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
 
-  const mutation = useMutation<Observation, AxiosError, Partial<ObservationFormData>>({
+  const mutation = useMutation<void, AxiosError, Partial<ObservationFormData>>({
     mutationFn: async (observationFormData: Partial<ObservationFormData>) => {
       logger.info({formValues: observationFormData}, 'submitting observation');
-      return submitObservation(logger, {center_id, apiPrefix: nationalAvalancheCenterHost, observationFormData});
+      return submitObservation({center_id, apiPrefix: nationalAvalancheCenterHost, observationFormData});
     },
     onMutate: () => {
       Toast.show({

--- a/components/observations/submitObservation.ts
+++ b/components/observations/submitObservation.ts
@@ -1,256 +1,14 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import axios from 'axios';
-import * as FileSystem from 'expo-file-system';
-import {manipulateAsync, SaveFormat} from 'expo-image-manipulator';
+import _ from 'lodash';
 import uuid from 'react-native-uuid';
-import {z} from 'zod';
 
-import {ObservationFormData, simpleObservationFormSchema} from 'components/observations/ObservationFormData';
+import {ObservationFormData} from 'components/observations/ObservationFormData';
+import {ObservationUploader} from 'components/observations/uploader/ObservationsUploader';
+import {TaskQueueEntry} from 'components/observations/uploader/Task';
 import {logger} from 'logger';
-import {AvalancheCenterID, avalancheCenterIDSchema, MediaItem, mediaItemSchema, MediaUsage, Observation} from 'types/nationalAvalancheCenter';
-import {apiDateString} from 'utils/date';
+import {AvalancheCenterID, MediaUsage} from 'types/nationalAvalancheCenter';
 
-const taskQueueEntrySchema = z.discriminatedUnion('type', [
-  z.object({
-    id: z.string().uuid(),
-    type: z.literal('image'),
-    data: z.object({
-      apiPrefix: z.string(),
-      image: z.object({
-        uri: z.string(),
-        exif: z
-          .object({
-            Orientation: z.number().or(z.string()).optional(),
-          })
-          .optional(),
-      }),
-      name: z.string(),
-      center_id: avalancheCenterIDSchema,
-      photoUsage: z.nativeEnum(MediaUsage),
-    }),
-  }),
-  z.object({
-    id: z.string().uuid(),
-    type: z.literal('observation'),
-    data: z.object({
-      formData: simpleObservationFormSchema,
-      extraData: z.object({
-        url: z.string().url(),
-        imageTaskIds: z.array(z.string().uuid()),
-        center_id: avalancheCenterIDSchema,
-        organization: avalancheCenterIDSchema,
-        observer_type: z.literal('public'),
-      }),
-    }),
-  }),
-]);
-type TaskQueueEntry = z.infer<typeof taskQueueEntrySchema>;
-type ObservationTaskData = Extract<TaskQueueEntry, {type: 'observation'}>['data'];
-
-const taskQueueSchema = z.array(taskQueueEntrySchema);
-
-const TASK_QUEUE_KEY = 'TASK_QUEUE';
-let pendingTaskQueueUpdate: null | NodeJS.Timeout = null;
-
-const processTaskQueue = async () => {
-  pendingTaskQueueUpdate = null;
-  const queue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(TASK_QUEUE_KEY)) || '[]'));
-  logger.debug({queue}, 'processTaskQueue');
-  if (queue.length === 0) {
-    return;
-  }
-  const entry = queue[0];
-  try {
-    switch (entry.type) {
-      case 'image':
-        await uploadImage(entry.id, entry.data);
-        break;
-      case 'observation':
-        await uploadObservation(entry.id, entry.data);
-        break;
-    }
-    logger.debug({entry}, `processed task queue entry successfully`);
-    await AsyncStorage.setItem(TASK_QUEUE_KEY, JSON.stringify(queue.slice(1)));
-    subscribers.forEach(subscriber => subscriber(entry, true, 0));
-  } catch (error) {
-    logger.error({error, entry}, `error processing task queue entry`);
-    subscribers.forEach(subscriber => subscriber(entry, false, 0));
-  } finally {
-    pendingTaskQueueUpdate = setTimeout(() => void processTaskQueue(), 1000);
-  }
-};
-
-const enqueueTasks = async (entries: TaskQueueEntry[]) => {
-  logger.debug({entries}, 'enqueueTasks');
-  const queue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(TASK_QUEUE_KEY)) || '[]'));
-  queue.push(...entries);
-  await AsyncStorage.setItem(TASK_QUEUE_KEY, JSON.stringify(queue));
-  if (!pendingTaskQueueUpdate) {
-    pendingTaskQueueUpdate = setTimeout(() => void processTaskQueue(), 1000);
-  }
-};
-
-export const resetTaskQueue = async () => {
-  logger.debug('resetTaskQueue');
-  await AsyncStorage.setItem(TASK_QUEUE_KEY, JSON.stringify([]));
-};
-
-const extensionToMimeType = (extension: string) => {
-  switch (extension.toLowerCase()) {
-    case 'jpeg':
-    case 'jpg':
-      return 'image/jpeg';
-    case 'png':
-      return 'image/png';
-    default:
-      throw new Error(`Unknown mime type for extension: ${extension}`);
-  }
-};
-
-const imageUploadCachePrefix = 'IMAGE_UPLOAD_CACHE';
-
-// TODO: should put an expiration time on these cache entries and clear them less aggressively.
-export const clearUploadCache = async () => {
-  const keys = await AsyncStorage.getAllKeys();
-  keys.filter(k => k.startsWith(imageUploadCachePrefix)).map(async k => await AsyncStorage.removeItem(k));
-};
-
-const getUploadedImageByTaskId = async (taskId: string): Promise<MediaItem | null> => {
-  const imageCacheKey = `${imageUploadCachePrefix}:${taskId}`;
-  const imageCacheString = await AsyncStorage.getItem(imageCacheKey);
-  return imageCacheString ? mediaItemSchema.parse(JSON.parse(imageCacheString)) : null;
-};
-
-const setUploadedImageByTaskId = async (taskId: string, image: MediaItem): Promise<void> => {
-  const imageCacheKey = `${imageUploadCachePrefix}:${taskId}`;
-  await AsyncStorage.setItem(imageCacheKey, JSON.stringify(image));
-};
-
-const clearUploadedImageByTaskId = async (taskId: string): Promise<void> => {
-  const imageCacheKey = `${imageUploadCachePrefix}:${taskId}`;
-  await AsyncStorage.removeItem(imageCacheKey);
-};
-
-type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
-let subscribers: Subscriber[] = [];
-const subscribeToTaskInvocations = (callback: Subscriber) => {
-  subscribers.push(callback);
-};
-
-const unsubscribeFromTaskInvocations = (callback: Subscriber) => {
-  subscribers = subscribers.filter(subscriber => subscriber !== callback);
-};
-
-interface PickedImage {
-  uri: string;
-  exif?: {
-    // this is how it's defined in expo-image-picker
-    Orientation?: string | number;
-  };
-}
-interface UploadImageOptions {
-  apiPrefix: string;
-  center_id: AvalancheCenterID;
-  image: PickedImage;
-  name: string;
-  photoUsage: MediaUsage;
-}
-
-const loadImageData = async ({uri, exif}: PickedImage): Promise<{imageDataBase64: string; mimeType: string; filename: string}> => {
-  // This weird use of `slice` is because the version of Hermes that Expo is currently pinned to doesn't support `at()`
-  const filename = uri.split('/').slice(-1)[0];
-  const extension = filename.split('.').slice(-1)[0] || '';
-
-  const orientation = exif?.Orientation as string | number;
-  if (typeof orientation !== 'number' || orientation <= 1) {
-    const imageDataBase64 = await FileSystem.readAsStringAsync(uri, {encoding: 'base64'});
-    return {imageDataBase64, filename, mimeType: extensionToMimeType(extension)};
-  } else {
-    // This is an image with a non-standard orientation, and it's not handled correctly by the NAC image
-    // pipeline (you get things like flipped thumbnails). More info on EXIF orientation: https://sirv.com/help/articles/rotate-photos-to-be-upright/
-    //
-    // The solution is pretty simple: allow the expo image manipulation library to save a copy, which
-    // writes the image with a "normal" orientation and applies any necessary transforms to make it look correct.
-    const result = await manipulateAsync(uri, [], {format: SaveFormat.JPEG, base64: true});
-    return {imageDataBase64: result.base64 ?? '', filename, mimeType: 'image/jpeg'};
-  }
-};
-
-const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage}: UploadImageOptions): Promise<MediaItem> => {
-  // If we've already uploaded this image once, don't do it again.
-  const cached = await getUploadedImageByTaskId(taskId);
-  const thisLogger = logger.child({uri: image.uri});
-  if (cached) {
-    thisLogger.debug({taskId, image}, `image has already been uploaded, using cached media item`);
-    try {
-      return Promise.resolve(cached);
-    } catch (error) {
-      thisLogger.warn(`unable to load cached image data, uploading it again`);
-      await clearUploadedImageByTaskId(taskId);
-      // fallthrough
-    }
-  }
-
-  const {imageDataBase64, filename, mimeType} = await loadImageData(image);
-
-  const payload = {
-    file: `data:${mimeType};base64,${imageDataBase64}`,
-    type: 'image',
-    file_name: filename,
-    center_id,
-    forecast_zone_id: [],
-    taken_by: name,
-    access: photoUsage,
-    source: 'public',
-    // TODO would be nice to tag images that came from this app, but haven't figured that out yet
-  };
-
-  const response = await axios.post<MediaItem>(`${apiPrefix}/v2/public/media`, payload, {
-    headers: {
-      // Public API uses the Origin header to determine who's authorized to call it
-      Origin: 'https://nwac.us',
-    },
-  });
-  await setUploadedImageByTaskId(taskId, response.data);
-  return response.data;
-};
-
-async function uploadObservation(id: string, data: ObservationTaskData): Promise<Observation> {
-  const {formData, extraData} = data;
-  const {url, imageTaskIds, ...params} = extraData;
-  const media = (await Promise.all(imageTaskIds.map(getUploadedImageByTaskId))).filter((image): image is MediaItem => image != null);
-  const payload: Partial<Observation> = {
-    ...formData,
-    ...params,
-    media,
-    obs_source: 'public',
-    // Date has to be a plain-old YYYY-MM-DD string
-    start_date: apiDateString(formData.start_date),
-    status: 'published',
-  };
-  try {
-    const {data: responseData} = await axios.post<Observation>(url, payload, {
-      headers: {
-        // Public API uses the Origin header to determine who's authorized to call it
-        Origin: 'https://nwac.us',
-      },
-    });
-    // You'd think we could feed data to Zod and get a strongly typed object back, but
-    // the object that we get back from the post can't actually be parsed by our schema :(
-    // TODO(skuznets): figure out what we get from POST and actually parse it ...
-    return responseData;
-  } catch (error) {
-    logger.error(
-      {
-        error,
-        url,
-        payload,
-      },
-      'error uploading observation',
-    );
-    throw error;
-  }
-}
+const uploader = new ObservationUploader();
+void uploader.initialize();
 
 export const submitObservation = async ({
   apiPrefix,
@@ -266,10 +24,15 @@ export const submitObservation = async ({
 
     const tasks: TaskQueueEntry[] = [];
 
+    // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in,
+    // but returns string otherwise. hence the use of `as string`.
+    const observationTaskId = uuid.v4() as string;
+
     observationFormData.images?.forEach(image => {
       tasks.push({
-        // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in
         id: uuid.v4() as string,
+        parentId: observationTaskId,
+        attemptCount: 0,
         type: 'image',
         data: {
           apiPrefix: apiPrefix,
@@ -290,42 +53,39 @@ export const submitObservation = async ({
       });
     });
 
-    const imageTaskIds = tasks.map(task => task.id);
-    // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in
-    const uploadTaskId = uuid.v4() as string;
     const url = `${apiPrefix}/obs/v1/public/observation/`;
     tasks.push({
-      id: uploadTaskId,
+      id: observationTaskId,
       type: 'observation',
+      parentId: undefined,
+      attemptCount: 0,
       data: {
-        formData: {
-          ...observationFormData,
-        },
+        // We don't need to persist images with the observation task, since they're already
+        // encoded in individual image upload tasks
+        formData: _.omit(observationFormData, 'images') as ObservationFormData,
         extraData: {
-          imageTaskIds,
           url,
           center_id,
           organization: center_id,
           observer_type: 'public',
-          // Date has to be a plain-old YYYY-MM-DD string
-          // start_date: apiDateString(observationFormData.start_date ?? new Date()),
+          media: [],
         },
       },
     });
 
     const promise: Promise<void> = new Promise((resolve, _reject) => {
       const listener = (entry: TaskQueueEntry, success: boolean) => {
-        if (entry.type === 'observation' && entry.id === uploadTaskId) {
+        if (entry.type === 'observation' && entry.id === observationTaskId) {
           if (success) {
             resolve(/*entry.data as Observation*/);
-            unsubscribeFromTaskInvocations(listener);
+            uploader.unsubscribeFromTaskInvocations(listener);
           }
         }
       };
-      subscribeToTaskInvocations(listener);
+      uploader.subscribeToTaskInvocations(listener);
     });
 
-    await enqueueTasks(tasks);
+    await uploader.enqueueTasks(tasks);
 
     return promise;
   } catch (e) {
@@ -333,6 +93,3 @@ export const submitObservation = async ({
     throw e;
   }
 };
-
-// Kick off the task queue on startup
-pendingTaskQueueUpdate = setTimeout(() => void processTaskQueue(), 1000);

--- a/components/observations/submitObservation.ts
+++ b/components/observations/submitObservation.ts
@@ -1,14 +1,103 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
-import {Logger} from 'browser-bunyan';
 import * as FileSystem from 'expo-file-system';
 import {manipulateAsync, SaveFormat} from 'expo-image-manipulator';
-import {ImagePickerAsset} from 'expo-image-picker';
-import md5 from 'md5';
+import uuid from 'react-native-uuid';
+import {z} from 'zod';
 
-import {ObservationFormData} from 'components/observations/ObservationFormData';
-import {AvalancheCenterID, MediaItem, mediaItemSchema, MediaUsage, Observation} from 'types/nationalAvalancheCenter';
+import {ObservationFormData, simpleObservationFormSchema} from 'components/observations/ObservationFormData';
+import {logger} from 'logger';
+import {AvalancheCenterID, avalancheCenterIDSchema, MediaItem, mediaItemSchema, MediaUsage, Observation} from 'types/nationalAvalancheCenter';
 import {apiDateString} from 'utils/date';
+
+const taskQueueEntryTypeSchema = z.enum(['image', 'observation']);
+type TaskQueueEntryType = z.infer<typeof taskQueueEntryTypeSchema>;
+
+const taskQueueEntrySchema = z.discriminatedUnion('type', [
+  z.object({
+    id: z.string().uuid(),
+    type: z.literal('image'),
+    data: z.object({
+      apiPrefix: z.string(),
+      image: z.object({
+        uri: z.string(),
+        exif: z
+          .object({
+            Orientation: z.number().or(z.string()).optional(),
+          })
+          .optional(),
+      }),
+      name: z.string(),
+      center_id: avalancheCenterIDSchema,
+      photoUsage: z.nativeEnum(MediaUsage),
+    }),
+  }),
+  z.object({
+    id: z.string().uuid(),
+    type: z.literal('observation'),
+    data: simpleObservationFormSchema.partial().extend({
+      url: z.string().url(),
+      imageTaskIds: z.array(z.string().uuid()),
+      center_id: avalancheCenterIDSchema,
+      organization: avalancheCenterIDSchema,
+      status: z.literal('published'),
+      observer_type: z.literal('public'),
+      // Date has to be a plain-old YYYY-MM-DD string
+      start_date: z.string(),
+    }),
+  }),
+]);
+type TaskQueueEntry = z.infer<typeof taskQueueEntrySchema>;
+type ImageTaskData = Extract<TaskQueueEntry, {type: 'image'}>['data'];
+type ObservationTaskData = Extract<TaskQueueEntry, {type: 'observation'}>['data'];
+
+const taskQueueSchema = z.array(taskQueueEntrySchema);
+
+const TASK_QUEUE_KEY = 'TASK_QUEUE';
+let pendingTaskQueueUpdate: null | NodeJS.Timeout = null;
+
+const processTaskQueue = async () => {
+  pendingTaskQueueUpdate = null;
+  const queue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(TASK_QUEUE_KEY)) || '[]'));
+  logger.debug({queue}, 'processTaskQueue');
+  if (queue.length === 0) {
+    return;
+  }
+  const entry = queue[0];
+  try {
+    switch (entry.type) {
+      case 'image':
+        await uploadImage(entry.id, entry.data);
+        break;
+      case 'observation':
+        await uploadObservation(entry.id, entry.data);
+        break;
+    }
+    logger.debug({entry}, `processed task queue entry successfully`);
+    await AsyncStorage.setItem(TASK_QUEUE_KEY, JSON.stringify(queue.slice(1)));
+    subscribers.forEach(subscriber => subscriber(entry, true, 0));
+  } catch (error) {
+    logger.error({error, entry}, `error processing task queue entry`);
+    subscribers.forEach(subscriber => subscriber(entry, false, 0));
+  } finally {
+    pendingTaskQueueUpdate = setTimeout(() => void processTaskQueue(), 1000);
+  }
+};
+
+const enqueueTasks = async (entries: TaskQueueEntry[]) => {
+  logger.debug({entries}, 'enqueueTasks');
+  const queue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(TASK_QUEUE_KEY)) || '[]'));
+  queue.push(...entries);
+  await AsyncStorage.setItem(TASK_QUEUE_KEY, JSON.stringify(queue));
+  if (!pendingTaskQueueUpdate) {
+    pendingTaskQueueUpdate = setTimeout(() => void processTaskQueue(), 1000);
+  }
+};
+
+const resetTaskQueue = async () => {
+  logger.debug('resetTaskQueue');
+  await AsyncStorage.setItem(TASK_QUEUE_KEY, JSON.stringify([]));
+};
 
 const extensionToMimeType = (extension: string) => {
   switch (extension.toLowerCase()) {
@@ -30,22 +119,53 @@ export const clearUploadCache = async () => {
   keys.filter(k => k.startsWith(imageUploadCachePrefix)).map(async k => await AsyncStorage.removeItem(k));
 };
 
+const getUploadedImageByTaskId = async (taskId: string): Promise<MediaItem | null> => {
+  const imageCacheKey = `${imageUploadCachePrefix}:${taskId}`;
+  const imageCacheString = await AsyncStorage.getItem(imageCacheKey);
+  return imageCacheString ? mediaItemSchema.parse(JSON.parse(imageCacheString)) : null;
+};
+
+const setUploadedImageByTaskId = async (taskId: string, image: MediaItem): Promise<void> => {
+  const imageCacheKey = `${imageUploadCachePrefix}:${taskId}`;
+  await AsyncStorage.setItem(imageCacheKey, JSON.stringify(image));
+};
+
+const clearUploadedImageByTaskId = async (taskId: string): Promise<void> => {
+  const imageCacheKey = `${imageUploadCachePrefix}:${taskId}`;
+  await AsyncStorage.removeItem(imageCacheKey);
+};
+
+type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
+let subscribers: Subscriber[] = [];
+const subscribeToTaskInvocations = (callback: Subscriber) => {
+  subscribers.push(callback);
+};
+
+const unsubscribeFromTaskInvocations = (callback: Subscriber) => {
+  subscribers = subscribers.filter(subscriber => subscriber !== callback);
+};
+
+interface PickedImage {
+  uri: string;
+  exif?: {
+    // this is how it's defined in expo-image-picker
+    Orientation?: string | number;
+  };
+}
 interface UploadImageOptions {
   apiPrefix: string;
   center_id: AvalancheCenterID;
-  image: ImagePickerAsset;
+  image: PickedImage;
   name: string;
   photoUsage: MediaUsage;
 }
 
-const getImageData = async (image: ImagePickerAsset): Promise<{imageDataBase64: string; mimeType: string; filename: string}> => {
-  const {uri} = image;
-
+const loadImageData = async ({uri, exif}: PickedImage): Promise<{imageDataBase64: string; mimeType: string; filename: string}> => {
   // This weird use of `slice` is because the version of Hermes that Expo is currently pinned to doesn't support `at()`
   const filename = uri.split('/').slice(-1)[0];
   const extension = filename.split('.').slice(-1)[0] || '';
 
-  const orientation = image.exif?.Orientation as string | number;
+  const orientation = exif?.Orientation as string | number;
   if (typeof orientation !== 'number' || orientation <= 1) {
     const imageDataBase64 = await FileSystem.readAsStringAsync(uri, {encoding: 'base64'});
     return {imageDataBase64, filename, mimeType: extensionToMimeType(extension)};
@@ -60,8 +180,22 @@ const getImageData = async (image: ImagePickerAsset): Promise<{imageDataBase64: 
   }
 };
 
-const uploadImage = async (logger: Logger, {apiPrefix, image, name, center_id, photoUsage}: UploadImageOptions): Promise<MediaItem> => {
-  const {imageDataBase64, filename, mimeType} = await getImageData(image);
+const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage}: UploadImageOptions): Promise<MediaItem> => {
+  // If we've already uploaded this image once, don't do it again.
+  const cached = await getUploadedImageByTaskId(taskId);
+  const thisLogger = logger.child({uri: image.uri});
+  if (cached) {
+    thisLogger.debug({taskId, image}, `image has already been uploaded, using cached media item`);
+    try {
+      return Promise.resolve(cached);
+    } catch (error) {
+      thisLogger.warn(`unable to load cached image data, uploading it again`);
+      await clearUploadedImageByTaskId(taskId);
+      // fallthrough
+    }
+  }
+
+  const {imageDataBase64, filename, mimeType} = await loadImageData(image);
 
   const payload = {
     file: `data:${mimeType};base64,${imageDataBase64}`,
@@ -75,74 +209,127 @@ const uploadImage = async (logger: Logger, {apiPrefix, image, name, center_id, p
     // TODO would be nice to tag images that came from this app, but haven't figured that out yet
   };
 
-  // If we've already uploaded this image once with a particular set of settings, don't do it again.
-  const payloadHash = md5(JSON.stringify(payload));
-  const imageCacheKey = `${imageUploadCachePrefix}:${payloadHash}`;
-  const cached = await AsyncStorage.getItem(imageCacheKey);
-  const thisLogger = logger.child({uri: image.uri});
-  if (cached) {
-    thisLogger.debug({payload: payload}, `image has already been uploaded, using cached media item`);
-    try {
-      return Promise.resolve(mediaItemSchema.parse(JSON.parse(cached)));
-    } catch (error) {
-      thisLogger.warn(`unable to load cached image data, uploading it again`);
-      await AsyncStorage.removeItem(imageCacheKey);
-      // fallthrough
-    }
-  }
-
   const response = await axios.post<MediaItem>(`${apiPrefix}/v2/public/media`, payload, {
     headers: {
       // Public API uses the Origin header to determine who's authorized to call it
       Origin: 'https://nwac.us',
     },
   });
-  await AsyncStorage.setItem(imageCacheKey, JSON.stringify(response.data));
+  await setUploadedImageByTaskId(taskId, response.data);
   return response.data;
 };
 
-export const submitObservation = async (
-  logger: Logger,
-  {
-    apiPrefix,
-    center_id,
-    observationFormData,
-  }: {
-    apiPrefix: string;
-    center_id: AvalancheCenterID;
-    observationFormData: Partial<ObservationFormData>;
-  },
-): Promise<Observation> => {
-  const {photoUsage, name} = observationFormData;
-  // TODO: probably should upload these sequentially instead of in parallel
-  const media = await Promise.all(
-    observationFormData.images?.map(image =>
-      uploadImage(logger, {
-        apiPrefix: apiPrefix,
-        image: image,
-        name: name ?? '',
-        center_id: center_id,
-        photoUsage: photoUsage ?? MediaUsage.Credit,
-      }),
-    ) ?? [],
-  );
-  logger.info({media: media}, 'submitted media');
-
-  const url = `${apiPrefix}/obs/v1/public/observation/`;
-  const payload = {
-    ...observationFormData,
-    center_id,
-    organization: center_id,
-    status: 'published',
-    media: media,
-    observer_type: 'public',
-    // Date has to be a plain-old YYYY-MM-DD string
-    start_date: apiDateString(observationFormData.start_date ?? new Date()),
+async function uploadObservation(id: string, data: ObservationTaskData): Promise<Observation> {
+  const {url, imageTaskIds, ...params} = data;
+  const media = (await Promise.all(imageTaskIds.map(getUploadedImageByTaskId))).filter((image): image is MediaItem => image != null);
+  const payload: Partial<Observation> = {
+    ...params,
+    media,
+    obs_source: 'public',
+    body: params.observation_summary,
   };
+  try {
+    const {data: responseData} = await axios.post<Observation>(url, payload, {
+      headers: {
+        // Public API uses the Origin header to determine who's authorized to call it
+        Origin: 'https://nwac.us',
+      },
+    });
+    // You'd think we could feed data to Zod and get a strongly typed object back, but
+    // the object that we get back from the post can't actually be parsed by our schema :(
+    // TODO(skuznets): figure out what we get from POST and actually parse it ...
+    return responseData;
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        url,
+        payload,
+      },
+      'error uploading observation',
+    );
+    throw error;
+  }
+}
 
-  const {data} = await axios.post<Observation>(url, payload);
-  // You'd think we could feed data to Zod and get a strongly typed object back, but
-  // the object that we get back from the post can't actually be parsed by our schema :(
-  // TODO(skuznets): figure out what we get from POST and actually parse it ...
-  return data;
+export const submitObservation = async ({
+  apiPrefix,
+  center_id,
+  observationFormData,
+}: {
+  apiPrefix: string;
+  center_id: AvalancheCenterID;
+  observationFormData: Partial<ObservationFormData>;
+}): Promise<void> => {
+  try {
+    const {photoUsage, name} = observationFormData;
+
+    const tasks: TaskQueueEntry[] = [];
+
+    observationFormData.images?.forEach(image => {
+      tasks.push({
+        // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in
+        id: uuid.v4() as string,
+        type: 'image',
+        data: {
+          apiPrefix: apiPrefix,
+          image: {
+            uri: image.uri,
+            exif: image.exif
+              ? {
+                  // The type of ImagePickerAsset.exif is (unfortunately) Record<string, any>
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                  Orientation: image.exif.Orientation,
+                }
+              : undefined,
+          },
+          name: name ?? '',
+          center_id: center_id,
+          photoUsage: photoUsage ?? MediaUsage.Credit,
+        },
+      });
+    });
+
+    const imageTaskIds = tasks.map(task => task.id);
+    // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in
+    const uploadTaskId = uuid.v4() as string;
+    const url = `${apiPrefix}/obs/v1/public/observation/`;
+    tasks.push({
+      id: uploadTaskId,
+      type: 'observation',
+      data: {
+        ...observationFormData,
+        imageTaskIds,
+        url,
+        center_id,
+        organization: center_id,
+        status: 'published',
+        observer_type: 'public',
+        // Date has to be a plain-old YYYY-MM-DD string
+        start_date: apiDateString(observationFormData.start_date ?? new Date()),
+      },
+    });
+
+    const promise: Promise<void> = new Promise((resolve, _reject) => {
+      const listener = (entry: TaskQueueEntry, success: boolean) => {
+        if (entry.type === 'observation' && entry.id === uploadTaskId) {
+          if (success) {
+            resolve(/*entry.data as Observation*/);
+            unsubscribeFromTaskInvocations(listener);
+          }
+        }
+      };
+      subscribeToTaskInvocations(listener);
+    });
+
+    await enqueueTasks(tasks);
+
+    return promise;
+  } catch (e) {
+    logger.error({e}, 'error submitting observation');
+    throw e;
+  }
 };
+
+// Kick off the task queue on startup
+pendingTaskQueueUpdate = setTimeout(() => void processTaskQueue(), 1000);

--- a/components/observations/submitObservation.ts
+++ b/components/observations/submitObservation.ts
@@ -60,9 +60,9 @@ export const submitObservation = async ({
       parentId: undefined,
       attemptCount: 0,
       data: {
-        // We don't need to persist images with the observation task, since they're already
+        // We don't persist images with the observation task, since they're already
         // encoded in individual image upload tasks
-        formData: _.omit(observationFormData, 'images') as ObservationFormData,
+        formData: _.omit(observationFormData, 'images'),
         extraData: {
           url,
           center_id,
@@ -77,7 +77,7 @@ export const submitObservation = async ({
       const listener = (entry: TaskQueueEntry, success: boolean) => {
         if (entry.type === 'observation' && entry.id === observationTaskId) {
           if (success) {
-            resolve(/*entry.data as Observation*/);
+            resolve();
             uploader.unsubscribeFromTaskInvocations(listener);
           }
         }

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -1,0 +1,232 @@
+jest.mock('components/observations/uploader/uploadImage');
+
+import {AxiosError} from 'axios';
+import {ObservationUploader, backoffTimeMs, isRetryableError} from 'components/observations/uploader/ObservationsUploader';
+import {TaskQueueEntry} from 'components/observations/uploader/Task';
+import {uploadImage as uploadImageOriginal} from 'components/observations/uploader/uploadImage';
+// import Deferred from 'tests/helpers/Deferred';
+import {logger} from 'logger';
+import {MediaItem, MediaType, MediaUsage} from 'types/nationalAvalancheCenter';
+
+const uploadImage = uploadImageOriginal as jest.MockedFunction<typeof uploadImageOriginal>;
+
+class Deferred<T> {
+  public promise: Promise<T>;
+  public resolve!: (value: T | PromiseLike<T>) => void;
+  public reject!: (reason?: unknown) => void;
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    this.promise = new Promise<T>(function (resolve, reject) {
+      self.reject = reject;
+      self.resolve = resolve;
+    });
+  }
+}
+
+const createAxiosError = (status: number): AxiosError =>
+  new AxiosError(
+    'Boom!',
+    'ESOMETHING',
+    {
+      url: 'http://localhost:3000',
+    },
+    {
+      path: '/foo',
+    },
+    {
+      status,
+      config: {
+        url: 'http://localhost:3000',
+      },
+      headers: {},
+      data: {},
+      statusText: 'Boom!',
+    },
+  );
+
+describe('isRetryableError', () => {
+  it('should return true for server errors', () => {
+    const error = createAxiosError(500);
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('should return true for request timeout errors', () => {
+    const error = createAxiosError(408);
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('should return true for too early errors', () => {
+    const error = createAxiosError(425);
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('should return true for rate limited errors', () => {
+    const error = createAxiosError(429);
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('should return false for non-retryable errors', () => {
+    const error = createAxiosError(400);
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  it('should return false for non-network errors', () => {
+    const error = new Error('Some Error');
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  it('should return false for random objects', () => {
+    const error = 'howdy';
+    expect(isRetryableError(error)).toBe(false);
+  });
+});
+
+describe('backoffTimeMs', () => {
+  it('should return 0 for the first attempt', () => {
+    expect(backoffTimeMs(0)).toBe(0);
+  });
+  it('should return 1000 for the second attempt', () => {
+    expect(backoffTimeMs(1)).toBe(2000);
+  });
+  it('should return 4000 for the third attempt', () => {
+    expect(backoffTimeMs(2)).toBe(4000);
+  });
+  it('should return 8000 for the fourth attempt', () => {
+    expect(backoffTimeMs(3)).toBe(8000);
+  });
+  it('should return 16000 for the fourth attempt', () => {
+    expect(backoffTimeMs(4)).toBe(16000);
+  });
+  it('should return 30000 for the fourth attempt and beyond', () => {
+    expect(backoffTimeMs(5)).toBe(30000);
+    expect(backoffTimeMs(10)).toBe(30000);
+    expect(backoffTimeMs(100)).toBe(30000);
+  });
+});
+
+describe('ObservationUploader', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  const createUploader = async () => {
+    const uploader = new ObservationUploader();
+    const processTaskQueueInvocations: Deferred<void>[] = [];
+    const processTaskQueue = uploader['processTaskQueue'];
+    // the `as keyof typeof uploader` allows us to spy on the private method `processTaskQueue`
+    const processTaskQueueSpy = jest.spyOn(uploader, 'processTaskQueue' as keyof typeof uploader).mockImplementation(async () => {
+      logger.info('processTaskQueue called');
+      const deferred = new Deferred<void>();
+      processTaskQueueInvocations.push(deferred);
+      try {
+        await processTaskQueue.call(uploader);
+        deferred.resolve();
+      } catch (error) {
+        logger.info('processTaskQueue caught error');
+        deferred.reject(error);
+      }
+      logger.info('processTaskQueue finished');
+    });
+    await uploader.initialize();
+    return {uploader, processTaskQueueSpy, processTaskQueueInvocations};
+  };
+
+  it('should start in an idle state', async () => {
+    const {processTaskQueueSpy} = await createUploader();
+    expect(processTaskQueueSpy).not.toHaveBeenCalled();
+  });
+
+  it('should try to call uploadImage with a timeout of 0 when enqueueing a task', async () => {
+    const {uploader, processTaskQueueSpy, processTaskQueueInvocations} = await createUploader();
+    uploadImage.mockReturnValue(Promise.resolve(successfulUploadImageResponse));
+
+    await uploader.enqueueTasks([imageUploadTask()]);
+
+    expect(processTaskQueueSpy).toHaveBeenCalledTimes(0);
+    jest.advanceTimersByTime(0);
+    await processTaskQueueInvocations[0].promise;
+    expect(processTaskQueueSpy).toHaveBeenCalledTimes(1);
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('should delay by the exponential backoff controlled by attemptCount', async () => {
+    const {uploader, processTaskQueueInvocations} = await createUploader();
+    uploadImage.mockReturnValue(Promise.resolve(successfulUploadImageResponse));
+
+    await uploader.enqueueTasks([
+      {
+        ...imageUploadTask(),
+        attemptCount: 3,
+      },
+    ]);
+    // We don't expect uploadImage to be called until 8000ms have passed
+    jest.advanceTimersByTime(7999);
+    expect(uploadImage).toHaveBeenCalledTimes(0);
+    expect(processTaskQueueInvocations).toHaveLength(0);
+
+    jest.advanceTimersByTime(1);
+    await processTaskQueueInvocations[0].promise;
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry on retryable errors', async () => {
+    const {uploader, processTaskQueueSpy, processTaskQueueInvocations} = await createUploader();
+    uploadImage.mockRejectedValueOnce(createAxiosError(500)).mockResolvedValueOnce(successfulUploadImageResponse);
+
+    await uploader.enqueueTasks([imageUploadTask()]);
+
+    // Advance the timer to run the first invocation of processTaskQueue
+    jest.advanceTimersByTime(0);
+    jest.runAllTicks();
+    expect(processTaskQueueInvocations).toHaveLength(1);
+    await processTaskQueueInvocations[0].promise;
+
+    expect(processTaskQueueSpy).toHaveBeenCalledTimes(1);
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+
+    // Since the first call failed, it'll retry after the backoff time
+    jest.advanceTimersByTime(backoffTimeMs(1));
+    expect(processTaskQueueInvocations).toHaveLength(2);
+    await processTaskQueueInvocations[1].promise;
+
+    // Since the second call succeeded, it won't retry again
+    expect(processTaskQueueSpy).toHaveBeenCalledTimes(2);
+    expect(uploadImage).toHaveBeenCalledTimes(2);
+  });
+});
+
+const successfulUploadImageResponse: MediaItem = {
+  id: 'de2218f6-63ba-11ee-9b3b-9fdd388ae1ef',
+  url: {
+    original: 'https://avalanche-org-media.s3.us-west-2.amazonaws.com/49DCBED7-2B97-4502-AB97-87D9C0C9FDA6_651f1796edad5.jpg',
+    large: 'https://avalanche-org-media.s3.us-west-2.amazonaws.com/49DCBED7-2B97-4502-AB97-87D9C0C9FDA6_651f1796edad5-large.jpg',
+    medium: 'https://avalanche-org-media.s3.us-west-2.amazonaws.com/49DCBED7-2B97-4502-AB97-87D9C0C9FDA6_651f1796edad5-medium.jpg',
+    thumbnail: 'https://avalanche-org-media.s3.us-west-2.amazonaws.com/49DCBED7-2B97-4502-AB97-87D9C0C9FDA6_651f1796edad5-thumbnail.jpg',
+  },
+  type: MediaType.Image,
+  title: null,
+  caption: null,
+};
+
+const imageUploadTask = (): TaskQueueEntry => ({
+  id: '2d58dbbc-03a4-40a8-bfa8-a61448ccb6c6',
+  parentId: 'fbf53196-2af3-45fe-be3a-f2be5e6368e0',
+  attemptCount: 0,
+  type: 'image',
+  data: {
+    apiPrefix: 'https://localhost:3000',
+    image: {
+      uri: 'file:///test.jpg',
+      exif: {Orientation: 1},
+    },
+    name: `created ${new Date().toLocaleTimeString()}`,
+    center_id: 'NWAC',
+    photoUsage: MediaUsage.Credit,
+  },
+});

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -6,16 +6,11 @@ import {uploadImage} from 'components/observations/uploader/uploadImage';
 import {uploadObservation} from 'components/observations/uploader/uploadObservation';
 import {logger} from 'logger';
 
-//
-// ObservationsUploader maintains a persistent queue in AsyncStorage of upload tasks to be performed.
-//
-// TODO
-// - exponential backoff
-// - detect online/offline errors and respond appropriately
-
 type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
 
 export const isRetryableError = (error: unknown): boolean => {
+  // This may evolve over time as we learn more about what errors the NAC API can
+  // return and what errors are transient vs permanent, but it's a reasonable starting point.
   if (error instanceof AxiosError) {
     if (error.response) {
       const status = error.response.status;
@@ -26,7 +21,7 @@ export const isRetryableError = (error: unknown): boolean => {
         status === 429 // too many requests - rate limited
       );
     } else {
-      // Network error, the server never responded
+      // Network error or timeout. Implies that the server never responded
       return true;
     }
   }
@@ -37,9 +32,20 @@ export const backoffTimeMs = (attemptCount: number): number => {
   return attemptCount === 0 ? 0 : Math.min(1000 * 2 ** attemptCount, 30000);
 };
 
+// The ObservationUploader manages a persistent queue of upload tasks (images and observations) to be performed.
+// It is responsible for:
+// - persisting the queue to disk
+// - running the queue
+// - retrying failed tasks
+// - notifying subscribers of task completion
+//
+// It delegates out to the uploadImage and uploadObservation functions to actually perform the uploads.
+//
+// TODO
+// - build out a status API
+// - detect online/offline errors and respond appropriately
 export class ObservationUploader {
   private static TASK_QUEUE_KEY = 'OBSERVATION_UPLOAD_TASK_QUEUE';
-  private static PROCESS_INTERVAL_MS = 1000;
 
   private pendingTaskQueueUpdate: null | NodeJS.Timeout = null;
   private taskQueue: TaskQueueEntry[] = [];
@@ -48,7 +54,12 @@ export class ObservationUploader {
   private subscribers: Subscriber[] = [];
 
   async initialize() {
-    this.taskQueue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(ObservationUploader.TASK_QUEUE_KEY)) || '[]'));
+    try {
+      this.taskQueue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(ObservationUploader.TASK_QUEUE_KEY)) || '[]'));
+    } catch (error) {
+      this.logger.warn({error}, `failed to parse task queue from disk, resetting to empty`);
+      this.taskQueue = [];
+    }
     this.ready = true;
     this.tryRunTaskQueue();
   }
@@ -67,6 +78,7 @@ export class ObservationUploader {
   }
 
   private tryRunTaskQueue() {
+    this.checkInitialized();
     this.logger.debug({queueLength: this.taskQueue.length, pendingTaskQueueUpdate: this.pendingTaskQueueUpdate != null}, 'tryRunTaskQueue');
     if (this.taskQueue.length === 0 || this.pendingTaskQueueUpdate) {
       return;
@@ -77,6 +89,7 @@ export class ObservationUploader {
   }
 
   async enqueueTasks(entries: TaskQueueEntry[]) {
+    this.checkInitialized();
     this.logger.debug({entries}, 'enqueueTasks');
     this.taskQueue.push(...entries);
     await this.flush();
@@ -95,7 +108,7 @@ export class ObservationUploader {
       switch (entry.type) {
         case 'image':
           {
-            // We upload the image, and if successful we upload the parent observation task to include it
+            // We upload the image, and if successful we update the parent observation task to include it
             const mediaItem = await uploadImage(entry.id, entry.data);
             const parentTask = this.taskQueue.find(task => task.id === entry.parentId);
             if (!parentTask || parentTask.type !== 'observation') {
@@ -114,8 +127,10 @@ export class ObservationUploader {
       this.subscribers.forEach(subscriber => subscriber(entry, true, entry.attemptCount));
       this.taskQueue.shift(); // we're done with this task, so remove it from the queue
     } catch (error) {
-      this.logger.error({error, entry, retryable: isRetryableError(error)}, `error processing task queue entry`);
-      if (!isRetryableError(error)) {
+      if (isRetryableError(error)) {
+        this.logger.warn({error, entry, retryable: isRetryableError(error)}, `transient error processing task queue entry. it will be retried.`);
+      } else {
+        this.logger.error({error, entry, retryable: isRetryableError(error)}, `fatal error processing task queue entry. it will not be retried.`);
         // Since this can't be retried, remove it from the queue
         this.taskQueue.shift();
       }
@@ -135,10 +150,12 @@ export class ObservationUploader {
   }
 
   subscribeToTaskInvocations(callback: Subscriber) {
+    this.checkInitialized();
     this.subscribers.push(callback);
   }
 
   unsubscribeFromTaskInvocations(callback: Subscriber) {
+    this.checkInitialized();
     this.subscribers = this.subscribers.filter(subscriber => subscriber !== callback);
   }
 }

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -1,0 +1,144 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {AxiosError} from 'axios';
+
+import {TaskQueueEntry, taskQueueSchema} from 'components/observations/uploader/Task';
+import {uploadImage} from 'components/observations/uploader/uploadImage';
+import {uploadObservation} from 'components/observations/uploader/uploadObservation';
+import {logger} from 'logger';
+
+//
+// ObservationsUploader maintains a persistent queue in AsyncStorage of upload tasks to be performed.
+//
+// TODO
+// - exponential backoff
+// - detect online/offline errors and respond appropriately
+
+type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
+
+export const isRetryableError = (error: unknown): boolean => {
+  if (error instanceof AxiosError) {
+    if (error.response) {
+      const status = error.response.status;
+      return (
+        status >= 500 || // server error
+        status === 408 || // request timeout, probably returned by LB
+        status === 425 || // too early
+        status === 429 // too many requests - rate limited
+      );
+    } else {
+      // Network error, the server never responded
+      return true;
+    }
+  }
+  return false;
+};
+
+export const backoffTimeMs = (attemptCount: number): number => {
+  return attemptCount === 0 ? 0 : Math.min(1000 * 2 ** attemptCount, 30000);
+};
+
+export class ObservationUploader {
+  private static TASK_QUEUE_KEY = 'OBSERVATION_UPLOAD_TASK_QUEUE';
+  private static PROCESS_INTERVAL_MS = 1000;
+
+  private pendingTaskQueueUpdate: null | NodeJS.Timeout = null;
+  private taskQueue: TaskQueueEntry[] = [];
+  private ready = false;
+  private logger = logger.child({component: 'ObservationUploader'});
+  private subscribers: Subscriber[] = [];
+
+  async initialize() {
+    this.taskQueue = taskQueueSchema.parse(JSON.parse((await AsyncStorage.getItem(ObservationUploader.TASK_QUEUE_KEY)) || '[]'));
+    this.ready = true;
+    this.tryRunTaskQueue();
+  }
+
+  private checkInitialized() {
+    if (!this.ready) {
+      this.logger.error('ObservationUploader not initialized');
+      throw new Error('ObservationUploader not initialized');
+    }
+  }
+
+  private async flush() {
+    this.checkInitialized();
+    this.logger.debug({queue: this.taskQueue}, 'flushing new task queue to disk');
+    await AsyncStorage.setItem(ObservationUploader.TASK_QUEUE_KEY, JSON.stringify(this.taskQueue));
+  }
+
+  private tryRunTaskQueue() {
+    this.logger.debug({queueLength: this.taskQueue.length, pendingTaskQueueUpdate: this.pendingTaskQueueUpdate != null}, 'tryRunTaskQueue');
+    if (this.taskQueue.length === 0 || this.pendingTaskQueueUpdate) {
+      return;
+    }
+    const headEntry = this.taskQueue[0];
+    this.pendingTaskQueueUpdate = setTimeout(() => void this.processTaskQueue(), backoffTimeMs(headEntry.attemptCount));
+    this.logger.debug({backoffTimeMs: backoffTimeMs(headEntry.attemptCount), pendingTaskQueueUpdate: this.pendingTaskQueueUpdate != null}, 'tryRunTaskQueue complete');
+  }
+
+  async enqueueTasks(entries: TaskQueueEntry[]) {
+    this.logger.debug({entries}, 'enqueueTasks');
+    this.taskQueue.push(...entries);
+    await this.flush();
+    this.tryRunTaskQueue();
+  }
+
+  private async processTaskQueue() {
+    this.pendingTaskQueueUpdate = null;
+    this.logger.debug({queue: this.taskQueue}, 'processTaskQueue');
+    if (!this.taskQueue.length) {
+      return;
+    }
+    const entry = this.taskQueue[0];
+    entry.attemptCount++;
+    try {
+      switch (entry.type) {
+        case 'image':
+          {
+            // We upload the image, and if successful we upload the parent observation task to include it
+            const mediaItem = await uploadImage(entry.id, entry.data);
+            const parentTask = this.taskQueue.find(task => task.id === entry.parentId);
+            if (!parentTask || parentTask.type !== 'observation') {
+              this.logger.warn({entry, parentTask, queue: this.taskQueue}, `Unexpected: image task has no parent observation task`);
+            } else {
+              parentTask.data.extraData.media.push(mediaItem);
+              // this change will be flushed in the `finally` block below
+            }
+          }
+          break;
+        case 'observation':
+          await uploadObservation(entry.id, entry.data);
+          break;
+      }
+      this.logger.debug({entry}, `processed task queue entry successfully`);
+      this.subscribers.forEach(subscriber => subscriber(entry, true, entry.attemptCount));
+      this.taskQueue.shift(); // we're done with this task, so remove it from the queue
+    } catch (error) {
+      this.logger.error({error, entry, retryable: isRetryableError(error)}, `error processing task queue entry`);
+      if (!isRetryableError(error)) {
+        // Since this can't be retried, remove it from the queue
+        this.taskQueue.shift();
+      }
+      this.subscribers.forEach(subscriber => subscriber(entry, false, entry.attemptCount));
+    }
+
+    this.logger.debug({taskCount: this.taskQueue.length}, 'processTaskQueue end');
+    await this.flush();
+    this.tryRunTaskQueue();
+  }
+
+  async resetTaskQueue() {
+    this.logger.debug('resetTaskQueue');
+    this.checkInitialized();
+    this.taskQueue = [];
+    await this.flush();
+  }
+
+  subscribeToTaskInvocations(callback: Subscriber) {
+    this.subscribers.push(callback);
+  }
+
+  unsubscribeFromTaskInvocations(callback: Subscriber) {
+    this.subscribers = this.subscribers.filter(subscriber => subscriber !== callback);
+  }
+}

--- a/components/observations/uploader/Task.ts
+++ b/components/observations/uploader/Task.ts
@@ -1,0 +1,47 @@
+import {z} from 'zod';
+
+import {simpleObservationFormSchema} from 'components/observations/ObservationFormData';
+import {avalancheCenterIDSchema, mediaItemSchema, MediaUsage} from 'types/nationalAvalancheCenter';
+
+const taskQueueEntrySchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('image'),
+    id: z.string().uuid(),
+    parentId: z.string().uuid(),
+    attemptCount: z.number(),
+    data: z.object({
+      apiPrefix: z.string(),
+      image: z.object({
+        uri: z.string(),
+        exif: z
+          .object({
+            Orientation: z.number().or(z.string()).optional(),
+          })
+          .optional(),
+      }),
+      name: z.string(),
+      center_id: avalancheCenterIDSchema,
+      photoUsage: z.nativeEnum(MediaUsage),
+    }),
+  }),
+  z.object({
+    type: z.literal('observation'),
+    id: z.string().uuid(),
+    parentId: z.string().uuid().optional(),
+    attemptCount: z.number(),
+    data: z.object({
+      formData: simpleObservationFormSchema,
+      extraData: z.object({
+        url: z.string().url(),
+        center_id: avalancheCenterIDSchema,
+        organization: avalancheCenterIDSchema,
+        observer_type: z.literal('public'),
+        media: z.array(mediaItemSchema),
+      }),
+    }),
+  }),
+]);
+export type TaskQueueEntry = z.infer<typeof taskQueueEntrySchema>;
+export type ObservationTaskData = Extract<TaskQueueEntry, {type: 'observation'}>['data'];
+
+export const taskQueueSchema = z.array(taskQueueEntrySchema);

--- a/components/observations/uploader/uploadImage.ts
+++ b/components/observations/uploader/uploadImage.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+import * as FileSystem from 'expo-file-system';
+import {manipulateAsync, SaveFormat} from 'expo-image-manipulator';
+
+import {AvalancheCenterID, MediaItem, MediaUsage} from 'types/nationalAvalancheCenter';
+
+interface PickedImage {
+  uri: string;
+  exif?: {
+    // this is how it's defined in expo-image-picker
+    Orientation?: string | number;
+  };
+}
+interface UploadImageOptions {
+  apiPrefix: string;
+  center_id: AvalancheCenterID;
+  image: PickedImage;
+  name: string;
+  photoUsage: MediaUsage;
+}
+
+const extensionToMimeType = (extension: string) => {
+  switch (extension.toLowerCase()) {
+    case 'jpeg':
+    case 'jpg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    default:
+      throw new Error(`Unknown mime type for extension: ${extension}`);
+  }
+};
+
+const loadImageData = async ({uri, exif}: PickedImage): Promise<{imageDataBase64: string; mimeType: string; filename: string}> => {
+  // This weird use of `slice` is because the version of Hermes that Expo is currently pinned to doesn't support `at()`
+  const filename = uri.split('/').slice(-1)[0];
+  const extension = filename.split('.').slice(-1)[0] || '';
+
+  const orientation = exif?.Orientation as string | number;
+  if (typeof orientation !== 'number' || orientation <= 1) {
+    const imageDataBase64 = await FileSystem.readAsStringAsync(uri, {encoding: 'base64'});
+    return {imageDataBase64, filename, mimeType: extensionToMimeType(extension)};
+  } else {
+    // This is an image with a non-standard orientation, and it's not handled correctly by the NAC image
+    // pipeline (you get things like flipped thumbnails). More info on EXIF orientation: https://sirv.com/help/articles/rotate-photos-to-be-upright/
+    //
+    // The solution is pretty simple: allow the expo image manipulation library to save a copy, which
+    // writes the image with a "normal" orientation and applies any necessary transforms to make it look correct.
+    const result = await manipulateAsync(uri, [], {format: SaveFormat.JPEG, base64: true});
+    return {imageDataBase64: result.base64 ?? '', filename, mimeType: 'image/jpeg'};
+  }
+};
+
+export const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage}: UploadImageOptions): Promise<MediaItem> => {
+  const {imageDataBase64, filename, mimeType} = await loadImageData(image);
+
+  const payload = {
+    file: `data:${mimeType};base64,${imageDataBase64}`,
+    type: 'image',
+    file_name: filename,
+    center_id,
+    forecast_zone_id: [],
+    taken_by: name,
+    access: photoUsage,
+    source: 'public',
+    // TODO would be nice to tag images that came from this app, but haven't figured that out yet
+  };
+
+  const response = await axios.post<MediaItem>(`${apiPrefix}/v2/public/media`, payload, {
+    headers: {
+      // Public API uses the Origin header to determine who's authorized to call it
+      Origin: 'https://nwac.us',
+    },
+  });
+  return response.data;
+};

--- a/components/observations/uploader/uploadObservation.ts
+++ b/components/observations/uploader/uploadObservation.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+
+import {ObservationTaskData} from 'components/observations/uploader/Task';
+import {logger} from 'logger';
+import {Observation} from 'types/nationalAvalancheCenter';
+import {apiDateString} from 'utils/date';
+
+export async function uploadObservation(id: string, data: ObservationTaskData): Promise<Observation> {
+  const {formData, extraData} = data;
+  const {url, ...params} = extraData;
+  const payload: Partial<Observation> = {
+    ...formData,
+    ...params,
+    obs_source: 'public',
+    // Date has to be a plain-old YYYY-MM-DD string
+    start_date: apiDateString(formData.start_date),
+    status: 'published',
+  };
+  try {
+    const {data: responseData} = await axios.post<Observation>(url, payload, {
+      headers: {
+        // Public API uses the Origin header to determine who's authorized to call it
+        Origin: 'https://nwac.us',
+      },
+    });
+    // You'd think we could feed data to Zod and get a strongly typed object back, but
+    // the object that we get back from the post can't actually be parsed by our schema :(
+    // TODO(skuznets): figure out what we get from POST and actually parse it ...
+    return responseData;
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        url,
+        payload,
+      },
+      'error uploading observation',
+    );
+    throw error;
+  }
+}

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -30,7 +30,6 @@ import {Card, CollapsibleCard} from 'components/content/Card';
 import {ConnectionLost, InternalError, NotFound} from 'components/content/QueryState';
 import {ActionToast, ErrorToast, InfoToast, SuccessToast, WarningToast} from 'components/content/Toast';
 import {TableRow} from 'components/observations/ObservationDetailView';
-import {clearUploadCache} from 'components/observations/submitObservation';
 import {ForecastScreen} from 'components/screens/ForecastScreen';
 import {MapScreen} from 'components/screens/MapScreen';
 import {NWACObservationScreen, ObservationScreen} from 'components/screens/ObservationsScreen';
@@ -232,7 +231,6 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                             void (async () => {
                               await AsyncStorage.removeItem(QUERY_CACHE_ASYNC_STORAGE_KEY);
                               queryCache.clear();
-                              await clearUploadCache();
                             })();
                           }}>
                           Reset the query cache

--- a/package.json
+++ b/package.json
@@ -164,6 +164,9 @@
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|d3(-?[a-z]+)?|internmap)"
     ],
+    "setupFiles": [
+      "./tests/setupAsyncStorage.ts"
+    ],
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect"
     ],

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
     "react-native-toast-message": "^2.1.6",
+    "react-native-uuid": "^2.0.1",
     "react-native-web": "~0.19.6",
     "sentry-expo": "~7.0.0",
     "tamagui": "^1.35.8",

--- a/tests/setupAsyncStorage.ts
+++ b/tests/setupAsyncStorage.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'));

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -931,6 +931,11 @@ export const FormatPartnerType = (value: PartnerType): string => {
   return reverseLookup(PartnerType, value);
 };
 
+const ObsSourceType = {
+  Public: 'public',
+  Dashboard: 'dashboard',
+} as const;
+
 export const instabilitySchema = z.object({
   avalanches_observed: z.boolean().optional(/* only because of NWAC */),
   avalanches_triggered: z.boolean().optional(/* only because of NWAC */),
@@ -968,6 +973,8 @@ export const observationSchema = z.object({
   instability: instabilitySchema,
   instability_summary: z.string().nullable().optional(/* only because of NWAC */),
   observation_summary: z.string().nullable().optional(/* only because of NWAC */),
+  body: z.string().nullable().optional(/* this is a new field required on submission but never returned...? */),
+  obs_source: z.nativeEnum(ObsSourceType).optional(),
   media: z.array(mediaItemSchema).nullable().optional(/* only because of NWAC */),
   avalanches_summary: z.string().nullable().optional(/* only because of NWAC */),
   urls: z.array(z.string()).optional(/* only because of NWAC */),

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -973,7 +973,6 @@ export const observationSchema = z.object({
   instability: instabilitySchema,
   instability_summary: z.string().nullable().optional(/* only because of NWAC */),
   observation_summary: z.string().nullable().optional(/* only because of NWAC */),
-  body: z.string().nullable().optional(/* this is a new field required on submission but never returned...? */),
   obs_source: z.nativeEnum(ObsSourceType).optional(),
   media: z.array(mediaItemSchema).nullable().optional(/* only because of NWAC */),
   avalanches_summary: z.string().nullable().optional(/* only because of NWAC */),

--- a/yarn.lock
+++ b/yarn.lock
@@ -13800,6 +13800,11 @@ react-native-toast-message@^2.1.6:
   resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.1.6.tgz#322827c66901fa22cb3db614c7383cc717f5bbe2"
   integrity sha512-VctXuq20vmRa9AE13acaNZhrLcS3FaBS2zEevS3+vhBsnVZYG0FIlWIis9tVnpnNxUb3ART+BWtwQjzSttXTng==
 
+react-native-uuid@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
+  integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
+
 react-native-web-internals@1.35.8:
   version "1.35.8"
   resolved "https://registry.yarnpkg.com/react-native-web-internals/-/react-native-web-internals-1.35.8.tgz#7099b093248be91d7b8a750cb246c9076162a960"


### PR DESCRIPTION
First, they actually work again! Had to include the new `obs_source` param.

Second: this PR massively overhauls how we track, schedule and retry the observation jobs. This comment describes what we're doing now:
https://github.com/NWACus/avy/blob/f399cfd4a4cfc53f3e4c037432575fc087185be6/components/observations/uploader/ObservationsUploader.ts#L35-L42

The `submitObservation` method is now very stripped down. It enqueues tasks into the `ObservationUploader`, which is then in turn responsible for scheduling calls to `uploadImage` and `uploadObservation` in sequence. Modules are split apart and much easier to read IMO.

Observation uploads should now be resilient in the face of network errors and even app restarts. There are also a bunch of tests in `ObservationUploader.test.ts` where I had to learn lots of tricks about how to test async code with Jest 😬.

The first enhancement I want to make is to detect online/offline status and pause/resume the task queue, but there's enough code here and enough improvement that I want to get this in first.