### PR TITLE
Logging: copy to clipboard, more work on reducing log size

### DIFF
--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -4,7 +4,8 @@ import {AxiosError} from 'axios';
 import {TaskQueueEntry, taskQueueSchema} from 'components/observations/uploader/Task';
 import {uploadImage} from 'components/observations/uploader/uploadImage';
 import {uploadObservation} from 'components/observations/uploader/uploadObservation';
-import {filterBigStrings, logger} from 'logger';
+import {logger} from 'logger';
+import {filterLoggedData} from 'logging/filterLoggedData';
 
 type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
 
@@ -128,9 +129,9 @@ export class ObservationUploader {
       this.taskQueue.shift(); // we're done with this task, so remove it from the queue
     } catch (error) {
       if (isRetryableError(error)) {
-        this.logger.warn({error: filterBigStrings(error), entry, retryable: isRetryableError(error)}, `transient error processing task queue entry. it will be retried.`);
+        this.logger.warn({error: filterLoggedData(error), entry, retryable: isRetryableError(error)}, `transient error processing task queue entry. it will be retried.`);
       } else {
-        this.logger.error({error: filterBigStrings(error), entry, retryable: isRetryableError(error)}, `fatal error processing task queue entry. it will not be retried.`);
+        this.logger.error({error: filterLoggedData(error), entry, retryable: isRetryableError(error)}, `fatal error processing task queue entry. it will not be retried.`);
         // Since this can't be retried, remove it from the queue
         this.taskQueue.shift();
       }

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -4,7 +4,7 @@ import {AxiosError} from 'axios';
 import {TaskQueueEntry, taskQueueSchema} from 'components/observations/uploader/Task';
 import {uploadImage} from 'components/observations/uploader/uploadImage';
 import {uploadObservation} from 'components/observations/uploader/uploadObservation';
-import {logger} from 'logger';
+import {filterBigStrings, logger} from 'logger';
 
 type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
 
@@ -128,9 +128,9 @@ export class ObservationUploader {
       this.taskQueue.shift(); // we're done with this task, so remove it from the queue
     } catch (error) {
       if (isRetryableError(error)) {
-        this.logger.warn({error, entry, retryable: isRetryableError(error)}, `transient error processing task queue entry. it will be retried.`);
+        this.logger.warn({error: filterBigStrings(error), entry, retryable: isRetryableError(error)}, `transient error processing task queue entry. it will be retried.`);
       } else {
-        this.logger.error({error, entry, retryable: isRetryableError(error)}, `fatal error processing task queue entry. it will not be retried.`);
+        this.logger.error({error: filterBigStrings(error), entry, retryable: isRetryableError(error)}, `fatal error processing task queue entry. it will not be retried.`);
         // Since this can't be retried, remove it from the queue
         this.taskQueue.shift();
       }

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -15,7 +15,9 @@ import {MenuStackNavigationProps, MenuStackParamList, TabNavigationProps, TabNav
 import {Divider, HStack, View, VStack} from 'components/core';
 
 import * as Application from 'expo-application';
+import * as Clipboard from 'expo-clipboard';
 import Constants from 'expo-constants';
+import * as FileSystem from 'expo-file-system';
 import * as Updates from 'expo-updates';
 import * as WebBrowser from 'expo-web-browser';
 
@@ -198,33 +200,45 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                             },
                           ]}
                         />
-                        <Button
-                          buttonStyle="normal"
-                          // this is disabled on iOS and enabled on Android,
-                          // since we don't have proper attachment support on iOS
-                          // https://github.com/expo/expo/issues/24613
-                          disabled={Platform.OS === 'ios'}
-                          onPress={() => {
-                            void (async () => {
-                              if (
-                                !(await sendMail({
-                                  to: 'developer+app-logs@nwac.us',
-                                  subject: 'NWAC app log files',
-                                  body: `\n\n---\n\nRun \`yarn bunyan ${logFilePath.split('/').slice(-1)[0]}\` to view.\nRun \`yarn bunyan --help\` for additional options.`,
-                                  attachments: [logFilePath],
-                                  logger,
-                                }))
-                              ) {
-                                Toast.show({
-                                  type: 'error',
-                                  text1: 'Email is not configured!',
-                                  position: 'bottom',
-                                });
-                              }
-                            })();
-                          }}>
-                          Email log file
-                        </Button>
+                        <HStack alignItems="center" justifyContent={'space-between'} space={16}>
+                          <Button
+                            buttonStyle="normal"
+                            // this is disabled on iOS and enabled on Android,
+                            // since we don't have proper attachment support on iOS
+                            // https://github.com/expo/expo/issues/24613
+                            disabled={Platform.OS === 'ios'}
+                            onPress={() => {
+                              void (async () => {
+                                if (
+                                  !(await sendMail({
+                                    to: 'developer+app-logs@nwac.us',
+                                    subject: 'NWAC app log files',
+                                    body: `\n\n---\n\nRun \`yarn bunyan ${logFilePath.split('/').slice(-1)[0]}\` to view.\nRun \`yarn bunyan --help\` for additional options.`,
+                                    attachments: [logFilePath],
+                                    logger,
+                                  }))
+                                ) {
+                                  Toast.show({
+                                    type: 'error',
+                                    text1: 'Email is not configured!',
+                                    position: 'bottom',
+                                  });
+                                }
+                              })();
+                            }}>
+                            Email log file
+                          </Button>
+                          <Button
+                            buttonStyle="normal"
+                            onPress={() => {
+                              void (async () => {
+                                const log = await FileSystem.readAsStringAsync(logFilePath);
+                                await Clipboard.setStringAsync(log);
+                              })();
+                            }}>
+                            Copy log to clipboard
+                          </Button>
+                        </HStack>
                         <Button
                           buttonStyle="normal"
                           onPress={() => {

--- a/eas.json
+++ b/eas.json
@@ -9,6 +9,10 @@
       "distribution": "internal",
       "channel": "main"
     },
+    "adhoc": {
+      "distribution": "internal",
+      "channel": "main"
+    },
     "simulator": {
       "distribution": "internal",
       "channel": "main",

--- a/logger.ts
+++ b/logger.ts
@@ -41,3 +41,21 @@ export const logger = createLogger({
   serializers: stdSerializers,
   streams,
 });
+
+// Sometimes we're sending very large data params like base64-encoded images.
+// Let's not log those, eh?
+export const filterBigStrings = (params: unknown): unknown => {
+  if (!params || (typeof params !== 'object' && typeof params !== 'string')) {
+    return params;
+  }
+
+  if (typeof params === 'string') {
+    return params.length > 100 ? params.substring(0, 100) + '...' : params;
+  }
+
+  if (Array.isArray(params)) {
+    return params.map(filterBigStrings);
+  }
+
+  return Object.fromEntries(Object.entries(params).map(([k, v]) => [k, filterBigStrings(v)]));
+};

--- a/logger.ts
+++ b/logger.ts
@@ -41,21 +41,3 @@ export const logger = createLogger({
   serializers: stdSerializers,
   streams,
 });
-
-// Sometimes we're sending very large data params like base64-encoded images.
-// Let's not log those, eh?
-export const filterBigStrings = (params: unknown): unknown => {
-  if (!params || (typeof params !== 'object' && typeof params !== 'string')) {
-    return params;
-  }
-
-  if (typeof params === 'string') {
-    return params.length > 100 ? params.substring(0, 100) + '...' : params;
-  }
-
-  if (Array.isArray(params)) {
-    return params.map(filterBigStrings);
-  }
-
-  return Object.fromEntries(Object.entries(params).map(([k, v]) => [k, filterBigStrings(v)]));
-};

--- a/logging/fileStream.ts
+++ b/logging/fileStream.ts
@@ -1,6 +1,7 @@
 import {LogStream} from 'browser-bunyan';
 import * as FileSystem from 'expo-file-system';
 import {debounce} from 'lodash';
+import {filterLoggedData} from 'logging/filterLoggedData';
 
 export class FileStream implements LogStream {
   private readonly filePath: string;
@@ -28,7 +29,8 @@ export class FileStream implements LogStream {
       // the bunyan command line tool can't format these records correctly without a pid and hostname field
       pid: 0,
       hostname: 'localhost',
-      ...record,
+      // filterLoggedData will take anything and return the same type
+      ...(filterLoggedData(record) as object),
     });
     this.buffer.push(recordString);
     void this.flush();

--- a/logging/filterLoggedData.ts
+++ b/logging/filterLoggedData.ts
@@ -1,0 +1,17 @@
+// Sometimes we're sending very large data params like base64-encoded images.
+// Let's not log those, eh?
+export const filterLoggedData = (params: unknown): unknown => {
+  if (!params || (typeof params !== 'object' && typeof params !== 'string')) {
+    return params;
+  }
+
+  if (typeof params === 'string') {
+    return params.length > 100 ? params.substring(0, 100) + '...' : params;
+  }
+
+  if (Array.isArray(params)) {
+    return params.map(filterLoggedData);
+  }
+
+  return Object.fromEntries(Object.entries(params).map(([k, v]) => [k, filterLoggedData(v)]));
+};

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "expo-application": "~5.3.0",
     "expo-background-fetch": "~11.3.0",
     "expo-checkbox": "~2.4.0",
+    "expo-clipboard": "~4.3.1",
     "expo-constants": "~14.4.2",
     "expo-dev-client": "~2.4.11",
     "expo-device": "~5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8868,6 +8868,11 @@ expo-checkbox@~2.4.0:
   resolved "https://registry.yarnpkg.com/expo-checkbox/-/expo-checkbox-2.4.0.tgz#5d5bb82117f4d781eb1d4db0ff96e1f0a4a0547a"
   integrity sha512-ZEe79B73I+NDkLZQ2pR1E5rv9ey1oleNI/s2/Jdb9zKWztS0KVU2K+drFn2t/zyoSbR1U+CNwik2v7h6JxrXcA==
 
+expo-clipboard@~4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-4.3.1.tgz#ce6ed35ae31c7fc1aeadb005b8eb9b39a8bb9b40"
+  integrity sha512-WIsjvAsr2+/NZRa84mKxjui1EdPpdKbQIC2LN/KMBNuT7g4GQYL3oo9WO9G/C7doKQ7f7pnfdvO3N6fUnoRoJw==
+
 expo-constants@~14.4.2:
   version "14.4.2"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-14.4.2.tgz#cac5e8b524069545739b8d8595ce96cc5be6578c"


### PR DESCRIPTION
Does what it says on the tin. Uses the newly renamed `filterLoggedData` function to truncate large strings in logged data. Adds a copy to clipboard button to work around iOS mail issues.