### PR TITLE
Fix errors caused by uploading large images

### DIFF
--- a/components/observations/submitObservation.ts
+++ b/components/observations/submitObservation.ts
@@ -38,6 +38,8 @@ export const submitObservation = async ({
           apiPrefix: apiPrefix,
           image: {
             uri: image.uri,
+            width: image.width,
+            height: image.height,
             exif: image.exif
               ? {
                   // The type of ImagePickerAsset.exif is (unfortunately) Record<string, any>

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -265,6 +265,8 @@ const imageUploadTask = (): TaskQueueEntry => ({
     apiPrefix: 'https://localhost:3000',
     image: {
       uri: 'file:///test.jpg',
+      width: 640,
+      height: 480,
       exif: {Orientation: 1},
     },
     name: `created ${new Date().toLocaleTimeString()}`,

--- a/components/observations/uploader/Task.ts
+++ b/components/observations/uploader/Task.ts
@@ -13,6 +13,8 @@ const taskQueueEntrySchema = z.discriminatedUnion('type', [
       apiPrefix: z.string(),
       image: z.object({
         uri: z.string(),
+        width: z.number(),
+        height: z.number(),
         exif: z
           .object({
             Orientation: z.number().or(z.string()).optional(),

--- a/components/observations/uploader/uploadImage.ts
+++ b/components/observations/uploader/uploadImage.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
-import * as FileSystem from 'expo-file-system';
-import {manipulateAsync, SaveFormat} from 'expo-image-manipulator';
+import {Action, manipulateAsync, SaveFormat} from 'expo-image-manipulator';
 
 import {AvalancheCenterID, MediaItem, MediaUsage} from 'types/nationalAvalancheCenter';
 
 interface PickedImage {
   uri: string;
+  width: number;
+  height: number;
   exif?: {
     // this is how it's defined in expo-image-picker
     Orientation?: string | number;
@@ -19,36 +20,32 @@ interface UploadImageOptions {
   photoUsage: MediaUsage;
 }
 
-const extensionToMimeType = (extension: string) => {
-  switch (extension.toLowerCase()) {
-    case 'jpeg':
-    case 'jpg':
-      return 'image/jpeg';
-    case 'png':
-      return 'image/png';
-    default:
-      throw new Error(`Unknown mime type for extension: ${extension}`);
-  }
-};
-
-const loadImageData = async ({uri, exif}: PickedImage): Promise<{imageDataBase64: string; mimeType: string; filename: string}> => {
+const loadImageData = async ({uri, width, height}: PickedImage): Promise<{imageDataBase64: string; mimeType: string; filename: string}> => {
   // This weird use of `slice` is because the version of Hermes that Expo is currently pinned to doesn't support `at()`
   const filename = uri.split('/').slice(-1)[0];
-  const extension = filename.split('.').slice(-1)[0] || '';
-
-  const orientation = exif?.Orientation as string | number;
-  if (typeof orientation !== 'number' || orientation <= 1) {
-    const imageDataBase64 = await FileSystem.readAsStringAsync(uri, {encoding: 'base64'});
-    return {imageDataBase64, filename, mimeType: extensionToMimeType(extension)};
-  } else {
-    // This is an image with a non-standard orientation, and it's not handled correctly by the NAC image
-    // pipeline (you get things like flipped thumbnails). More info on EXIF orientation: https://sirv.com/help/articles/rotate-photos-to-be-upright/
-    //
-    // The solution is pretty simple: allow the expo image manipulation library to save a copy, which
-    // writes the image with a "normal" orientation and applies any necessary transforms to make it look correct.
-    const result = await manipulateAsync(uri, [], {format: SaveFormat.JPEG, base64: true});
-    return {imageDataBase64: result.base64 ?? '', filename, mimeType: 'image/jpeg'};
+  const portrait = height > width;
+  const maxDimension = portrait ? height : width;
+  const clampedDimension = Math.min(maxDimension, 2048);
+  const manipulationActions: Action[] = [];
+  if (clampedDimension !== maxDimension) {
+    manipulationActions.push({
+      resize: {
+        width: portrait ? undefined : clampedDimension,
+        height: portrait ? clampedDimension : undefined,
+      },
+    });
   }
+
+  // We are happy to always run the image through the image manipulation pipeline, even if
+  // manipulationActions is empty, because it will resave the image as a JPEG and apply
+  // any necessary transforms to make it look correct. Images with non-standard orientations
+  // are not handled correctly by the NAC image pipeline (you get things like flipped thumbnails).
+  // More info on EXIF orientation: https://sirv.com/help/articles/rotate-photos-to-be-upright/
+  //
+  // The solution is pretty simple: allow the expo image manipulation library to save a copy, which
+  // writes the image with a "normal" orientation and applies any necessary transforms to make it look correct.
+  const result = await manipulateAsync(uri, manipulationActions, {format: SaveFormat.JPEG, base64: true});
+  return {imageDataBase64: result.base64 ?? '', filename, mimeType: 'image/jpeg'};
 };
 
 export const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage}: UploadImageOptions): Promise<MediaItem> => {


### PR DESCRIPTION
Fixes #431 

Applies a very conservative limit of 2k pixels on the longest side - we should figure out what the actual limits look like. 

Honestly it's pretty wasteful that images are going through a PHP server instead of straight to S3 but 🤷 time is finite, I get it.