### PR TITLE
Make observation submission better when offline

### DIFF
--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -91,6 +91,8 @@ export const SimpleForm: React.FC<{
       logger.error({error: error}, 'mutation failed');
     },
     retry: true,
+    // This mutation is always allowed to run! The uploader manages retries and persistence of this task
+    networkMode: 'always',
   });
 
   const onSubmitHandler = (data: ObservationFormData) => {

--- a/components/observations/submitObservation.ts
+++ b/components/observations/submitObservation.ts
@@ -2,13 +2,10 @@ import _ from 'lodash';
 import uuid from 'react-native-uuid';
 
 import {ObservationFormData} from 'components/observations/ObservationFormData';
-import {ObservationUploader} from 'components/observations/uploader/ObservationsUploader';
+import {getUploader} from 'components/observations/uploader/ObservationsUploader';
 import {TaskQueueEntry} from 'components/observations/uploader/Task';
 import {logger} from 'logger';
 import {AvalancheCenterID, MediaUsage} from 'types/nationalAvalancheCenter';
-
-const uploader = new ObservationUploader();
-void uploader.initialize();
 
 export const submitObservation = async ({
   apiPrefix,
@@ -75,6 +72,7 @@ export const submitObservation = async ({
       },
     });
 
+    const uploader = getUploader();
     const promise: Promise<void> = new Promise((resolve, _reject) => {
       const listener = (entry: TaskQueueEntry, success: boolean) => {
         if (entry.type === 'observation' && entry.id === observationTaskId) {

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -51,6 +51,29 @@ const createAxiosError = (status: number): AxiosError =>
   );
 
 describe('isRetryableError', () => {
+  it('should return true for network offline errors', () => {
+    const error = new AxiosError(
+      'Boom!',
+      'ERR_NETWORK',
+      {
+        url: 'http://localhost:3000',
+      },
+      {
+        path: '/foo',
+      },
+      {
+        status: 400,
+        config: {
+          url: 'http://localhost:3000',
+        },
+        headers: {},
+        data: {},
+        statusText: 'Boom!',
+      },
+    );
+    expect(isRetryableError(error)).toBe(true);
+  });
+
   it('should return true for server errors', () => {
     const error = createAxiosError(500);
     expect(isRetryableError(error)).toBe(true);

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -13,7 +13,9 @@ export const isRetryableError = (error: unknown): boolean => {
   // This may evolve over time as we learn more about what errors the NAC API can
   // return and what errors are transient vs permanent, but it's a reasonable starting point.
   if (error instanceof AxiosError) {
-    if (error.response) {
+    if (error.code === 'ERR_NETWORK') {
+      return true;
+    } else if (error.response) {
       const status = error.response.status;
       return (
         status >= 500 || // server error

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -162,3 +162,9 @@ export class ObservationUploader {
     this.subscribers = this.subscribers.filter(subscriber => subscriber !== callback);
   }
 }
+
+const uploader: ObservationUploader = new ObservationUploader();
+void uploader.initialize();
+export const getUploader = () => {
+  return uploader;
+};

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -32,6 +32,7 @@ import {Card, CollapsibleCard} from 'components/content/Card';
 import {ConnectionLost, InternalError, NotFound} from 'components/content/QueryState';
 import {ActionToast, ErrorToast, InfoToast, SuccessToast, WarningToast} from 'components/content/Toast';
 import {TableRow} from 'components/observations/ObservationDetailView';
+import {getUploader} from 'components/observations/uploader/ObservationsUploader';
 import {ForecastScreen} from 'components/screens/ForecastScreen';
 import {MapScreen} from 'components/screens/MapScreen';
 import {NWACObservationScreen, ObservationScreen} from 'components/screens/ObservationsScreen';
@@ -251,6 +252,9 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                         </Button>
                         <Button buttonStyle="normal" onPress={() => void clearPreferences()}>
                           Reset preferences
+                        </Button>
+                        <Button buttonStyle="normal" onPress={() => void getUploader().resetTaskQueue()}>
+                          Reset the observation uploader
                         </Button>
                         <HStack justifyContent="space-between" alignItems="center" space={16}>
                           <Body>Use staging environment</Body>


### PR DESCRIPTION
- Make Axios ERR_NETWORK errors retryable
- Make the `useMutation` call run in offline mode
- Make the `NetworkImage` component work with local files in offline mode
- Add a debug menu button to clear the observation queue