### PR TITLE
Revert "colors.ts: ensure correct names are provided"

### DIFF
--- a/components/content/InfoTooltip.tsx
+++ b/components/content/InfoTooltip.tsx
@@ -5,16 +5,15 @@ import {BodyBlack, Title3Semibold} from 'components/text';
 import {HTML, HTMLRendererConfig, HTMLRendererConfigProps} from 'components/text/HTML';
 import {merge} from 'lodash';
 import React, {useCallback, useState} from 'react';
-import {Insets, Modal, TextStyle, TouchableWithoutFeedback, ViewStyle} from 'react-native';
+import {ColorValue, Insets, Modal, TextStyle, TouchableWithoutFeedback, ViewStyle} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
-import {ColorName} from 'theme/colors';
 
 export interface InfoTooltipProps {
   title: string;
   content: string;
   size: number;
-  color?: ColorName;
+  color?: ColorValue;
   solidIcon?: keyof typeof AntDesign.glyphMap;
   outlineIcon?: keyof typeof AntDesign.glyphMap;
 

--- a/components/core/View.test.tsx
+++ b/components/core/View.test.tsx
@@ -3,14 +3,13 @@ import {render, screen} from '@testing-library/react-native';
 import React from 'react';
 
 import {View} from 'components/core/View';
-import {colorLookup} from 'theme';
 
 describe('View', () => {
   it("sets top-level properties on the wrapped View's style property", () => {
-    render(<View width={100} height={'100%'} backgroundColor="red.100" testID="foo" />);
+    render(<View width={100} height={'100%'} backgroundColor="red" testID="foo" />);
     const view = screen.getByTestId('foo');
     expect(view.props.style).toEqual({
-      backgroundColor: colorLookup('red.100').toString(),
+      backgroundColor: 'red',
       width: 100,
       height: '100%',
     });
@@ -26,39 +25,39 @@ describe('View', () => {
   });
 
   it('top-level properties overwrite the inner `style`, when specified after the `style` prop', () => {
-    render(<View style={{width: 50, backgroundColor: 'blue'}} backgroundColor="red.100" testID="foo" />);
+    render(<View style={{width: 50, backgroundColor: 'blue'}} backgroundColor="red" testID="foo" />);
     const view = screen.getByTestId('foo');
     expect(view.props.style).toEqual({
-      backgroundColor: colorLookup('red.100').toString(),
+      backgroundColor: 'red',
       width: 50,
     });
   });
 
   it('property shorthand can overwrite `style` props', () => {
-    render(<View style={{backgroundColor: 'blue'}} bg="red.100" testID="foo" />);
+    render(<View style={{backgroundColor: 'blue'}} bg="red" testID="foo" />);
     const view = screen.getByTestId('foo');
     expect(view.props.style).toEqual({
-      backgroundColor: colorLookup('red.100').toString(),
+      backgroundColor: 'red',
     });
   });
 
   it('when multiple property aliases target the same property, last one wins', () => {
-    render(<View style={{backgroundColor: 'blue'}} bg="red.100" backgroundColor="pink.200" bgColor="yellow.300" testID="foo" />);
+    render(<View style={{backgroundColor: 'blue'}} bg="red" backgroundColor="pink" bgColor="yellow" testID="foo" />);
     const view = screen.getByTestId('foo');
     expect(view.props.style).toEqual({
-      backgroundColor: colorLookup('yellow.300').toString(),
+      backgroundColor: 'yellow',
     });
 
-    render(<View style={{backgroundColor: 'blue'}} bgColor="yellow.300" backgroundColor="pink.200" bg="red.100" testID="foo" />);
+    render(<View style={{backgroundColor: 'blue'}} bgColor="yellow" backgroundColor="pink" bg="red" testID="foo" />);
     const view2 = screen.getByTestId('foo');
     expect(view2.props.style).toEqual({
-      backgroundColor: colorLookup('red.100').toString(),
+      backgroundColor: 'red',
     });
 
-    render(<View style={{backgroundColor: 'blue'}} bgColor="yellow.300" bg="red.100" backgroundColor="pink.200" testID="foo" />);
+    render(<View style={{backgroundColor: 'blue'}} bgColor="yellow" bg="red" backgroundColor="pink" testID="foo" />);
     const view3 = screen.getByTestId('foo');
     expect(view3.props.style).toEqual({
-      backgroundColor: colorLookup('pink.200').toString(),
+      backgroundColor: 'pink',
     });
   });
 

--- a/components/text/index.tsx
+++ b/components/text/index.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {Text, TextProps, TextStyle} from 'react-native';
 
 import {colorLookup} from 'theme';
-import {ColorName, COLORS} from 'theme/colors';
 
 export interface TextWrapperProps extends TextProps {
   color?: TextStyle['color'];
@@ -20,7 +19,7 @@ export interface TextWrapperProps extends TextProps {
 const TextWrapper: React.FC<TextWrapperProps> = ({color, fontFamily, fontSize, fontStyle, letterSpacing, lineHeight, textAlign, textTransform, children, ...props}) => {
   const style = omitBy(
     {
-      color: color ? (color in COLORS ? colorLookup(color as ColorName).toString() : color) : color,
+      color: color ? colorLookup(color) : color,
       fontFamily,
       fontSize,
       letterSpacing,

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -453,6 +453,4 @@ export const COLORS: Record<string, ColorValue> = {
   'tertiary.900': '#064e3b',
 } as const;
 
-export type ColorName = keyof typeof COLORS;
-
-export const colorLookup = (color: ColorName): ColorValue => COLORS[color];
+export const colorLookup = (color: ColorValue): ColorValue => (typeof color === 'string' && COLORS[color] ? COLORS[color] : color);


### PR DESCRIPTION
This reverts commit 91aec5797614a5492031b0ca78ce0d884336c0f1. (PR #417)

The PR broke many background colors and @charlotteguard needs a fix quickly