### PR TITLE
Online/offline detection for ObservationUploader

### DIFF
--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -1,6 +1,8 @@
 jest.mock('components/observations/uploader/uploadImage');
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from '@react-native-community/netinfo';
+
 import {AxiosError} from 'axios';
 import {ObservationUploader, backoffTimeMs, isRetryableError} from 'components/observations/uploader/ObservationsUploader';
 import {TaskQueueEntry} from 'components/observations/uploader/Task';
@@ -9,6 +11,7 @@ import {logger} from 'logger';
 import {MediaItem, MediaType, MediaUsage} from 'types/nationalAvalancheCenter';
 
 const uploadImage = uploadImageOriginal as jest.MockedFunction<typeof uploadImageOriginal>;
+const MockNetInfo = NetInfo as typeof NetInfo & {mockGoOffline: () => undefined; mockGoOnline: () => undefined};
 
 // Deferred wraps up a Promise and allows the promise to be resolved or rejected externally.
 // This is different from a vanilla Promise, which only allows accessing its resolve/reject
@@ -138,7 +141,7 @@ describe('ObservationUploader', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    uploadImage.mockReset();
     jest.useRealTimers();
   });
 
@@ -262,6 +265,45 @@ describe('ObservationUploader', () => {
 
     // Since this is a fatal error, it won't retry
     expect(uploader['taskQueue']).toHaveLength(0);
+  });
+
+  describe('online/offline', () => {
+    it('should be paused when offline', async () => {
+      MockNetInfo.mockGoOffline();
+
+      const {uploader, processTaskQueueInvocations} = await createUploader();
+      uploadImage.mockResolvedValueOnce(successfulUploadImageResponse);
+
+      await uploader.enqueueTasks([imageUploadTask()]);
+
+      // Advance the timer to run the first invocation of processTaskQueue
+      jest.advanceTimersByTime(0);
+      jest.runAllTicks();
+      // But it won't actually run because we're offline
+      expect(processTaskQueueInvocations).toHaveLength(0);
+
+      // Clear the queue before wrapping up this test
+      await uploader.resetTaskQueue();
+    });
+
+    it('should resume when back online', async () => {
+      MockNetInfo.mockGoOffline();
+
+      const {uploader, processTaskQueueInvocations} = await createUploader();
+      uploadImage.mockResolvedValueOnce(successfulUploadImageResponse);
+
+      await uploader.enqueueTasks([imageUploadTask()]);
+
+      MockNetInfo.mockGoOnline();
+
+      // Advance the timer to run the first invocation of processTaskQueue
+      jest.advanceTimersByTime(0);
+      jest.runAllTicks();
+      // Now it will run because we're back online
+      expect(processTaskQueueInvocations).toHaveLength(1);
+      await processTaskQueueInvocations[0].promise;
+      expect(uploadImage).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -5,7 +5,6 @@ import {AxiosError} from 'axios';
 import {ObservationUploader, backoffTimeMs, isRetryableError} from 'components/observations/uploader/ObservationsUploader';
 import {TaskQueueEntry} from 'components/observations/uploader/Task';
 import {uploadImage as uploadImageOriginal} from 'components/observations/uploader/uploadImage';
-// import Deferred from 'tests/helpers/Deferred';
 import {logger} from 'logger';
 import {MediaItem, MediaType, MediaUsage} from 'types/nationalAvalancheCenter';
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,16 @@
+import type {Config} from 'jest';
+
+const config: Config = {
+  silent: true, // suppresses all logging. override with --silent=false on the command line
+  preset: 'jest-expo',
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|d3(-?[a-z]+)?|internmap)',
+  ],
+  setupFiles: ['./tests/setupAsyncStorage.ts', './tests/mockNetInfo.ts'],
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  moduleNameMapper: {
+    '^.+.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
+  },
+};
+
+export default config;

--- a/logger.ts
+++ b/logger.ts
@@ -21,15 +21,17 @@ if (process.env.EXPO_PUBLIC_DISABLE_LOGBOX) {
   LogBox.ignoreAllLogs(true);
 }
 
+const defaultLogLevel = process.env.NODE_ENV === 'test' ? 'WARN' : 'INFO';
+
 const streams: StreamOptions[] = [
   {
-    level: (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO',
+    level: (Constants.expoConfig?.extra?.log_level as string) ?? defaultLogLevel,
     stream: new ConsoleFormattedStream(),
   },
 ];
 
-// Log to file in preview and development channels
-if (Updates.channel !== 'release') {
+// Log to file in preview and development channels, but not in tests
+if (Updates.channel !== 'release' && process.env.NODE_ENV === 'test') {
   streams.push({
     level: 'DEBUG',
     stream: new FileStream(logFilePath),

--- a/package.json
+++ b/package.json
@@ -160,20 +160,5 @@
     "ts-to-zod": "^3.1.2",
     "typescript": "^5.1.3"
   },
-  "jest": {
-    "preset": "jest-expo",
-    "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|d3(-?[a-z]+)?|internmap)"
-    ],
-    "setupFiles": [
-      "./tests/setupAsyncStorage.ts"
-    ],
-    "setupFilesAfterEnv": [
-      "@testing-library/jest-native/extend-expect"
-    ],
-    "moduleNameMapper": {
-      "^.+.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
-    }
-  },
   "private": true
 }

--- a/tests/mockNetInfo.ts
+++ b/tests/mockNetInfo.ts
@@ -1,0 +1,42 @@
+const onlineState = {
+  type: 'cellular',
+  isConnected: true,
+  isInternetReachable: true,
+};
+
+const offlineState = {
+  type: 'none',
+  isConnected: false,
+  isInternetReachable: false,
+};
+
+interface NetInfoState {
+  type: string;
+  isConnected: boolean;
+  isInternetReachable: boolean;
+}
+
+let currentState = onlineState;
+const listeners: ((state: NetInfoState) => void)[] = [];
+
+const MockNetInfo = {
+  configure: jest.fn(),
+  fetch: jest.fn().mockImplementation(() => {
+    return Promise.resolve(currentState);
+  }),
+  refresh: jest.fn().mockResolvedValue(currentState),
+  addEventListener: jest.fn().mockImplementation((handler: (state: NetInfoState) => void) => {
+    listeners.push(handler);
+  }),
+  useNetInfo: jest.fn().mockImplementation(() => Promise.resolve(currentState)),
+  mockGoOnline: () => {
+    currentState = onlineState;
+    listeners.forEach(listener => listener(currentState));
+  },
+  mockGoOffline: () => {
+    currentState = offlineState;
+    listeners.forEach(listener => listener(currentState));
+  },
+};
+
+jest.mock('@react-native-community/netinfo', () => MockNetInfo);


### PR DESCRIPTION
With this change the ObservationUploader will put itself to sleep when the device is offline, and wake up when it's back online. Added a couple of tests as well.

Also updated the Jest config to make `silent` the default so that you don't see log lines (you can override by running `yarn jest --silent=false`).