### PR TITLE
Observations list view improvements

### DIFF
--- a/components/content/QueryState.tsx
+++ b/components/content/QueryState.tsx
@@ -129,8 +129,5 @@ export const Unavailable: React.FunctionComponent = () => {
 
 // incompleteQueryState checks to see if any of the queries are not yet complete - if so, render a <QueryState/>.
 export const incompleteQueryState = (...results: UseQueryResult[]): boolean => {
-  return results
-    .map(result => [result.isError, result.isLoading, isResultNotFound(result)])
-    .flat()
-    .reduce((accumulator, value) => accumulator || value);
+  return results.some(result => result.isError || result.isLoading);
 };

--- a/components/forecast/ObservationsTab.tsx
+++ b/components/forecast/ObservationsTab.tsx
@@ -14,7 +14,7 @@ export const ObservationsTab: React.FunctionComponent<ObservationsTabProps> = ({
   return (
     // the top padding helps push the filter bar down in this view - a better solution may exist
     <View flex={1} pt={16}>
-      <ObservationsListView center_id={center_id} requestedTime={requestedTime} initialFilterConfig={{zone: zone_name}} />
+      <ObservationsListView center_id={center_id} requestedTime={requestedTime} additionalFilters={{zone: zone_name}} />
     </View>
   );
 };

--- a/components/form/DateField.tsx
+++ b/components/form/DateField.tsx
@@ -11,9 +11,11 @@ import {utcDateToLocalDateString} from 'utils/date';
 interface DateFieldProps {
   name: string;
   label: string;
+  minimumDate: Date;
+  maximumDate: Date;
 }
 
-export const DateField: React.FC<DateFieldProps> = ({name, label}) => {
+export const DateField: React.FC<DateFieldProps> = ({name, label, minimumDate, maximumDate}) => {
   const {field} = useController({name: name});
   const [datePickerVisible, setDatePickerVisible] = useState(false);
 
@@ -35,10 +37,10 @@ export const DateField: React.FC<DateFieldProps> = ({name, label}) => {
       if (datePickerVisible) {
         void DateTimePickerAndroid.dismiss('date');
       } else {
-        void DateTimePickerAndroid.open({mode: 'date', display: 'default', onChange: onDateSelected, value: value ?? new Date()});
+        void DateTimePickerAndroid.open({mode: 'date', display: 'default', onChange: onDateSelected, value: value ?? new Date(), minimumDate, maximumDate});
       }
     }
-  }, [datePickerVisible, setDatePickerVisible, onDateSelected, value]);
+  }, [datePickerVisible, setDatePickerVisible, onDateSelected, value, minimumDate, maximumDate]);
 
   // TODO: maximum/minimum date
   return (
@@ -55,7 +57,17 @@ export const DateField: React.FC<DateFieldProps> = ({name, label}) => {
         </HStack>
       </TouchableOpacity>
 
-      {datePickerVisible && Platform.OS === 'ios' && <DateTimePicker value={value || new Date()} mode="date" display="inline" themeVariant="light" onChange={onDateSelected} />}
+      {datePickerVisible && Platform.OS === 'ios' && (
+        <DateTimePicker
+          value={value || new Date()}
+          mode="date"
+          display="inline"
+          themeVariant="light"
+          onChange={onDateSelected}
+          minimumDate={minimumDate}
+          maximumDate={maximumDate}
+        />
+      )}
     </VStack>
   );
 };

--- a/components/form/SelectField.tsx
+++ b/components/form/SelectField.tsx
@@ -107,6 +107,10 @@ export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, la
           setValue(name, newValue, {shouldValidate: false, shouldDirty: false, shouldTouch: false});
         }}
         styles={selectStyles}
+        // Setting `scrollToSelectedOption` based on https://github.com/MobileReality/react-native-select-pro/issues/230
+        // Seems to fix problem with items not showing up in list
+        scrollToSelectedOption={false}
+        theme="none"
         flatListProps={{
           // only works on Android, unfortunately
           persistentScrollbar: true,

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -58,8 +58,7 @@ const DATE_LABELS: Record<DateValue, string> = {
 
 const currentSeasonDates = (requestedTime: RequestedTime): {from: Date; to: Date} => {
   const endDate = requestedTimeToUTCDate(requestedTime);
-  // Months are zero-based, so September is 8
-  const startDate = new Date(endDate.getUTCMonth() >= 8 ? endDate.getUTCFullYear() : endDate.getUTCFullYear() - 1, 8, 1);
+  const startDate = startOfSeasonLocalDate(requestedTime);
   return {from: startDate, to: endDate};
 };
 

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -186,7 +186,7 @@ export const filtersForConfig = (mapLayer: MapLayer, config: ObservationFilterCo
 
 interface ObservationsFilterFormProps {
   requestedTime: RequestedTime;
-  mapLayer?: MapLayer;
+  mapLayer: MapLayer;
   initialFilterConfig: ObservationFilterConfig;
   currentFilterConfig: ObservationFilterConfig;
   setFilterConfig: React.Dispatch<React.SetStateAction<ObservationFilterConfig>>;

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -15,57 +15,72 @@ import {SelectField} from 'components/form/SelectField';
 import {SwitchField} from 'components/form/SwitchField';
 import {BodyBlack, BodySemibold, Title3Semibold} from 'components/text';
 import {geoContains} from 'd3-geo';
-import {getMonth, getYear, isAfter, isBefore, parseISO, sub} from 'date-fns';
+import {isAfter, isBefore, parseISO} from 'date-fns';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {FieldErrors, FormProvider, useForm} from 'react-hook-form';
 import {KeyboardAvoidingView, Platform, View as RNView, SafeAreaView, ScrollView, TouchableOpacity, findNodeHandle} from 'react-native';
 import {colorLookup} from 'theme';
 import {MapLayer, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
+import {RequestedTime, requestedTimeToUTCDate} from 'utils/date';
 import {z} from 'zod';
 
 const avalancheInstabilitySchema = z.enum(['observed', 'triggered', 'caught']);
 type avalancheInstability = z.infer<typeof avalancheInstabilitySchema>;
 
-const dateValueSchema = z.enum(['past_day', 'past_3_days', 'past_week', 'past_month', 'past_season', 'custom']);
+const dateValueSchema = z.enum(['past_season', 'custom']);
 type DateValue = z.infer<typeof dateValueSchema>;
 
-const observationFilterConfigSchema = z
-  .object({
-    zone: z.string(),
-    dates: z.object({
-      value: dateValueSchema,
-      from: z.date(),
-      to: z.date(),
-    }),
-    observerType: z.nativeEnum(PartnerType),
-    instability: z.object({
-      avalanches: avalancheInstabilitySchema,
-      cracking: z.boolean(),
-      collapsing: z.boolean(),
-    }),
-  })
-  .deepPartial();
+const observationFilterConfigSchema = z.object({
+  zone: z.string().optional(),
+  dates: z.object({
+    value: dateValueSchema,
+    from: z.date(),
+    to: z.date(),
+  }),
+  observerType: z.nativeEnum(PartnerType).optional(),
+  instability: z
+    .object({
+      avalanches: avalancheInstabilitySchema.optional(),
+      cracking: z.boolean().optional(),
+      collapsing: z.boolean().optional(),
+    })
+    .optional(),
+});
 
 export type ObservationFilterConfig = z.infer<typeof observationFilterConfigSchema>;
 
 type FilterFunction = (observation: ObservationFragment) => boolean;
 
 const DATE_LABELS: Record<DateValue, string> = {
-  past_day: 'Last 24 hours',
-  past_3_days: 'Last 72 hours',
-  past_week: 'Last 7 days',
-  past_month: 'Last month',
-  past_season: 'Last forecast season',
+  past_season: 'Last season',
   custom: 'Custom range',
 };
 
+export const createDefaultFilterConfig = (requestedTime: RequestedTime, defaults: Partial<ObservationFilterConfig> | undefined): ObservationFilterConfig => {
+  const endDate: Date = requestedTimeToUTCDate(requestedTime);
+  // Months are zero-base, so September is 8
+  const startDate = new Date(endDate.getUTCMonth() >= 8 ? endDate.getUTCFullYear() : endDate.getUTCFullYear() - 1, 8, 1);
+  console.log('createDefaultFilterConfig', {
+    dates: {
+      value: 'past_season',
+      from: startDate,
+      to: endDate,
+    },
+    ...defaults,
+  });
+  return {
+    dates: {
+      value: 'past_season',
+      from: startDate,
+      to: endDate,
+    },
+    ...defaults,
+  };
+};
+
 export const dateLabelForFilterConfig = (dates: z.infer<typeof observationFilterConfigSchema.shape.dates>): string => {
-  const value = dates?.value || 'past_week';
+  const value = dates?.value || 'past_season';
   switch (value) {
-    case 'past_day':
-    case 'past_3_days':
-    case 'past_week':
-    case 'past_month':
     case 'past_season':
       return DATE_LABELS[value];
     case 'custom':
@@ -76,37 +91,11 @@ export const dateLabelForFilterConfig = (dates: z.infer<typeof observationFilter
   }
 };
 
-export const datesForFilterConfig = (dates: z.infer<typeof observationFilterConfigSchema.shape.dates>, currentDate: Date): {startDate: Date; endDate: Date} => {
-  const value = dates?.value || 'past_week';
-  switch (value) {
-    case 'past_day':
-      return {startDate: sub(currentDate, {days: 1}), endDate: currentDate};
-    case 'past_3_days':
-      return {startDate: sub(currentDate, {days: 3}), endDate: currentDate};
-    case 'past_week':
-      return {startDate: sub(currentDate, {weeks: 1}), endDate: currentDate};
-    case 'past_month':
-      return {startDate: sub(currentDate, {months: 1}), endDate: currentDate};
-    case 'past_season':
-      return {
-        endDate: currentDate,
-        // the season starts Nov 1st, that's either this year or last year depending on when we are asking
-        startDate: getMonth(currentDate) <= 11 ? new Date(`${getYear(sub(currentDate, {years: 1}))}-11-01`) : new Date(`${getYear(currentDate)}-11-01`),
-      };
-    case 'custom':
-      // TODO we should validate that these values don't span more than a month, for the same reason as above
-      if (!dates?.from || !dates?.to) {
-        throw new Error('custom date range requires from and to dates');
-      }
-      return {startDate: dates.from, endDate: dates.to};
-  }
-};
-
 const matchesDates = (currentDate: Date, dates: z.infer<typeof observationFilterConfigSchema.shape.dates>): FilterFunction => {
   if (!dates) {
     return () => true;
   }
-  const {startDate, endDate} = datesForFilterConfig(dates, currentDate);
+  const {from: startDate, to: endDate} = dates;
   return (observation: ObservationFragment) => isAfter(parseISO(observation.createdAt), startDate) && isBefore(parseISO(observation.createdAt), endDate);
 };
 
@@ -153,7 +142,7 @@ interface FilterListItem {
 export const filtersForConfig = (
   mapLayer: MapLayer,
   config: ObservationFilterConfig,
-  initialFilterConfig: ObservationFilterConfig | undefined,
+  additionalFilters: Partial<ObservationFilterConfig> | undefined,
   currentDate: Date,
 ): FilterListItem[] => {
   if (!config) {
@@ -161,9 +150,7 @@ export const filtersForConfig = (
   }
 
   const filterFuncs: FilterListItem[] = [];
-  if (config.dates && config.dates.value) {
-    filterFuncs.push({filter: matchesDates(currentDate, config.dates), label: dateLabelForFilterConfig(config.dates)});
-  }
+  filterFuncs.push({filter: matchesDates(currentDate, config.dates), label: dateLabelForFilterConfig(config.dates)});
 
   if (config.zone) {
     filterFuncs.push({
@@ -171,7 +158,7 @@ export const filtersForConfig = (
       label: config.zone,
       // If the zone was specified as part of the initialFilterConfig (i.e. we're browsing the Obs tab of a particular zone),
       // then removeFilter should be undefined since re-setting the filters should keep that zone filter around
-      removeFilter: initialFilterConfig?.zone ? undefined : config => ({...config, zone: undefined}),
+      removeFilter: additionalFilters?.zone ? undefined : config => ({...config, zone: undefined}),
     });
   }
 
@@ -292,12 +279,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                   }>
                   <VStack space={formFieldSpacing} mt={8}>
                     <SelectField name="zone" label="Zone" radio items={mapLayer.features.map(feature => feature.properties.name)} disabled={Boolean(initialFilterConfig.zone)} />
-                    <SelectField
-                      name="dates.value"
-                      label="Dates"
-                      radio
-                      items={(['past_day', 'past_3_days', 'past_week', 'past_month', 'custom'] as const).map(val => ({value: val, label: DATE_LABELS[val]}))}
-                    />
+                    <SelectField name="dates.value" label="Dates" radio items={(['past_season', 'custom'] as const).map(val => ({value: val, label: DATE_LABELS[val]}))} />
                     <Conditional name="dates.value" value={'custom'}>
                       <DateField name="dates.from" label="Published After" />
                       <DateField name="dates.to" label="Published Before" />

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -152,7 +152,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
     [],
   );
 
-  if (incompleteQueryState(observationsResult)) {
+  if (incompleteQueryState(observationsResult, mapResult) || !mapLayer) {
     return (
       <Center width="100%" height="100%">
         <QueryState results={[observationsResult]} />

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -164,6 +164,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
     <VStack width="100%" height="100%" space={0}>
       <Modal visible={filterModalVisible}>
         <ObservationsFilterForm
+          requestedTime={requestedTime}
           mapLayer={mapLayer}
           initialFilterConfig={originalFilterConfig}
           currentFilterConfig={filterConfig}

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -29,6 +29,7 @@ import Toast from 'react-native-toast-message';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, ImageMediaItem, InstabilityDistribution, MediaType} from 'types/nationalAvalancheCenter';
+import {startOfSeasonLocalDate} from 'utils/date';
 
 export const SimpleForm: React.FC<{
   center_id: AvalancheCenterID;
@@ -62,6 +63,7 @@ export const SimpleForm: React.FC<{
   const scrollViewRef = useRef<ScrollView>(null);
 
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
+  const today = new Date();
 
   const mutation = useMutation<void, AxiosError, ObservationFormData>({
     mutationFn: async (observationFormData: ObservationFormData) => {
@@ -223,7 +225,7 @@ export const SimpleForm: React.FC<{
                           autoCorrect: false,
                         }}
                       />
-                      <DateField name="start_date" label="Observation date" />
+                      <DateField name="start_date" label="Observation date" minimumDate={startOfSeasonLocalDate(today)} maximumDate={today} />
                       <SelectField
                         name="activity"
                         label="Activity"

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -17,12 +17,12 @@ import {ZodError} from 'zod';
 
 const PAGE_SIZE: Duration = {weeks: 2};
 
-export const useNACObservations = (center_id: AvalancheCenterID, endDate: RequestedTime) => {
+export const useNACObservations = (center_id: AvalancheCenterID, endDate: RequestedTime, options: {enabled: boolean}) => {
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id, endDate);
   const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  thisLogger.debug({endDate, enabled: options.enabled}, 'initiating query');
 
   // For NAC, we fetch in 2 week pages, until we get results that are older than the requested end date minus the lookback window
   const lookbackWindowStart: Date = add(requestedTimeToUTCDate(endDate), MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW);
@@ -50,6 +50,7 @@ export const useNACObservations = (center_id: AvalancheCenterID, endDate: Reques
     },
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
+    enabled: options.enabled,
   });
 };
 

--- a/hooks/useObservations.ts
+++ b/hooks/useObservations.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {useQuery, UseQueryOptions} from '@tanstack/react-query';
-import {useFetch} from 'hooks/observations-fetcher';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]};
@@ -392,8 +390,7 @@ export const ObservationDocument = `
   }
 }
     ${EverythingFragmentDoc}`;
-export const useObservationQuery = <TData = ObservationQuery, TError = unknown>(variables: ObservationQueryVariables, options?: UseQueryOptions<ObservationQuery, TError, TData>) =>
-  useQuery<ObservationQuery, TError, TData>(['observation', variables], useFetch<ObservationQuery, ObservationQueryVariables>(ObservationDocument).bind(null, variables), options);
+
 export const ObservationsDocument = `
     query observations($center: String!, $startDate: String!, $endDate: String!) {
   getObservationList(centerId: $center, startDate: $startDate, endDate: $endDate) {
@@ -401,15 +398,20 @@ export const ObservationsDocument = `
   }
 }
     ${OverviewFragmentDoc}`;
-export const useObservationsQuery = <TData = ObservationsQuery, TError = unknown>(
-  variables: ObservationsQueryVariables,
-  options?: UseQueryOptions<ObservationsQuery, TError, TData>,
-) =>
-  useQuery<ObservationsQuery, TError, TData>(
-    ['observations', variables],
-    useFetch<ObservationsQuery, ObservationsQueryVariables>(ObservationsDocument).bind(null, variables),
-    options,
-  );
 
-// No matter what span of time we're looking at, we will never query over more than 3 months of observations
-export const MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW: Duration = {months: -3};
+// These are unused - can they be deleted?
+// export const useObservationQuery = <TData = ObservationQuery, TError = unknown>(variables: ObservationQueryVariables, options?: UseQueryOptions<ObservationQuery, TError, TData>) =>
+//   useQuery<ObservationQuery, TError, TData>(['observation', variables], useFetch<ObservationQuery, ObservationQueryVariables>(ObservationDocument).bind(null, variables), options);
+//
+// export const useObservationsQuery = <TData = ObservationsQuery, TError = unknown>(
+//   variables: ObservationsQueryVariables,
+//   options?: UseQueryOptions<ObservationsQuery, TError, TData>,
+// ) =>
+//   useQuery<ObservationsQuery, TError, TData>(
+//     ['observations', variables],
+//     useFetch<ObservationsQuery, ObservationsQueryVariables>(ObservationsDocument).bind(null, variables),
+//     options,
+//   );
+
+// No matter what span of time we're looking at, we will never query over more than 12 months of observations
+export const MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW: Duration = {months: -12};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@formatjs/intl-locale": "^3.3.4",
     "@formatjs/intl-pluralrules": "^5.2.6",
     "@hookform/resolvers": "^2.9.11",
-    "@mobile-reality/react-native-select-pro": "^2.1.0",
+    "@mobile-reality/react-native-select-pro": "^2.2.2",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-camera-roll/camera-roll": "^5.2.0",
     "@react-native-community/datetimepicker": "7.2.0",

--- a/utils/date.test.ts
+++ b/utils/date.test.ts
@@ -1,5 +1,6 @@
+import {toDate} from 'date-fns-tz';
 import * as TimezoneMock from 'timezone-mock';
-import {apiDateString, nominalForecastDateString, nominalNWACWeatherForecastDate, utcDateToLocalDateString, utcDateToLocalTimeString} from 'utils/date';
+import {apiDateString, nominalForecastDateString, nominalNWACWeatherForecastDate, startOfSeasonLocalDate, utcDateToLocalDateString, utcDateToLocalTimeString} from 'utils/date';
 
 describe('Dates', () => {
   describe('apiDateString', () => {
@@ -103,6 +104,24 @@ describe('Dates', () => {
     });
     it('returns the current day afternoon when requesting after the expiry time using UTC', () => {
       expect(nominalNWACWeatherForecastDate(new Date('2023-01-25T03:44:27-00:00'))).toBe('2023-01-24 afternoon');
+    });
+  });
+
+  describe('startOfSeasonLocalDate', () => {
+    const localDate = (dateString: string): Date => {
+      return toDate(dateString, {timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone});
+    };
+    it('returns September 1 of the current year when date is after september 1', () => {
+      expect(startOfSeasonLocalDate(localDate('2023-10-01'))).toEqual(localDate('2023-09-01'));
+    });
+    it('returns September 1 of the previous year when date is before august 31', () => {
+      expect(startOfSeasonLocalDate(localDate('2023-01-01'))).toEqual(localDate('2022-09-01'));
+    });
+    it('returns September 1 of the previous year when date is august 31', () => {
+      expect(startOfSeasonLocalDate(localDate('2023-08-31'))).toEqual(localDate('2022-09-01'));
+    });
+    it('returns September 1 of the current year when date is september 31', () => {
+      expect(startOfSeasonLocalDate(localDate('2023-09-01'))).toEqual(localDate('2023-09-01'));
     });
   });
 });

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -110,3 +110,19 @@ export const parseRequestedTimeString = (requestedTime: RequestedTimeString): Re
 
   return 'latest';
 };
+
+export const startOfSeasonLocalDate = (requestedTime: RequestedTime): Date => {
+  // NWAC defines the season as 9/1 -> 8/31 of the next year. We'll apply this globally for now,
+  // maybe change based on center in the future.
+
+  // Given the requestedTime value, let's jump through some hoops to get the date at midnight local time
+  // Midnight on September 1 in UTC is 6pm on August 31 in Seattle, and we don't want to get 8/31 back from this method - we want to get 9/1.
+  const utcDate: Date = requestedTimeToUTCDate(requestedTime);
+  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const localDateString = formatInTimeZone(utcDate, localTimeZone, 'yyyy-MM-dd');
+  // can't do new Date(localDateString) or that'll interpret the date as UTC
+  const date = toDate(localDateString, {timeZone: localTimeZone});
+
+  // Months are zero-based, so September is 8
+  return new Date(date.getMonth() >= 8 ? date.getFullYear() : date.getFullYear() - 1, 8, 1, 0, 0, 0, 0);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,10 +3665,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz#9ceecc94b49fbaa15666e38ae8587f64acce007d"
   integrity sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==
 
-"@mobile-reality/react-native-select-pro@^2.1.0":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@mobile-reality/react-native-select-pro/-/react-native-select-pro-2.1.5.tgz#f2ba5eec5758b9c858086c4031b6db25f44b0262"
-  integrity sha512-2TmXLy6Fom/egfIQdIxMRyJCGkk+9E8YLRazVIrer8UvX/g198LE/3zT0gUca9rn9LAY/uv69eLLb/s+ZFzVaw==
+"@mobile-reality/react-native-select-pro@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@mobile-reality/react-native-select-pro/-/react-native-select-pro-2.2.2.tgz#96f5dd5746bff2a74eb665f35704709b4c601c3d"
+  integrity sha512-A7s+D2IqGnw1mN5VZUAvn5JAe2Em3TgJaq4PRUT4QmqG1BrtIeh5NXoOM93qtOJBwKbUNn6jAVLM4uiuQfdEMg==
   dependencies:
     "@gorhom/portal" "1.0.14"
     react-fast-compare "3.2.1"


### PR DESCRIPTION
Quite a few changes to improve the list view experience

- implement the new spec for date filtering - you can view the current season, or a date range within it, but you can't view arbitrary dates
- that said, date filtering respects the time machine, so you can warp to last season for debugging purposes
- fix a bug with dropdown items not being visible in the filter form
- clean up rendering of loading states; should get rid of duplicate loading spinners
- the list view only has one observation query active - either NWAC or NAC, but we don't need to interleave both
- you can now scroll all the way to the beginning of the season

I'll add some comments inline

Fixes: #403, #335, #439