### PR TITLE
Opt-in unescaping of HTML entities in Text components

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -221,7 +221,7 @@ export const ObservationCard: React.FunctionComponent<{
                   </VStack>
                   <VStack space={8} style={{flex: 1}}>
                     <AllCapsSmBlack>Author</AllCapsSmBlack>
-                    <AllCapsSm style={{textTransform: 'none'}} color="text.secondary">
+                    <AllCapsSm style={{textTransform: 'none'}} color="text.secondary" unescapeHTMLEntities>
                       {observation.name || 'Unknown'}
                     </AllCapsSm>
                   </VStack>

--- a/components/text/Text.test.tsx
+++ b/components/text/Text.test.tsx
@@ -1,0 +1,25 @@
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+
+import {Body} from 'components/text';
+
+describe('Text', () => {
+  describe('HTML entitiy escaping', () => {
+    const input = 'Brooke Maushund &amp; Matt Primomo';
+    const output = 'Brooke Maushund & Matt Primomo';
+
+    it('does not strip HTML entities by default', () => {
+      render(<Body>{input}</Body>);
+      expect(screen.getByText(input)).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      expect(() => screen.getByText(output)).toThrow();
+    });
+
+    it('strips HTML entities when option is set', () => {
+      render(<Body unescapeHTMLEntities>{input}</Body>);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      expect(() => screen.getByText(input)).toThrow();
+      expect(screen.getByText(output)).not.toBeNull();
+    });
+  });
+});

--- a/components/text/index.tsx
+++ b/components/text/index.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 
 import {Text, TextProps, TextStyle} from 'react-native';
 
+import {decode} from 'html-entities';
+
 import {colorLookup} from 'theme';
 
 export interface TextWrapperProps extends TextProps {
@@ -14,9 +16,22 @@ export interface TextWrapperProps extends TextProps {
   lineHeight?: TextStyle['lineHeight'];
   textAlign?: TextStyle['textAlign'];
   textTransform?: TextStyle['textTransform'];
+  unescapeHTMLEntities?: boolean;
 }
 
-const TextWrapper: React.FC<TextWrapperProps> = ({color, fontFamily, fontSize, fontStyle, letterSpacing, lineHeight, textAlign, textTransform, children, ...props}) => {
+const TextWrapper: React.FC<TextWrapperProps> = ({
+  color,
+  fontFamily,
+  fontSize,
+  fontStyle,
+  letterSpacing,
+  lineHeight,
+  textAlign,
+  textTransform,
+  children,
+  unescapeHTMLEntities = false,
+  ...props
+}) => {
   const style = omitBy(
     {
       color: color ? colorLookup(color) : color,
@@ -32,7 +47,17 @@ const TextWrapper: React.FC<TextWrapperProps> = ({color, fontFamily, fontSize, f
   if (style.fontFamily && fontStyle === 'italic') {
     style.fontFamily = String(style.fontFamily) + '_Italic';
   }
-  return <Text {...merge({}, props, {style})}>{children}</Text>;
+  return (
+    <Text {...merge({}, props, {style})}>
+      {React.Children.map(children, child => {
+        if (unescapeHTMLEntities && typeof child === 'string') {
+          return decode(child);
+        } else {
+          return child;
+        }
+      })}
+    </Text>
+  );
 };
 
 // TODO figure out letter spacing values - what *are* the react native units?

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "expo-web-browser": "~12.3.2",
     "get-graphql-schema": "^2.1.2",
     "global": "^4.4.0",
+    "html-entities": "^2.4.0",
     "jest": "^29.2.1",
     "jest-expo": "^49.0.0",
     "jest-transform-stub": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10060,6 +10060,11 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
+html-entities@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.4.0.tgz#edd0cee70402584c8c76cc2c0556db09d1f45061"
+  integrity sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
Fixes #250 

This is a conservative approach to the problem - only escaping entities when explicitly asked to. It might be ok to escape everywhere, but I'd want to spend some time looking at the app deeply before pushing a change like that out.

before | after
--- | ---
<img width="480" src="https://user-images.githubusercontent.com/101196/225038873-6cda82fb-2b19-467c-a563-c3b690f28515.jpeg"> | <img width="480" src="https://github.com/NWACus/avy/assets/101196/008806cd-f5d8-4ed9-b957-c15ea914b86a">
