### PR TITLE
Fix problem with runaway observation preloads

### DIFF
--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -83,6 +83,10 @@ export const prefetchNACObservations = async (queryClient: QueryClient, national
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    // Prefetching is looping forever without these params being set. Not sure why!
+    // Theory: this GQL path uses POST instead of GET, and the POST is not being cached by default...?
+    staleTime: 60 * 60 * 1000, // any fetched data we have is valid for an hour
+    cacheTime: 60 * 60 * 1000, // drop it from memory after an hour
   });
 };
 


### PR DESCRIPTION
This is straight up voodoo. The diff has my best guess about the root cause, but I googled around for `prefetchInfiniteQuery POST` and various other queries without finding anything referring to this.

Fixes #449 