### PR TITLE
Observation upload UX improvements

### DIFF
--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -12,8 +12,8 @@ const FAKE_OBSERVATION_DATA: Partial<ObservationFormData> = {
   },
   email: 'brian@nwac.us',
   name: 'Brian',
-  observation_summary: 'This is a test observation.',
-  location_name: 'at my kitchen table',
+  observation_summary: '[TEST] This is a test observation.',
+  location_name: '[TEST] Snoqualmie Pass',
 };
 
 export const defaultObservationFormData = (initialValues: Partial<ObservationFormData> | null = null): Partial<ObservationFormData> =>

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -176,8 +176,8 @@ describe('ObservationUploader', () => {
 
     await expect(async () => await uploader.submitObservation(fakeObservation)).rejects.toThrow(/ObservationUploader not initialized/);
     await expect(async () => await uploader.resetTaskQueue()).rejects.toThrow(/ObservationUploader not initialized/);
-    expect(() => uploader.subscribeToTaskInvocations(() => undefined)).toThrow(/ObservationUploader not initialized/);
-    expect(() => uploader.unsubscribeFromTaskInvocations(() => undefined)).toThrow(/ObservationUploader not initialized/);
+    expect(() => uploader.subscribeToStateUpdates(() => undefined)).toThrow(/ObservationUploader not initialized/);
+    expect(() => uploader.unsubscribeFromStateUpdates(() => undefined)).toThrow(/ObservationUploader not initialized/);
   });
 
   it('should start in an idle state', async () => {

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -19,7 +19,7 @@ import {uploadImage} from 'components/observations/uploader/uploadImage';
 import {uploadObservation} from 'components/observations/uploader/uploadObservation';
 import {logger} from 'logger';
 import {filterLoggedData} from 'logging/filterLoggedData';
-import {AvalancheCenterID, MediaUsage, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
+import {AvalancheCenterID, MediaType, MediaUsage, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
 
 type Subscriber = (entry: TaskQueueEntry, success: boolean, attempts: number) => void;
 export interface ObservationFragmentWithStatus {
@@ -330,7 +330,19 @@ export class ObservationUploader {
       locationName: observation.location_name,
       instability: observation.instability,
       observationSummary: observation.observation_summary,
-      media: [], // coming soon
+      media: this.taskQueue
+        .filter(t => t.parentId === observationTask.id)
+        .filter(isImageTask)
+        .map(t => ({
+          type: MediaType.Image,
+          caption: null,
+          url: {
+            original: t.data.image.uri,
+            large: t.data.image.uri,
+            medium: t.data.image.uri,
+            thumbnail: t.data.image.uri,
+          },
+        })),
     };
   }
 

--- a/components/observations/uploader/usePendingObservations.ts
+++ b/components/observations/uploader/usePendingObservations.ts
@@ -1,17 +1,37 @@
-import {ObservationFragmentWithStatus, getUploader} from 'components/observations/uploader/ObservationsUploader';
+import {useQueryClient} from '@tanstack/react-query';
+import {ObservationFragmentWithStatus, UploaderState, getUploader} from 'components/observations/uploader/ObservationsUploader';
 import {useCallback, useEffect, useState} from 'react';
 
 export function usePendingObservations(): ObservationFragmentWithStatus[] {
-  const [observations, setObservations] = useState<ObservationFragmentWithStatus[]>(getUploader().getPendingObservations());
-  const refreshStatus = useCallback(() => {
-    setObservations(getUploader().getPendingObservations());
-  }, [setObservations]);
+  const queryClient = useQueryClient();
+  const [pendingObservations, setPendingObservations] = useState<ObservationFragmentWithStatus[]>(getUploader().getPendingObservations());
+  const refreshStatus = useCallback(
+    (_state: UploaderState) => {
+      const nextPendingObservations = getUploader().getPendingObservations();
+      if (nextPendingObservations.length < pendingObservations.length) {
+        // Invalidate the query cache for the obs list query. It's a blunt instrument,
+        // but it will force useNACObservations to return the newly uploaded data.
+        void queryClient.refetchQueries({
+          type: 'all',
+          exact: false,
+          queryKey: ['nac-observations'],
+          refetchPage: (_page, index, _allPages) => {
+            return index === 0;
+          },
+          // refetchPage: (_page, index, _allPages) => {
+          //   return index === 0;
+          // },
+        });
+      }
+      setPendingObservations(nextPendingObservations);
+    },
+    [pendingObservations, queryClient, setPendingObservations],
+  );
 
   useEffect(() => {
-    const listener = () => refreshStatus();
-    getUploader().subscribeToTaskInvocations(listener);
-    return () => getUploader().unsubscribeFromTaskInvocations(listener);
+    getUploader().subscribeToStateUpdates(refreshStatus);
+    return () => getUploader().unsubscribeFromStateUpdates(refreshStatus);
   }, [refreshStatus]);
 
-  return observations;
+  return pendingObservations;
 }

--- a/components/observations/uploader/usePendingObservations.ts
+++ b/components/observations/uploader/usePendingObservations.ts
@@ -9,18 +9,15 @@ export function usePendingObservations(): ObservationFragmentWithStatus[] {
     (_state: UploaderState) => {
       const nextPendingObservations = getUploader().getPendingObservations();
       if (nextPendingObservations.length < pendingObservations.length) {
-        // Invalidate the query cache for the obs list query. It's a blunt instrument,
-        // but it will force useNACObservations to return the newly uploaded data.
-        void queryClient.refetchQueries({
-          type: 'all',
+        // Invalidate the query cache for the obs list query - if the list view is open,
+        // it will fetch the observation into the list and enable the user to click into it.
+        void queryClient.invalidateQueries({
           exact: false,
           queryKey: ['nac-observations'],
-          refetchPage: (_page, index, _allPages) => {
+          refetchPage: (_page, index) => {
+            // We only need to refetch page 0, that's where the newest data is
             return index === 0;
           },
-          // refetchPage: (_page, index, _allPages) => {
-          //   return index === 0;
-          // },
         });
       }
       setPendingObservations(nextPendingObservations);

--- a/components/observations/uploader/usePendingObservations.ts
+++ b/components/observations/uploader/usePendingObservations.ts
@@ -1,0 +1,17 @@
+import {ObservationFragmentWithStatus, getUploader} from 'components/observations/uploader/ObservationsUploader';
+import {useCallback, useEffect, useState} from 'react';
+
+export function usePendingObservations(): ObservationFragmentWithStatus[] {
+  const [observations, setObservations] = useState<ObservationFragmentWithStatus[]>(getUploader().getPendingObservations());
+  const refreshStatus = useCallback(() => {
+    setObservations(getUploader().getPendingObservations());
+  }, [setObservations]);
+
+  useEffect(() => {
+    const listener = () => refreshStatus();
+    getUploader().subscribeToTaskInvocations(listener);
+    return () => getUploader().unsubscribeFromTaskInvocations(listener);
+  }, [refreshStatus]);
+
+  return observations;
+}

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -147,6 +147,10 @@ export const fetchNACObservations = async (
       logger.warn({error: parseResult.data.errors}, `error response on fetch`);
       throw new Error(`GraphQL error response: ${JSON.stringify(parseResult.data.errors)}`);
     }
+    logger.debug(
+      {observationCount: (parseResult.data.data?.getObservationList ?? []).length, startDate: formatRequestedTime(startDate), endDate: formatRequestedTime(endDate)},
+      `observation page fetch complete`,
+    );
     return {
       data: parseResult.data.data?.getObservationList ?? [],
       startDate: formatRequestedTime(startDate),

--- a/hooks/useObservations.ts
+++ b/hooks/useObservations.ts
@@ -398,20 +398,3 @@ export const ObservationsDocument = `
   }
 }
     ${OverviewFragmentDoc}`;
-
-// These are unused - can they be deleted?
-// export const useObservationQuery = <TData = ObservationQuery, TError = unknown>(variables: ObservationQueryVariables, options?: UseQueryOptions<ObservationQuery, TError, TData>) =>
-//   useQuery<ObservationQuery, TError, TData>(['observation', variables], useFetch<ObservationQuery, ObservationQueryVariables>(ObservationDocument).bind(null, variables), options);
-//
-// export const useObservationsQuery = <TData = ObservationsQuery, TError = unknown>(
-//   variables: ObservationsQueryVariables,
-//   options?: UseQueryOptions<ObservationsQuery, TError, TData>,
-// ) =>
-//   useQuery<ObservationsQuery, TError, TData>(
-//     ['observations', variables],
-//     useFetch<ObservationsQuery, ObservationsQueryVariables>(ObservationsDocument).bind(null, variables),
-//     options,
-//   );
-
-// No matter what span of time we're looking at, we will never query over more than 12 months of observations
-export const MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW: Duration = {months: -12};

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -126,3 +126,8 @@ export const startOfSeasonLocalDate = (requestedTime: RequestedTime): Date => {
   // Months are zero-based, so September is 8
   return new Date(date.getMonth() >= 8 ? date.getFullYear() : date.getFullYear() - 1, 8, 1, 0, 0, 0, 0);
 };
+
+export const endOfSeasonLocalDate = (requestedTime: RequestedTime): Date => {
+  const startOfSeason = startOfSeasonLocalDate(requestedTime);
+  return new Date(startOfSeason.getFullYear() + 1, 8, 1, 0, 0, 0);
+};


### PR DESCRIPTION
- show pending observations in the obs list. this UX is still TBD
- when submission is complete, list updates to show the new obs
- show toasts as designed on upload form

Fixes: #429 by not making the cancel button a cancel button anymore. We still need to decide what the UX for cancellation looks like - is it a cancel button on the pending obs in the obs list?

~Still TBD:~
- ~listview doesn't refresh correctly once obs is submitted, so new obs don't show up until restart (tracking in issue #462)~
this is now fixed - the issue is that the date filters were set up to end at the exact time that the list view was loaded, as opposed to midnight on the custom date range or at the end of the season in the default case.

https://github.com/NWACus/avy/assets/101196/05007ef0-c974-471e-95c5-9957e4f28b46

![simulator_screenshot_CDFCA733-A138-4FA0-82B8-0FBB8545637F](https://github.com/NWACus/avy/assets/101196/ead1e162-d6bd-4444-a5e2-38c33761b6a7)

