### PR TITLE
Fix query hook logging

### DIFF
--- a/hooks/useAvalancheCenterCapabilities.ts
+++ b/hooks/useAvalancheCenterCapabilities.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -17,8 +17,10 @@ export const useAvalancheCenterCapabilities = (): UseQueryResult<AllAvalancheCen
   const {nationalAvalancheCenterWordpressHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterWordpressHost);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<AllAvalancheCenterCapabilities, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -17,8 +17,10 @@ export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID): UseQue
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<AvalancheCenter, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, useQueryClient, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -29,8 +29,10 @@ export const useAvalancheForecast = (
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id, zone_id, requestedTime, expiryTimeZone ?? '', expiryTimeHours ?? 0);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<ForecastResult, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useAvalancheForecastById.ts
+++ b/hooks/useAvalancheForecastById.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -19,8 +19,10 @@ export const useAvalancheForecastById = (fragment: ForecastResult) => {
 
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, forecastId);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<ForecastResult, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, useQueryClient, UseQueryResult} from '@tanstack/react-query';
 import {add, areIntervalsOverlapping} from 'date-fns';
@@ -16,8 +16,10 @@ export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forec
   const {nationalAvalancheCenterHost} = useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = ['products', center_id, forecast_zone_id, apiDateString(date)];
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<ForecastSummaryFragment, Error>({
     queryKey: key,

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -18,8 +18,10 @@ export const useAvalancheForecastFragments = (center_id: AvalancheCenterID, date
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id, date);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<ProductFragmentArray, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useAvalancheWarning.ts
+++ b/hooks/useAvalancheWarning.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import axios, {AxiosError, AxiosResponse} from 'axios';
 
@@ -18,8 +18,10 @@ export const useAvalancheWarning = (center_id: AvalancheCenterID, zone_id: numbe
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id, zone_id, requested_time);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<WarningResultWithZone, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useCachedImageURI.ts
+++ b/hooks/useCachedImageURI.ts
@@ -4,7 +4,7 @@ import {formatDistanceToNowStrict} from 'date-fns';
 import * as FileSystem from 'expo-file-system';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import md5 from 'md5';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 const rootDirectory = `${FileSystem.cacheDirectory ?? '/'}image-cache/`;
 export const queryKeyPrefix = 'image';
@@ -27,8 +27,10 @@ export const initialize = (): Promise<boolean> => {
 export const useCachedImageURI = (uri: string) => {
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(uri);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   // NetworkImage (which uses this hook) is also used to display file:// URIs, for
   // images to upload for example. In that case, we should still run the query even when offline.

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -17,8 +17,10 @@ export const useMapLayer = (center_id: AvalancheCenterID | undefined): UseQueryR
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = center_id && queryKey(nationalAvalancheCenterHost, center_id);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<MapLayer, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useNACObservation.ts
+++ b/hooks/useNACObservation.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import * as Sentry from 'sentry-expo';
 
@@ -17,8 +17,10 @@ export const useNACObservation = (id: string): UseQueryResult<Observation, Axios
   const {nationalAvalancheCenterHost: host} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(host, id);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<Observation, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -23,8 +23,8 @@ export const useNACObservations = (center_id: AvalancheCenterID, endDate: Reques
   const key = queryKey(nationalAvalancheCenterHost, center_id, endDate);
   const [thisLogger] = useState(logger.child({query: key}));
   useEffect(() => {
-    thisLogger.debug({endDate, enabled}, 'initiating query');
-  }, [thisLogger, endDate, enabled]);
+    thisLogger.debug({endDate, enabled: options.enabled}, 'initiating query');
+  }, [thisLogger, endDate, options.enabled]);
 
   // For NAC, we fetch in 2 week pages, until we get results that are older than the requested end date minus the lookback window
   const lookbackWindowStart: Date = add(requestedTimeToUTCDate(endDate), MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW);

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import * as Sentry from 'sentry-expo';
 
@@ -21,8 +21,10 @@ export const useNACObservations = (center_id: AvalancheCenterID, endDate: Reques
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id, endDate);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug({endDate, enabled: options.enabled}, 'initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug({endDate, enabled}, 'initiating query');
+  }, [thisLogger, endDate, enabled]);
 
   // For NAC, we fetch in 2 week pages, until we get results that are older than the requested end date minus the lookback window
   const lookbackWindowStart: Date = add(requestedTimeToUTCDate(endDate), MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW);

--- a/hooks/useNWACObservation.ts
+++ b/hooks/useNWACObservation.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -17,8 +17,10 @@ export const useNWACObservation = (id: number): UseQueryResult<Observation, Axio
   const {nwacHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nwacHost, id);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<Observation, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useInfiniteQuery} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -22,8 +22,10 @@ export const useNWACObservations = (center_id: AvalancheCenterID, endDate: Reque
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   // We key on end date, but not window - window merely controls how far we'll fetch backwards
   const key = queryKey(nwacHost, center_id, endDate);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug({endDate, enabled: options.enabled}, 'initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug({endDate, enabled}, 'initiating query');
+  }, [thisLogger, endDate, enabled]);
 
   // For NWAC, we fetch in 2 week pages, until we get results that are older than the requested end date minus the lookback window
   const lookbackWindowStart: Date = add(requestedTimeToUTCDate(endDate), MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW);

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -24,8 +24,8 @@ export const useNWACObservations = (center_id: AvalancheCenterID, endDate: Reque
   const key = queryKey(nwacHost, center_id, endDate);
   const [thisLogger] = useState(logger.child({query: key}));
   useEffect(() => {
-    thisLogger.debug({endDate, enabled}, 'initiating query');
-  }, [thisLogger, endDate, enabled]);
+    thisLogger.debug({endDate, enabled: options.enabled}, 'initiating query');
+  }, [thisLogger, endDate, options.enabled]);
 
   // For NWAC, we fetch in 2 week pages, until we get results that are older than the requested end date minus the lookback window
   const lookbackWindowStart: Date = add(requestedTimeToUTCDate(endDate), MAXIMUM_OBSERVATIONS_LOOKBACK_WINDOW);

--- a/hooks/useNWACWeatherForecast.ts
+++ b/hooks/useNWACWeatherForecast.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -24,8 +24,10 @@ export const useNWACWeatherForecast = (
   const date = requestedTimeToUTCDate(requestedTime);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nwacHost, zone_id, date);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<NWACWeatherForecast | 'ignore', AxiosError | ZodError | NotFoundError>({
     queryKey: key,

--- a/hooks/useSynopsis.ts
+++ b/hooks/useSynopsis.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import axios, {AxiosError, AxiosResponse} from 'axios';
 
@@ -19,8 +19,10 @@ export const useSynopsis = (center_id: AvalancheCenterID, zone_id: number, reque
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, center_id, zone_id, requested_time);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<Synopsis, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useWeatherForecast.ts
+++ b/hooks/useWeatherForecast.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError, AxiosResponse} from 'axios';
@@ -18,8 +18,10 @@ export const useWeatherForecast = (forecastId?: number): UseQueryResult<Weather,
 
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(nationalAvalancheCenterHost, forecastId ?? 0);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<Weather, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useWeatherStationTimeseries.ts
+++ b/hooks/useWeatherStationTimeseries.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import * as Sentry from 'sentry-expo';
 
@@ -24,8 +24,10 @@ export const useWeatherStationTimeseries = (
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(host, stations, requestedTime, duration);
   const {startDate, endDate} = queryInterval(requestedTime, duration);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<WeatherStationTimeseries, AxiosError | ZodError>({
     queryKey: key,

--- a/hooks/useWeatherStationsMetadata.ts
+++ b/hooks/useWeatherStationsMetadata.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import * as Sentry from 'sentry-expo';
 
@@ -17,8 +17,10 @@ export const useWeatherStationsMetadata = (center: AvalancheCenterID, token: str
   const {snowboundHost: host} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const key = queryKey(host, center);
-  const thisLogger = logger.child({query: key});
-  thisLogger.debug('initiating query');
+  const [thisLogger] = useState(logger.child({query: key}));
+  useEffect(() => {
+    thisLogger.debug('initiating query');
+  }, [thisLogger]);
 
   return useQuery<WeatherStationCollection, AxiosError | ZodError>({
     queryKey: key,

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.1",
     "react-intl": "^6.4.7",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-collapsible": "^1.6.0",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-image-viewing": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13864,10 +13864,10 @@ react-native-web@~0.19.6:
     postcss-value-parser "^4.2.0"
     styleq "^0.1.3"
 
-react-native@0.72.5:
-  version "0.72.5"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.72.5.tgz#2c343fa6f3ead362cf07376634a33a4078864357"
-  integrity sha512-oIewslu5DBwOmo7x5rdzZlZXCqDIna0R4dUwVpfmVteORYLr4yaZo5wQnMeR+H7x54GaMhmgeqp0ZpULtulJFg==
+react-native@0.72.6:
+  version "0.72.6"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.72.6.tgz#9f8d090694907e2f83af22e115cc0e4a3d5fa626"
+  integrity sha512-RafPY2gM7mcrFySS8TL8x+TIO3q7oAlHpzEmC7Im6pmXni6n1AuufGaVh0Narbr1daxstw7yW7T9BKW5dpVc2A==
   dependencies:
     "@jest/create-cache-key-function" "^29.2.1"
     "@react-native-community/cli" "11.3.7"


### PR DESCRIPTION
all of the `useSomeQuery` methods had a stanza like this
```
  const thisLogger = logger.child({query: key});
  thisLogger.debug('initiating query');
```
which **creates a new `thisLogger` every time through the hook** and has the side benefit of logging every time through the hook. so noisy!

I changed all of them to
```
  const [thisLogger] = useState(logger.child({query: key}));
  useEffect(() => {
    thisLogger.debug('initiating query');
  }, [thisLogger]);
```
and they now render once per hook instance, as expected.