### PR TITLE
Expo updates, Sentry config, resolve some Sentry errors

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,7 @@ SENTRY_AUTH_TOKEN=
 #
 # This is embedded in the app via app.config.ts. Must be present at runtime to send Sentry events.
 #
-SENTRY_DSN=
+EXPO_PUBLIC_SENTRY_DSN=
 
 #
 # These are embedded in the app via app.config.ts. Must be present to use maps. Not required for Expo Go.

--- a/.github/actions/expo/update/action.yaml
+++ b/.github/actions/expo/update/action.yaml
@@ -32,7 +32,15 @@ runs:
       shell: bash
       # Setting NODE_OPTIONS to increase the memory limit for the build command
       run: |
-        output="$(NODE_OPTIONS=--max_old_space_size=4096 EXPO_PUBLIC_GIT_REVISION=$(git rev-parse --short HEAD) eas update --branch=${{ inputs.channel }} --message="${{ inputs.message }}" --non-interactive --json)"
+        output="$(\
+          NODE_OPTIONS=--max_old_space_size=4096 \
+          EXPO_PUBLIC_GIT_REVISION=$(git rev-parse --short HEAD) \
+          EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }} \
+          eas update \
+            --branch=${{ inputs.channel }} \
+            --message="${{ inputs.message }}" \
+            --non-interactive \
+            --json)"
         echo "ios_id=$( jq --raw-output '.[] | select(.platform == "ios" ) | .id ' <<<"${output}" )" >> "${GITHUB_OUTPUT}"
         echo "android_id=$( jq --raw-output '.[] | select(.platform == "android" ) | .id ' <<<"${output}" )" >> "${GITHUB_OUTPUT}"
 

--- a/.github/actions/expo/update/action.yaml
+++ b/.github/actions/expo/update/action.yaml
@@ -17,6 +17,10 @@ inputs:
     required: true
     type: string
     description: 'The Expo auth token'
+  sentry_dsn:
+    required: true
+    type: string
+    description: 'The Sentry DSN'
 
 runs:
   using: 'composite'
@@ -35,7 +39,7 @@ runs:
         output="$(\
           NODE_OPTIONS=--max_old_space_size=4096 \
           EXPO_PUBLIC_GIT_REVISION=$(git rev-parse --short HEAD) \
-          EXPO_PUBLIC_SENTRY_DSN=${{ secrets.EXPO_PUBLIC_SENTRY_DSN }} \
+          EXPO_PUBLIC_SENTRY_DSN=${{ inputs.sentry_dsn }} \
           eas update \
             --branch=${{ inputs.channel }} \
             --message="${{ inputs.message }}" \

--- a/.github/workflows/expo_preview.yaml
+++ b/.github/workflows/expo_preview.yaml
@@ -39,6 +39,7 @@ jobs:
           channel: 'xxx-pr-${{ github.event.issue.number }}'
           message: '${{ github.event.issue.title }}'
           expo_token: ${{ secrets.EXPO_TOKEN }}
+          sentry_dsn: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
 
       - name: Add workflow result as comment on PR
         uses: actions/github-script@v6

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -30,3 +30,4 @@ jobs:
           channel: ${{ github.ref_name }}
           message: '${{ github.sha || github.ref_name }}'
           expo_token: ${{ secrets.EXPO_TOKEN }}
+          sentry_dsn: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}

--- a/App.tsx
+++ b/App.tsx
@@ -309,24 +309,8 @@ const BaseApp: React.FunctionComponent<{
 
   const navigationRef = useNavigationContainerRef();
 
-  // Hide the splash screen after fonts load. We're careful not to call hideAsync more than once;
-  // this seems to be the cause of the "No native splash screen registered" errors.
+  // Hide the splash screen after fonts load and updates are applied.
   // TODO: for maximum seamlessness, hide it after the map view is ready
-  const [splashScreenState, setSplashScreenState] = React.useState<'visible' | 'hiding' | 'hidden'>('visible');
-  useEffect(() => {
-    void (async () => {
-      if (fontsLoaded && splashScreenState === 'visible') {
-        setSplashScreenState('hiding');
-        try {
-          await SplashScreen.hideAsync();
-        } catch (error) {
-          logger.error({error}, 'Error from SplashScreen.hideAsync');
-        }
-        setSplashScreenState('hidden');
-      }
-    })();
-  }, [fontsLoaded, logger, splashScreenState, setSplashScreenState]);
-
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('checking');
   useEffect(() => {
     updateCheck()
@@ -337,6 +321,21 @@ const BaseApp: React.FunctionComponent<{
         setUpdateStatus('ready');
       });
   }, [setUpdateStatus, logger]);
+
+  const [splashScreenState, setSplashScreenState] = React.useState<'visible' | 'hiding' | 'hidden'>('visible');
+  useEffect(() => {
+    void (async () => {
+      if (fontsLoaded && updateStatus === 'ready' && splashScreenState === 'visible') {
+        setSplashScreenState('hiding');
+        try {
+          await SplashScreen.hideAsync();
+        } catch (error) {
+          logger.error({error}, 'Error from SplashScreen.hideAsync');
+        }
+        setSplashScreenState('hidden');
+      }
+    })();
+  }, [fontsLoaded, logger, splashScreenState, setSplashScreenState, updateStatus]);
 
   if (!fontsLoaded || splashScreenState !== 'hidden' || updateStatus !== 'ready') {
     // The splash screen keeps rendering while fonts are loading or updates are in progress

--- a/App.tsx
+++ b/App.tsx
@@ -133,6 +133,10 @@ if (Sentry?.init) {
           const data = await FileSystem.readAsStringAsync(logFilePath);
           hint.attachments = [{filename: 'log.json', data, contentType: 'application/json'}];
         }
+        event.tags = {
+          ...(event.tags ?? {}),
+          git_revision: process.env.EXPO_PUBLIC_GIT_REVISION,
+        };
         return event;
       },
     });

--- a/App.tsx
+++ b/App.tsx
@@ -22,7 +22,6 @@ import {AppStateStatus, Platform, StatusBar, StyleSheet, UIManager, useColorSche
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 import * as BackgroundFetch from 'expo-background-fetch';
-import Constants from 'expo-constants';
 import * as TaskManager from 'expo-task-manager';
 import * as Sentry from 'sentry-expo';
 
@@ -119,9 +118,9 @@ axios.interceptors.response.use(response => {
 void SplashScreen.preventAutoHideAsync();
 
 if (Sentry?.init) {
-  const dsn = (Constants.expoConfig?.extra?.sentry_dsn as string) ?? 'LOADED_FROM_ENVIRONMENT';
+  const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
   // Only initialize Sentry if we can find the correct env setup
-  if (dsn === 'LOADED_FROM_ENVIRONMENT') {
+  if (!dsn) {
     logger.warn('Sentry integration not configured, check your environment');
   } else {
     Sentry.init({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ For development, you will need a number of environment variables set to secret v
 - `ANDROID_GOOGLE_MAPS_API_KEY`
 - `IOS_GOOGLE_MAPS_API_KEY`
 - `SENTRY_API_TOKEN`
-- `SENTRY_DSN`
+- `EXPO_PUBLIC_SENTRY_DSN`
 
 These secrets can be uploaded to the Expo servers if they ever become out-of-sync with:
 

--- a/Updates.ts
+++ b/Updates.ts
@@ -1,0 +1,31 @@
+import * as Updates from 'expo-updates';
+import {logger} from 'logger';
+import {Alert} from 'react-native';
+
+export type UpdateStatus = 'checking' | 'downloading' | 'ready';
+
+export const updateCheck = async (): Promise<UpdateStatus> => {
+  if (Updates.isEmergencyLaunch) {
+    logger.warn('Emergency launch detected - update checking disabled');
+    return 'ready';
+  }
+  const update = await Updates.checkForUpdateAsync();
+  if (update.isAvailable) {
+    await Updates.fetchUpdateAsync();
+    await new Promise<void>(resolve => {
+      Alert.alert('Update Available', 'Avy needs to restart to apply an update.', [
+        {
+          text: 'OK',
+          onPress: () => {
+            Updates.reloadAsync()
+              .then(() => resolve())
+              .catch(() => resolve());
+          },
+          style: 'default',
+        },
+      ]);
+      return 'downloading';
+    });
+  }
+  return 'ready';
+};

--- a/Updates.ts
+++ b/Updates.ts
@@ -8,6 +8,10 @@ export const updateCheck = async (): Promise<UpdateStatus> => {
     logger.warn('Emergency launch detected - update checking disabled');
     return 'ready';
   }
+  if (Updates.channel !== 'preview' && Updates.channel !== 'release') {
+    return 'ready';
+  }
+
   const update = await Updates.checkForUpdateAsync();
   if (update.isAvailable) {
     await Updates.fetchUpdateAsync();

--- a/Updates.ts
+++ b/Updates.ts
@@ -1,8 +1,7 @@
 import * as Updates from 'expo-updates';
 import {logger} from 'logger';
-import {Alert} from 'react-native';
 
-export type UpdateStatus = 'checking' | 'downloading' | 'ready';
+export type UpdateStatus = 'checking' | 'restarting' | 'ready';
 
 export const updateCheck = async (): Promise<UpdateStatus> => {
   if (Updates.isEmergencyLaunch) {
@@ -12,20 +11,8 @@ export const updateCheck = async (): Promise<UpdateStatus> => {
   const update = await Updates.checkForUpdateAsync();
   if (update.isAvailable) {
     await Updates.fetchUpdateAsync();
-    await new Promise<void>(resolve => {
-      Alert.alert('Update Available', 'Avy needs to restart to apply an update.', [
-        {
-          text: 'OK',
-          onPress: () => {
-            Updates.reloadAsync()
-              .then(() => resolve())
-              .catch(() => resolve());
-          },
-          style: 'default',
-        },
-      ]);
-      return 'downloading';
-    });
+    await Updates.reloadAsync();
+    return 'restarting';
   }
   return 'ready';
 };

--- a/app.config.ts
+++ b/app.config.ts
@@ -10,7 +10,6 @@ export default ({config}: ConfigContext): Partial<ExpoConfig> => {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
   config.ios!.config!.googleMapsApiKey = process.env.IOS_GOOGLE_MAPS_API_KEY;
   config.android!.config!.googleMaps!.apiKey = process.env.ANDROID_GOOGLE_MAPS_API_KEY;
-  config.extra!.sentry_dsn = process.env.SENTRY_DSN;
   config.extra!.log_level = process.env.LOG_LEVEL != null ? process.env.LOG_LEVEL : 'info';
 
   return config;

--- a/app.json
+++ b/app.json
@@ -65,7 +65,6 @@
       "eas": {
         "projectId": "47e2fd36-5165-4eb4-9a2d-21beec393379"
       },
-      "sentry_dsn": "LOADED_FROM_ENVIRONMENT",
       "avalanche_center": "NWAC",
       "log_level": "info"
     },

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -69,9 +69,12 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
   }
 
   const zone: AvalancheForecastZone | undefined = center.zones.find(item => item.id === forecast_zone_id);
-  if (!zone || zone.status == AvalancheForecastZoneStatus.Disabled) {
+  if (!zone || zone.status === AvalancheForecastZoneStatus.Disabled) {
     const message = `Avalanche center ${center_id} had no zone with id ${forecast_zone_id}`;
-    Sentry.Native.captureException(new Error(message));
+    if (!zone) {
+      // If the zone is intentionally disabled, don't log to Sentry
+      Sentry.Native.captureException(new Error(message));
+    }
     return <NotFound what={[new NotFoundError(message, 'avalanche forecast zone')]} />;
   }
 

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -259,7 +259,7 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                         </HStack>
                       </VStack>
                     </Card>
-                    <Card borderRadius={0} borderColor="white" header={<BodyBlack>Debug Settings</BodyBlack>}>
+                    <Card borderRadius={0} borderColor="white" header={<BodyBlack>Observation Uploader</BodyBlack>}>
                       <VStack space={12}>
                         <Button buttonStyle="normal" onPress={() => logger.info({stats: getUploader().getState()}, 'ObservationUploader state')}>
                           Dump state to log

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -273,7 +273,7 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                       <VStack space={4}>
                         <Body>Config</Body>
                         {(() => {
-                          const dsn = Constants.expoConfig?.extra?.sentry_dsn as string | undefined;
+                          const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
                           return (
                             <BodySm fontFamily={Platform.select({ios: 'Courier New', android: 'monospace'})} color={colorLookup(dsn ? 'text' : 'red')}>
                               SENTRY_DSN: {dsn ? `${dsn.slice(0, 15)}...` : 'not supplied'}

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -91,7 +91,7 @@ export const prefetchAllActiveForecasts = async (
         void (async () => {
           void NWACWeatherForecastQuery.prefetch(queryClient, nwacHost, zone.id, currentDateTime, logger);
           void AvalancheWarningQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);
-          if (metadata.config?.blog) {
+          if (process.env.EXPO_PUBLIC_ENABLE_CONDITIONS_BLOG && metadata.config?.blog) {
             void SynopsisQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);
           }
           await AvalancheForecastQuery.prefetch(


### PR DESCRIPTION
Expo updates: modified the startup sequence to do the following:
- check if an update is available
- download and apply it if it is
- continue startup if it's not
Tested this by manually updating the preview channel multiple times.

Sentry config: was not getting set correctly when calling `eas update`. Changed to use the new recommended env variable convention (`EXPO_PUBLIC_*`).

Sentry errors: minimize warnings for things that are disabled, should resolve https://nwac.sentry.io/issues/4511582939/?project=4504317393436672&query=is:unresolved&stream_index=8