### PR TITLE
Adjust stale_time for prefetches and regular fetches

### DIFF
--- a/hooks/useAllAvalancheCenterMetadata.ts
+++ b/hooks/useAllAvalancheCenterMetadata.ts
@@ -27,7 +27,6 @@ export const useAllAvalancheCenterMetadata = (capabilities: AllAvalancheCenterCa
             queryKey: AvalancheCenterMetadataQuery.queryKey(nationalAvalancheCenterHost, center),
             queryFn: async (): Promise<AvalancheCenter> => AvalancheCenterMetadataQuery.fetchQuery(queryClient, nationalAvalancheCenterHost, center, logger),
             enabled: !!capabilities,
-            staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
             cacheTime: Infinity, // hold on to this cached data forever
           };
         })

--- a/hooks/useAvalancheCenterCapabilities.ts
+++ b/hooks/useAvalancheCenterCapabilities.ts
@@ -25,7 +25,6 @@ export const useAvalancheCenterCapabilities = (): UseQueryResult<AllAvalancheCen
   return useQuery<AllAvalancheCenterCapabilities, AxiosError | ZodError>({
     queryKey: key,
     queryFn: async (): Promise<AllAvalancheCenterCapabilities> => fetchAvalancheCenterCapabilities(nationalAvalancheCenterWordpressHost, thisLogger),
-    staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
     cacheTime: Infinity, // hold on to this cached data forever
   });
 };
@@ -48,6 +47,8 @@ export const prefetchAvalancheCenterCapabilities = async (queryClient: QueryClie
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: Infinity, // hold this in the query cache forever
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -25,7 +25,6 @@ export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID): UseQue
   return useQuery<AvalancheCenter, AxiosError | ZodError>({
     queryKey: key,
     queryFn: async (): Promise<AvalancheCenter> => fetchAvalancheCenterMetadata(nationalAvalancheCenterHost, center_id, thisLogger),
-    staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
     cacheTime: Infinity, // hold on to this cached data forever
   });
 };
@@ -48,6 +47,8 @@ export const prefetchAvalancheCenterMetadata = async (queryClient: QueryClient, 
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: Infinity, // hold this in the query cache forever
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useAvalancheForecastById.ts
+++ b/hooks/useAvalancheForecastById.ts
@@ -28,7 +28,6 @@ export const useAvalancheForecastById = (fragment: ForecastResult) => {
     queryKey: key,
     queryFn: (): Promise<ForecastResult> => fetchForecast(nationalAvalancheCenterHost, forecastId, thisLogger),
     enabled: !!forecastId,
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -51,6 +50,8 @@ export const prefetchAvalancheForecast = async (queryClient: QueryClient, nation
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -24,7 +24,6 @@ export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forec
   return useQuery<ForecastSummaryFragment, Error>({
     queryKey: key,
     queryFn: async (): Promise<ForecastSummaryFragment> => fetchAvalancheForecastFragment(queryClient, nationalAvalancheCenterHost, center_id, forecast_zone_id, date, thisLogger),
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };

--- a/hooks/useCachedImageURI.ts
+++ b/hooks/useCachedImageURI.ts
@@ -40,7 +40,6 @@ export const useCachedImageURI = (uri: string) => {
     queryKey: key,
     queryFn: async () => fetchCachedImageURI(uri, thisLogger),
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
-    staleTime: 24 * 60 * 60 * 1000, // do not refresh this data
     networkMode: requiresNetwork ? 'online' : 'always',
   });
 };
@@ -81,6 +80,8 @@ const prefetchCachedImageURI = async (queryClient: QueryClient, logger: Logger, 
       thisLogger.trace({duration: formatDistanceToNowStrict(start), destination: result}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -26,7 +26,6 @@ export const useMapLayer = (center_id: AvalancheCenterID | undefined): UseQueryR
     queryKey: key,
     queryFn: async (): Promise<MapLayer> => (center_id ? fetchMapLayer(nationalAvalancheCenterHost, center_id, thisLogger) : new Promise(() => null)),
     enabled: !!center_id,
-    staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
     cacheTime: Infinity, // hold on to this cached data forever
   });
 };
@@ -49,6 +48,8 @@ export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalanc
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: Infinity, // hold this in the query cache forever
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useNACObservation.ts
+++ b/hooks/useNACObservation.ts
@@ -25,7 +25,6 @@ export const useNACObservation = (id: string): UseQueryResult<Observation, Axios
   return useQuery<Observation, AxiosError | ZodError>({
     queryKey: key,
     queryFn: (): Promise<Observation> => fetchNACObservation(host, id, thisLogger),
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -48,6 +47,8 @@ export const prefetchNACObservation = async (queryClient: QueryClient, host: str
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -50,7 +50,6 @@ export const useNACObservations = (center_id: AvalancheCenterID, endDate: Reques
         return undefined;
       }
     },
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
     enabled: options.enabled,
   });
@@ -85,10 +84,8 @@ export const prefetchNACObservations = async (queryClient: QueryClient, national
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
-    // Prefetching is looping forever without these params being set. Not sure why!
-    // Theory: this GQL path uses POST instead of GET, and the POST is not being cached by default...?
-    staleTime: 60 * 60 * 1000, // any fetched data we have is valid for an hour
-    cacheTime: 60 * 60 * 1000, // drop it from memory after an hour
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useNWACObservation.ts
+++ b/hooks/useNWACObservation.ts
@@ -25,7 +25,6 @@ export const useNWACObservation = (id: number): UseQueryResult<Observation, Axio
   return useQuery<Observation, AxiosError | ZodError>({
     queryKey: key,
     queryFn: (): Promise<Observation> => fetchNWACObservation(nwacHost, id, thisLogger),
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -47,6 +46,8 @@ export const prefetchNWACObservation = async (queryClient: QueryClient, nwacHost
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -50,7 +50,6 @@ export const useNWACObservations = (center_id: AvalancheCenterID, endDate: Reque
         return undefined;
       }
     },
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
     enabled: options.enabled,
   });
@@ -86,6 +85,8 @@ export const prefetchNWACObservations = async (queryClient: QueryClient, nwacHos
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useNWACWeatherForecast.ts
+++ b/hooks/useNWACWeatherForecast.ts
@@ -38,7 +38,6 @@ export const useNWACWeatherForecast = (
         return fetchNWACWeatherForecast(nwacHost, zone_id, date, thisLogger);
       }
     },
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -68,6 +67,8 @@ export const prefetchNWACWeatherForecast = async (queryClient: QueryClient, nwac
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useWeatherForecast.ts
+++ b/hooks/useWeatherForecast.ts
@@ -27,7 +27,6 @@ export const useWeatherForecast = (forecastId?: number): UseQueryResult<Weather,
     queryKey: key,
     queryFn: (): Promise<Weather> => fetchWeatherForecast(nationalAvalancheCenterHost, forecastId ?? 0, thisLogger),
     enabled: !!forecastId,
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -50,6 +49,8 @@ export const prefetchWeatherForecast = async (queryClient: QueryClient, national
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useWeatherStationTimeseries.ts
+++ b/hooks/useWeatherStationTimeseries.ts
@@ -33,7 +33,6 @@ export const useWeatherStationTimeseries = (
     queryKey: key,
     queryFn: (): Promise<WeatherStationTimeseries> => fetchWeatherStationTimeseries(host, token ?? '', thisLogger, stations, startDate, endDate),
     enabled: !!token,
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -86,6 +85,8 @@ export const prefetchWeatherStationTimeseries = async (
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 

--- a/hooks/useWeatherStationsMetadata.ts
+++ b/hooks/useWeatherStationsMetadata.ts
@@ -26,7 +26,6 @@ export const useWeatherStationsMetadata = (center: AvalancheCenterID, token: str
     queryKey: key,
     queryFn: (): Promise<WeatherStationCollection> => fetchWeatherStationsMetadata(host, token ?? '', thisLogger),
     enabled: !!token,
-    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
@@ -49,6 +48,8 @@ export const prefetchWeatherStationsMetadata = async (queryClient: QueryClient, 
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
+    cacheTime: 24 * 60 * 60 * 1000, // hold this in the query cache for a day
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };
 


### PR DESCRIPTION
This PR does 2 things:
1) try to avoid over-fetching at startup, by applying a `stale_time` to the prefetch queries. This actually feels like a reasonable use of `stale_time` - we might never even display the data that we prefetch, and I think it's not terrible if it's 24 hours out of date (though that's just an opinion, open to hearing others).
2) try to avoid displaying stale data at runtime by removing `stale_time` from our regular app queries.

There's a table below that breaks down what changed. Fixes #474.
 
&nbsp; | `cache_time` | `stale_time`
--- | --- | ---
prefetching | **changed**<br>value: same duration as the regular fetch's `cache_time`<br>it will get dropped from the cache if not refreshed by then | **changed**<br>value: 24 hours<br>an app launch after 24 hours will try to prefetch again
regular fetch | **unchanged**<br>value: typically 24 hours, occasionally `Infinity`<br>it will get dropped from the cache if not refreshed by then | **changed**<br>value: 0<br>a live query will always try to refresh in the background, even as it displays data from the cache
