### PR TITLE
Translate center IDs on the fly when needed (SNFAC -> SAC)

### DIFF
--- a/components/text/Text.test.tsx
+++ b/components/text/Text.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-native/extend-expect';
 import {render, screen} from '@testing-library/react-native';
 import React from 'react';
 
@@ -20,6 +21,40 @@ describe('Text', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       expect(() => screen.getByText(input)).toThrow();
       expect(screen.getByText(output)).not.toBeNull();
+    });
+  });
+
+  describe('Center ID modification', () => {
+    it('does not modify center IDs like NWAC', () => {
+      const input = 'my favorite avalanche center is NWAC in Seattle';
+      render(<Body>{input}</Body>);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const element = screen.getByText(/my favorite/);
+      expect(element).toHaveTextContent(input);
+    });
+
+    it('does modify center IDs like SNFAC', () => {
+      const input = 'my favorite avalanche center is SNFAC in Idaho, known as SNFAC';
+      render(<Body>{input}</Body>);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const element = screen.getByText(/my favorite/);
+      expect(element).toHaveTextContent('my favorite avalanche center is SAC in Idaho, known as SAC');
+    });
+
+    it('is case-sensitive when modifying', () => {
+      const input = 'snfac Snfac sNfac snFAC SNFAC';
+      render(<Body>{input}</Body>);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const element = screen.getByText(/snfac/);
+      expect(element).toHaveTextContent('snfac Snfac sNfac snFAC SAC');
+    });
+
+    it('does not modify center id when translate prop is false', () => {
+      const input = 'NWAC SNFAC SAC';
+      render(<Body translate={false}>{input}</Body>);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const element = screen.getByText(/NWAC/);
+      expect(element).toHaveTextContent('NWAC SNFAC SAC');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@graphql-codegen/add": "^3.2.3",
     "@graphql-codegen/typescript-operations": "^2.5.10",
     "@graphql-codegen/typescript-react-query": "^4.0.6",
-    "@testing-library/jest-native": "^5.4.2",
+    "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/react-native": "^11.5.0",
     "@types/color": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,10 +5455,10 @@
     "@tanstack/query-core" "4.24.9"
     use-sync-external-store "^1.2.0"
 
-"@testing-library/jest-native@^5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-5.4.2.tgz#6b0c987cc57f8d900763e763025d00d26ccbc85f"
-  integrity sha512-Vo/CE1uvCVH1H8YPoOEXLXVsm+BjzSQTq35+wkri1fr0O5D+A2WZ+m3ni5g6f1OCzNKNGIAHmisBEWkDs1P1mw==
+"@testing-library/jest-native@^5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-5.4.3.tgz#9334c68eaf45db9eb20d0876728cc5d7fc2c3ea2"
+  integrity sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==
   dependencies:
     chalk "^4.1.2"
     jest-diff "^29.0.1"


### PR DESCRIPTION
Seems to work pretty well, fixes all the places I know about. Going to close this, but maybe this work will be useful sometime

<img width="364" alt="image" src="https://github.com/NWACus/avy/assets/101196/62618f5b-1ee0-4afd-aa9d-53b7be6bd09c">
<img width="362" alt="image" src="https://github.com/NWACus/avy/assets/101196/5fc2d533-0cdc-4227-9994-2b7fb1ac54a0">
<img width="368" alt="image" src="https://github.com/NWACus/avy/assets/101196/2a378760-6263-4db8-b3bf-38012547b503">
<img width="356" alt="image" src="https://github.com/NWACus/avy/assets/101196/2fda03c6-0ddd-4572-b451-22bcfbd990db">
