### PR TITLE
Implement updateRequired checker

### DIFF
--- a/components/content/Outcome.tsx
+++ b/components/content/Outcome.tsx
@@ -27,7 +27,7 @@ export const Outcome: React.FunctionComponent<OutcomeOptions> = ({
 }) => {
   return (
     <View style={inline ? {} : {height: '100%', width: '100%'}} bg="white" pb={32}>
-      <VStack justifyContent={'center'} flex={1}>
+      <VStack justifyContent={'center'} flex={inline ? 0 : 1}>
         <View mx={16}>
           <VStack space={24} alignItems={'center'}>
             <View mb={illustrationBottomMargin} ml={illustrationLeftMargin}>


### PR DESCRIPTION
Very similar to #500 - this checks the `update-required` feature flag and presents a modal if the user needs to update. The `down-for-maintenance` flag always takes precedence, however.

Small change to `Outcome` and its `inline` behavior so that it doesn't flex to fill its whole container. This allows stacking it with a custom button. I don't think this should cause any issues elsewhere (famous last words).

TODO / nice to have
- the modal should have a link that opens the app store for the user. I'll add an issue for this so someone can pick it up.

update-required | down-for-maintenance
--- | ---
![simulator_screenshot_DCE2920C-15F3-4001-97E7-DEB6F55617D4](https://github.com/NWACus/avy/assets/101196/0b05d6cc-ce50-4111-bb62-b07872bfa286) | ![simulator_screenshot_077001F8-7B25-4CD7-8219-529E942014A4](https://github.com/NWACus/avy/assets/101196/5fdbcd4f-674d-419e-b30c-61a2e2ae51a9)
