### PR TITLE
Catch errors from the ImagePicker and display an error string

### DIFF
--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -178,20 +178,27 @@ export const SimpleForm: React.FC<{
 
   const maxImageCount = 8;
   const [images, setImages] = useState<ImagePicker.ImagePickerAsset[]>([]);
+  const [imageLoadError, setImageLoadError] = useState(false);
   const pickImage = async () => {
-    // No permissions request is necessary for launching the image library
-    const result = await ImagePicker.launchImageLibraryAsync({
-      allowsMultipleSelection: true,
-      exif: true,
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
-      preferredAssetRepresentationMode: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
-      quality: 0.2,
-      selectionLimit: maxImageCount,
-    });
+    try {
+      setImageLoadError(false);
+      // No permissions request is necessary for launching the image library
+      const result = await ImagePicker.launchImageLibraryAsync({
+        allowsMultipleSelection: true,
+        exif: true,
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        preferredAssetRepresentationMode: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
+        quality: 0.2,
+        selectionLimit: maxImageCount,
+      });
 
-    if (!result.canceled) {
-      const newImages = images.concat(result.assets).slice(0, maxImageCount);
-      setImages(newImages);
+      if (!result.canceled) {
+        const newImages = images.concat(result.assets).slice(0, maxImageCount);
+        setImages(newImages);
+      }
+    } catch (error) {
+      setImageLoadError(true);
+      logger.error('ImagePicker error', {error});
     }
   };
 
@@ -513,20 +520,23 @@ export const SimpleForm: React.FC<{
                           )}
                         />
                       )}
-                      <Button
-                        buttonStyle="normal"
-                        onPress={() => void pickImage()}
-                        disabled={images.length === maxImageCount || disableFormControls || missingImagePermissions}
-                        renderChildren={({textColor}) => (
-                          <HStack alignItems="center" space={4}>
-                            <MaterialIcons name="add" size={24} color={textColor} style={{marginTop: 1}} />
-                            <BodyBlack color={textColor}>Add images</BodyBlack>
-                          </HStack>
+                      <VStack space={4}>
+                        <Button
+                          buttonStyle="normal"
+                          onPress={() => void pickImage()}
+                          disabled={images.length === maxImageCount || disableFormControls || missingImagePermissions}
+                          renderChildren={({textColor}) => (
+                            <HStack alignItems="center" space={4}>
+                              <MaterialIcons name="add" size={24} color={textColor} style={{marginTop: 1}} />
+                              <BodyBlack color={textColor}>Add images</BodyBlack>
+                            </HStack>
+                          )}
+                        />
+                        {missingImagePermissions && (
+                          <BodySm color={colorLookup('error.900')}>We need permission to access your photos to upload images. Please check your system settings.</BodySm>
                         )}
-                      />
-                      {missingImagePermissions && (
-                        <BodySm color={colorLookup('error.900')}>We need permission to access your photos to upload images. Please check your system settings.</BodySm>
-                      )}
+                        {imageLoadError && <BodySm color={colorLookup('error.900')}>An unexpected error occurred when loading your images.</BodySm>}
+                      </VStack>
                     </VStack>
                   </Card>
 

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -178,10 +178,8 @@ export const SimpleForm: React.FC<{
 
   const maxImageCount = 8;
   const [images, setImages] = useState<ImagePicker.ImagePickerAsset[]>([]);
-  const [imageLoadError, setImageLoadError] = useState(false);
   const pickImage = async () => {
     try {
-      setImageLoadError(false);
       // No permissions request is necessary for launching the image library
       const result = await ImagePicker.launchImageLibraryAsync({
         allowsMultipleSelection: true,
@@ -197,8 +195,17 @@ export const SimpleForm: React.FC<{
         setImages(newImages);
       }
     } catch (error) {
-      setImageLoadError(true);
       logger.error('ImagePicker error', {error});
+      // Are we offline? Things might be ok if they go online again.
+      const {networkStatus} = getUploader().getState();
+      Toast.show({
+        type: 'error',
+        text1:
+          networkStatus === 'offline'
+            ? `An unexpected error occurred when loading your images. Try again when you’re back online.`
+            : `An unexpected error occurred when loading your images.`,
+        position: 'bottom',
+      });
     }
   };
 
@@ -535,7 +542,6 @@ export const SimpleForm: React.FC<{
                         {missingImagePermissions && (
                           <BodySm color={colorLookup('error.900')}>We need permission to access your photos to upload images. Please check your system settings.</BodySm>
                         )}
-                        {imageLoadError && <BodySm color={colorLookup('error.900')}>An unexpected error occurred when loading your images.</BodySm>}
                       </VStack>
                     </VStack>
                   </Card>


### PR DESCRIPTION
This definitely fixes #524 - on iOS, picking photos from cloud storage in offline mode causes crash. I suspect it fixes other weirdness but can't say for sure. It probably fixes #514.

We don't really get much info back from ImagePicker when things go wrong. The entire contents of the exception object fit on a single line:
```
 ERROR  [2023-11-02T15:00:05.732Z] ERROR ImagePicker error {"error":{"code":"ERR_FAILED_TO_READ_IMAGE"}}
```
and googling for `ERR_FAILED_TO_READ_IMAGE` doesn't turn up anything useful. I couldn't really think of anything more to say than "An unexpected error occurred".

There's a different string for offline/online because that's one thing that we know can help. I don't know what else can help though 😢 


https://github.com/NWACus/avy/assets/101196/2e9c0173-5a9d-4696-bf51-783fa42a0576
