### PR TITLE
Show build date on about screen

### DIFF
--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -16,8 +16,10 @@ import * as WebBrowser from 'expo-web-browser';
 import {Ionicons} from '@expo/vector-icons';
 import {ActionList} from 'components/content/ActionList';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
+import {toISOStringUTC} from 'utils/date';
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
+  const buildDate = Updates.createdAt || new Date();
   return (
     <View style={StyleSheet.absoluteFillObject}>
       <VStack backgroundColor="white" width="100%" height="100%" pt={16} justifyContent="space-between">
@@ -45,7 +47,8 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
         <HStack space={4} px={32}>
           <VStack py={8} space={4}>
             <BodyXSm>
-              Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
+              Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
+              {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
             </BodyXSm>
             {Updates.updateId && (
               <BodyXSm>
@@ -62,9 +65,10 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
             onPress={() => {
               void (async () => {
                 await Clipboard.setStringAsync(
-                  `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})\nGit revision ${
-                    process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'
-                  }\nUpdate ${Updates.updateId || 'n/a'} (${Updates.channel || 'development'})`,
+                  `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
+Build date ${toISOStringUTC(buildDate)}
+Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
+Update ID ${Updates.updateId || 'n/a'} (${Updates.channel || 'development'})`,
                 );
               })();
             }}


### PR DESCRIPTION
We've all figured out that the version and build number of the binary are pretty useless when it comes to figuring out what the user is running - the crucial bit is the Expo update that they've downloaded. 

The git hash and update id identify the update very clearly, but don't give good at-a-glance information about how old the build is. This PR adds the build date to the info we display:

<img width="410" alt="image" src="https://github.com/NWACus/avy/assets/101196/1ce8df53-d686-47e8-9576-6618a9558a98">

Copying the info now includes a build date:

```
Avy version 2.29.6 (2.29.6)
Build date 2023-11-02 17:31:21Z
Git revision 128e299
Update ID n/a (development)
```