### PR TITLE
Implement the 10 second startup delay when loading updates

### DIFF
--- a/Updates.ts
+++ b/Updates.ts
@@ -3,20 +3,39 @@ import {logger} from 'logger';
 
 export type UpdateStatus = 'checking' | 'restarting' | 'ready';
 
-export const updateCheck = async (): Promise<UpdateStatus> => {
+export const startupUpdateCheck = async (): Promise<UpdateStatus> => {
   if (Updates.isEmergencyLaunch) {
     logger.warn('Emergency launch detected - update checking disabled');
     return 'ready';
   }
   if (Updates.channel !== 'preview' && Updates.channel !== 'release') {
+    logger.debug(`Unknown update channel '${Updates.channel || 'null'}' - update checking disabled`);
     return 'ready';
   }
 
-  const update = await Updates.checkForUpdateAsync();
-  if (update.isAvailable) {
-    await Updates.fetchUpdateAsync();
-    await Updates.reloadAsync();
-    return 'restarting';
+  try {
+    // After 10 seconds, we'll resolve as ready no matter what
+    const timeout = new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 10000));
+    const update = await Promise.race([timeout, Updates.checkForUpdateAsync()]);
+    if (update === 'timeout') {
+      logger.debug('checkForUpdateAsync timed out');
+      return 'ready';
+    }
+    if (update.isAvailable) {
+      // An update is available! Let's create a new 10 second timer and try to get it installed.
+      const timeout = new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 10000));
+      const fetch = await Promise.race([timeout, Updates.fetchUpdateAsync()]);
+      if (fetch === 'timeout') {
+        logger.debug('fetchUpdateAsync timed out');
+        return 'ready';
+      }
+      await Updates.reloadAsync();
+      return 'restarting';
+    } else {
+      logger.debug('No update available');
+    }
+  } catch (error) {
+    logger.warn({error}, 'Error checking for updates');
   }
   return 'ready';
 };


### PR DESCRIPTION
This stuff is hard to test without an actual build and update channel, so I'm going to merge and party on the `preview` channel today.

Changes:
- Render a loading screen that seamlessly replaces the splash screen, includes a spinner
- Render that screen while we check for updates
- Add the 10 second delay when checking for and downloading updates at startup

Not implemented yet:
- Watching for updates while the app is running and prompting for restart

Movie showing the splash screen with spinner:

https://github.com/NWACus/avy/assets/101196/f21581cc-741d-474d-940e-540b8be6eb5b

