### PR TITLE
Implement OTA updates on map screen

### DIFF
--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -4,10 +4,13 @@ import {StyleSheet, View} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {AvalancheForecastZoneMap} from 'components/AvalancheForecastZoneMap';
+import {useEASUpdateChecker} from 'hooks/useEASUpdateChecker';
 import {HomeStackParamList} from 'routes';
 import {parseRequestedTimeString} from 'utils/date';
 
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
+  useEASUpdateChecker();
+
   const {center_id, requestedTime} = route.params;
   return (
     <View style={{...styles.container}}>

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -27,7 +27,7 @@ export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'a
 
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container, borderWidth: 8, borderColor: color}}>
+    <View style={{...styles.container, borderWidth: 4, borderColor: color}}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -27,7 +27,7 @@ export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'a
 
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container, borderWidth: 4, borderColor: color}}>
+    <View style={{...styles.container, borderWidth: 8, borderColor: color}}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -5,6 +5,7 @@ import * as Updates from 'expo-updates';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
+import {useIsFocused} from '@react-navigation/native';
 import {AvalancheForecastZoneMap} from 'components/AvalancheForecastZoneMap';
 import {useEASUpdateStatus} from 'hooks/useEASUpdateStatus';
 import {HomeStackParamList} from 'routes';
@@ -12,9 +13,10 @@ import {parseRequestedTimeString} from 'utils/date';
 
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
   const updateStatus = useEASUpdateStatus();
+  const isActiveScreen = useIsFocused();
 
   useEffect(() => {
-    if (updateStatus === 'update-downloaded') {
+    if (updateStatus === 'update-downloaded' && isActiveScreen) {
       Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
         {
           text: 'OK',
@@ -22,7 +24,7 @@ export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'a
         },
       ]);
     }
-  }, [updateStatus]);
+  }, [isActiveScreen, updateStatus]);
 
   const {center_id, requestedTime} = route.params;
   return (

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -13,14 +13,6 @@ import {parseRequestedTimeString} from 'utils/date';
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
   const updateStatus = useEASUpdateStatus();
 
-  const color = {
-    idle: 'green',
-    'checking-for-update': 'magenta',
-    'update-available': 'blue',
-    'downloading-update': 'yellow',
-    'update-downloaded': 'red',
-  }[updateStatus];
-
   useEffect(() => {
     if (updateStatus === 'update-downloaded') {
       Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
@@ -34,7 +26,7 @@ export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'a
 
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container, borderWidth: 8, borderColor: color}}>
+    <View style={styles.container}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -11,9 +11,23 @@ import {parseRequestedTimeString} from 'utils/date';
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
   const updateAvailable = useEASUpdateChecker();
 
+  // Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
+  //   {
+  //     text: 'OK',
+  //     onPress: () => void Updates.reloadAsync(),
+  //   },
+  // ]);
+  const color = {
+    idle: 'green',
+    'checking-for-update': 'magenta',
+    'update-available': 'blue',
+    'downloading-update': 'yellow',
+    'update-downloaded': 'red',
+  }[updateAvailable];
+
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container, borderWidth: updateAvailable ? 4 : undefined, borderColor: updateAvailable ? 'blue' : undefined}}>
+    <View style={{...styles.container, borderWidth: 8, borderColor: color}}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -9,11 +9,11 @@ import {HomeStackParamList} from 'routes';
 import {parseRequestedTimeString} from 'utils/date';
 
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
-  useEASUpdateChecker();
+  const updateAvailable = useEASUpdateChecker();
 
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container}}>
+    <View style={{...styles.container, borderWidth: updateAvailable ? 4 : undefined, borderColor: updateAvailable ? 'blue' : undefined}}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import {StyleSheet, View} from 'react-native';
+import React, {useEffect} from 'react';
+import {Alert, StyleSheet, View} from 'react-native';
+
+import * as Updates from 'expo-updates';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
@@ -9,25 +11,30 @@ import {HomeStackParamList} from 'routes';
 import {parseRequestedTimeString} from 'utils/date';
 
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
-  const updateAvailable = useEASUpdateStatus();
+  const updateStatus = useEASUpdateStatus();
 
-  // Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
-  //   {
-  //     text: 'OK',
-  //     onPress: () => void Updates.reloadAsync(),
-  //   },
-  // ]);
   const color = {
     idle: 'green',
     'checking-for-update': 'magenta',
     'update-available': 'blue',
     'downloading-update': 'yellow',
     'update-downloaded': 'red',
-  }[updateAvailable];
+  }[updateStatus];
+
+  useEffect(() => {
+    if (updateStatus === 'update-downloaded') {
+      Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
+        {
+          text: 'OK',
+          onPress: () => void Updates.reloadAsync(),
+        },
+      ]);
+    }
+  }, [updateStatus]);
 
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container, borderWidth: 4, borderColor: color}}>
+    <View style={{...styles.container, borderWidth: 8, borderColor: color}}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -4,12 +4,12 @@ import {StyleSheet, View} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {AvalancheForecastZoneMap} from 'components/AvalancheForecastZoneMap';
-import {useEASUpdateChecker} from 'hooks/useEASUpdateChecker';
+import {useEASUpdateStatus} from 'hooks/useEASUpdateStatus';
 import {HomeStackParamList} from 'routes';
 import {parseRequestedTimeString} from 'utils/date';
 
 export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>) => {
-  const updateAvailable = useEASUpdateChecker();
+  const updateAvailable = useEASUpdateStatus();
 
   // Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
   //   {
@@ -27,7 +27,7 @@ export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'a
 
   const {center_id, requestedTime} = route.params;
   return (
-    <View style={{...styles.container, borderWidth: 4, borderColor: color}}>
+    <View style={{...styles.container, borderWidth: 8, borderColor: color}}>
       <AvalancheForecastZoneMap center={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
     </View>
   );

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -13,7 +13,6 @@ import * as WebBrowser from 'expo-web-browser';
 import {Ionicons} from '@expo/vector-icons';
 
 import {ActionList} from 'components/content/ActionList';
-import {Button} from 'components/content/Button';
 import {Center, HStack, View, VStack} from 'components/core';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
 import {MenuStackParamList} from 'routes';
@@ -30,12 +29,6 @@ const getUpdateGroupId = (): string => {
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
   const buildDate = Updates.createdAt || new Date();
   const [updateGroupId] = useState(getUpdateGroupId());
-  const [updateAvailable, setUpdateAvailable] = useState(false);
-  Updates.useUpdateEvents(event => {
-    if (event.type === Updates.UpdateEventType.UPDATE_AVAILABLE) {
-      setUpdateAvailable(true);
-    }
-  });
   return (
     <View style={StyleSheet.absoluteFillObject}>
       <VStack backgroundColor="white" width="100%" height="100%" pt={16} justifyContent="space-between">
@@ -60,44 +53,37 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
             ]}
           />
         </VStack>
-        <VStack space={16} px={32}>
-          {updateAvailable && (
-            <Button buttonStyle="primary" onPress={() => void (async () => await Updates.reloadAsync())()}>
-              <BodyBlack>Update available</BodyBlack>
-            </Button>
-          )}
-          <HStack space={4}>
-            <VStack py={8} space={4}>
+        <HStack space={4} px={32}>
+          <VStack py={8} space={4}>
+            <BodyXSm>
+              Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
+              {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
+            </BodyXSm>
+            {updateGroupId && (
               <BodyXSm>
-                Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
-                {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
+                Update: {updateGroupId} ({Updates.channel || 'development'})
               </BodyXSm>
-              {updateGroupId && (
-                <BodyXSm>
-                  Update: {updateGroupId} ({Updates.channel || 'development'})
-                </BodyXSm>
-              )}
-            </VStack>
-            <Ionicons.Button
-              name="copy-outline"
-              size={12}
-              color="black"
-              style={{backgroundColor: 'white'}}
-              iconStyle={{marginRight: 0}}
-              onPress={() => {
-                void (async () => {
-                  await Clipboard.setStringAsync(
-                    `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
+            )}
+          </VStack>
+          <Ionicons.Button
+            name="copy-outline"
+            size={12}
+            color="black"
+            style={{backgroundColor: 'white'}}
+            iconStyle={{marginRight: 0}}
+            onPress={() => {
+              void (async () => {
+                await Clipboard.setStringAsync(
+                  `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
 Build date ${toISOStringUTC(buildDate)}
 Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
 Update group ID ${updateGroupId} (channel: ${Updates.channel || 'development'})
 Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})`,
-                  );
-                })();
-              }}
-            />
-          </HStack>
-        </VStack>
+                );
+              })();
+            }}
+          />
+        </HStack>
       </VStack>
     </View>
   );

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -20,7 +20,7 @@ import {toISOStringUTC} from 'utils/date';
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
   const buildDate = Updates.createdAt || new Date();
-  const updateGroupId = Updates.manifest?.id || 'n/a';
+  const updateGroupId = Updates.manifest?.metadata ? JSON.stringify(Updates.manifest.metadata, null, 2) : 'n/a';
   return (
     <View style={StyleSheet.absoluteFillObject}>
       <VStack backgroundColor="white" width="100%" height="100%" pt={16} justifyContent="space-between">

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 
 import {StyleSheet} from 'react-native';
 
@@ -15,12 +15,19 @@ import * as WebBrowser from 'expo-web-browser';
 
 import {Ionicons} from '@expo/vector-icons';
 import {ActionList} from 'components/content/ActionList';
+import {Button} from 'components/content/Button';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
 import {toISOStringUTC} from 'utils/date';
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
   const buildDate = Updates.createdAt || new Date();
   const updateGroupId = Updates.manifest?.metadata ? JSON.stringify(Updates.manifest.metadata, null, 2) : 'n/a';
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  Updates.useUpdateEvents(event => {
+    if (event.type === Updates.UpdateEventType.UPDATE_AVAILABLE) {
+      setUpdateAvailable(true);
+    }
+  });
   return (
     <View style={StyleSheet.absoluteFillObject}>
       <VStack backgroundColor="white" width="100%" height="100%" pt={16} justifyContent="space-between">
@@ -45,41 +52,48 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
             ]}
           />
         </VStack>
-        <HStack space={4} px={32}>
-          <VStack py={8} space={4}>
-            <BodyXSm>
-              Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
-              {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
-            </BodyXSm>
-            {Updates.updateId && (
+        <VStack space={16} px={32}>
+          {updateAvailable && (
+            <Button buttonStyle="primary" onPress={() => void (async () => await Updates.reloadAsync())()}>
+              <BodyBlack>Update available</BodyBlack>
+            </Button>
+          )}
+          <HStack space={4}>
+            <VStack py={8} space={4}>
               <BodyXSm>
-                Update: {Updates.updateId.slice(0, 18)} ({Updates.channel || 'development'})
+                Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
+                {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
               </BodyXSm>
-            )}
-            {updateGroupId && (
-              <BodyXSm>
-                Update (group): {updateGroupId} ({Updates.channel || 'development'})
-              </BodyXSm>
-            )}
-          </VStack>
-          <Ionicons.Button
-            name="copy-outline"
-            size={12}
-            color="black"
-            style={{backgroundColor: 'white'}}
-            iconStyle={{marginRight: 0}}
-            onPress={() => {
-              void (async () => {
-                await Clipboard.setStringAsync(
-                  `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
+              {Updates.updateId && (
+                <BodyXSm>
+                  Update: {Updates.updateId} ({Updates.channel || 'development'})
+                </BodyXSm>
+              )}
+              {updateGroupId && (
+                <BodyXSm>
+                  Update (group): {updateGroupId} ({Updates.channel || 'development'})
+                </BodyXSm>
+              )}
+            </VStack>
+            <Ionicons.Button
+              name="copy-outline"
+              size={12}
+              color="black"
+              style={{backgroundColor: 'white'}}
+              iconStyle={{marginRight: 0}}
+              onPress={() => {
+                void (async () => {
+                  await Clipboard.setStringAsync(
+                    `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
 Build date ${toISOStringUTC(buildDate)}
 Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
 Update ID ${Updates.updateId || 'n/a'} (${Updates.channel || 'development'})`,
-                );
-              })();
-            }}
-          />
-        </HStack>
+                  );
+                })();
+              }}
+            />
+          </HStack>
+        </VStack>
       </VStack>
     </View>
   );

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -20,6 +20,7 @@ import {toISOStringUTC} from 'utils/date';
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
   const buildDate = Updates.createdAt || new Date();
+  const updateGroupId = Updates.manifest?.id || 'n/a';
   return (
     <View style={StyleSheet.absoluteFillObject}>
       <VStack backgroundColor="white" width="100%" height="100%" pt={16} justifyContent="space-between">
@@ -53,6 +54,11 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
             {Updates.updateId && (
               <BodyXSm>
                 Update: {Updates.updateId.slice(0, 18)} ({Updates.channel || 'development'})
+              </BodyXSm>
+            )}
+            {updateGroupId && (
+              <BodyXSm>
+                Update (group): {updateGroupId} ({Updates.channel || 'development'})
               </BodyXSm>
             )}
           </VStack>

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -74,7 +74,7 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
               </BodyXSm>
               {updateGroupId && (
                 <BodyXSm>
-                  Update (group): {updateGroupId} ({Updates.channel || 'development'})
+                  Update: {updateGroupId} ({Updates.channel || 'development'})
                 </BodyXSm>
               )}
             </VStack>

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -1,12 +1,9 @@
 import React, {useState} from 'react';
 
-import {StyleSheet} from 'react-native';
+import _ from 'lodash';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-
-import {MenuStackParamList} from 'routes';
-
-import {Center, HStack, View, VStack} from 'components/core';
+import {Platform, StyleSheet} from 'react-native';
 
 import * as Application from 'expo-application';
 import * as Clipboard from 'expo-clipboard';
@@ -14,14 +11,25 @@ import * as Updates from 'expo-updates';
 import * as WebBrowser from 'expo-web-browser';
 
 import {Ionicons} from '@expo/vector-icons';
+
 import {ActionList} from 'components/content/ActionList';
 import {Button} from 'components/content/Button';
+import {Center, HStack, View, VStack} from 'components/core';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
+import {MenuStackParamList} from 'routes';
 import {toISOStringUTC} from 'utils/date';
+
+const getUpdateGroupId = (): string => {
+  const metadata: unknown = Updates.manifest?.metadata;
+  if (metadata && typeof metadata === 'object') {
+    return _.get(metadata, 'updateGroup', 'n/a');
+  }
+  return 'n/a';
+};
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
   const buildDate = Updates.createdAt || new Date();
-  const updateGroupId = Updates.manifest?.metadata ? JSON.stringify(Updates.manifest.metadata, null, 2) : 'n/a';
+  const [updateGroupId] = useState(getUpdateGroupId());
   const [updateAvailable, setUpdateAvailable] = useState(false);
   Updates.useUpdateEvents(event => {
     if (event.type === Updates.UpdateEventType.UPDATE_AVAILABLE) {
@@ -64,11 +72,6 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
                 Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
                 {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
               </BodyXSm>
-              {Updates.updateId && (
-                <BodyXSm>
-                  Update: {Updates.updateId} ({Updates.channel || 'development'})
-                </BodyXSm>
-              )}
               {updateGroupId && (
                 <BodyXSm>
                   Update (group): {updateGroupId} ({Updates.channel || 'development'})
@@ -87,7 +90,8 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
                     `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
 Build date ${toISOStringUTC(buildDate)}
 Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
-Update ID ${Updates.updateId || 'n/a'} (${Updates.channel || 'development'})`,
+Update group ID ${updateGroupId} (channel: ${Updates.channel || 'development'})
+Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})`,
                   );
                 })();
               }}

--- a/hooks/useEASUpdateChecker.ts
+++ b/hooks/useEASUpdateChecker.ts
@@ -27,7 +27,7 @@ const tryCheckForUpdates = async (): Promise<boolean> => {
 };
 
 // When returning to foreground, don't look for updates more frequently than every 5 minutes
-const UPDATE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const UPDATE_REFRESH_INTERVAL_MS = 0; // 5 * 60 * 1000;
 const tryCheckForUpdatesWithDebounce = _.debounce(tryCheckForUpdates, UPDATE_REFRESH_INTERVAL_MS, {leading: true});
 
 // When this hook is mounted, it will do the following:

--- a/hooks/useEASUpdateChecker.ts
+++ b/hooks/useEASUpdateChecker.ts
@@ -1,0 +1,78 @@
+import React, {useEffect} from 'react';
+
+import * as Updates from 'expo-updates';
+import _ from 'lodash';
+
+import {useNetInfo} from '@react-native-community/netinfo';
+import {useAppState} from 'hooks/useAppState';
+import {logger as parentLogger} from 'logger';
+import {Alert} from 'react-native';
+
+const logger = parentLogger.child({component: 'useEASUpdate'});
+
+const tryCheckForUpdates = async (): Promise<boolean> => {
+  logger.debug('checking for updates');
+  try {
+    const result = await Updates.checkForUpdateAsync();
+    if (result.isAvailable) {
+      logger.info('update available, downloading');
+      await Updates.fetchUpdateAsync();
+      logger.info('update downloaded');
+      return true;
+    }
+  } catch (error) {
+    logger.debug('error checking for updates', {error});
+  }
+  return false;
+};
+
+// When returning to foreground, don't look for updates more frequently than every 5 minutes
+const UPDATE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const tryCheckForUpdatesWithDebounce = _.debounce(tryCheckForUpdates, UPDATE_REFRESH_INTERVAL_MS, {leading: true});
+
+// When this hook is mounted, it will do the following:
+//
+// - listen for appState changes (background/foreground)
+// - listen for network changes (offline/online)
+// - if the app is in the foreground and the network is online, check for updates
+// - if an update is available, alert the user and then reload the app
+//
+// The checks are throttled to only happen every UPDATE_REFRESH_INTERVAL_MS
+//
+export const useEASUpdateChecker = () => {
+  const [updateAvailable, setUpdateAvailable] = React.useState(false);
+  const appState = useAppState();
+
+  useEffect(() => {
+    void (async () => {
+      if (appState === 'active') {
+        logger.debug('appState changed to active, checking for updates');
+        setUpdateAvailable((await tryCheckForUpdatesWithDebounce()) || false);
+      }
+    })();
+  }, [appState, setUpdateAvailable]);
+
+  const netInfo = useNetInfo();
+  useEffect(() => {
+    void (async () => {
+      if (netInfo.isConnected && netInfo.isInternetReachable) {
+        logger.debug('network online, checking for updates');
+        setUpdateAvailable((await tryCheckForUpdatesWithDebounce()) || false);
+      }
+    })();
+  }, [netInfo, setUpdateAvailable]);
+
+  useEffect(() => {
+    if (updateAvailable) {
+      logger.info('update available, reloading');
+      Alert.alert('Update Available', 'A new version of the app is available. Press OK to apply the update.', [
+        {
+          text: 'OK',
+          onPress: () => void Updates.reloadAsync(),
+        },
+      ]);
+    }
+  }, [updateAvailable]);
+
+  return updateAvailable;
+};

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -32,20 +32,20 @@ const updateAvailableDebounced = _.debounce(updateAvailable, UPDATE_REFRESH_INTE
 // - listen for appState changes (background/foreground)
 // - listen for network changes (offline/online)
 // - if the app is in the foreground and the network is online, check for updates
-// - if an update is available, alert the user and then reload the app
+// - if an update is available, update the status
 //
 // The checks are throttled to only happen every UPDATE_REFRESH_INTERVAL_MS
 //
-type UpdateStatus = 'idle' | 'checking-for-update' | 'update-available' | 'downloading-update' | 'update-downloaded';
-export const useEASUpdateChecker = () => {
-  const updateStatusRef = React.useRef<UpdateStatus>('idle');
-  const [updateStatusState, setUpdateStatusState] = React.useState<UpdateStatus>(updateStatusRef.current);
+type EASUpdateStatus = 'idle' | 'checking-for-update' | 'update-available' | 'downloading-update' | 'update-downloaded';
+export const useEASUpdateStatus = () => {
+  const updateStatusRef = React.useRef<EASUpdateStatus>('idle');
+  const [updateStatusState, setUpdateStatusState] = React.useState<EASUpdateStatus>(updateStatusRef.current);
   const appState = useAppState();
   const netInfo = useNetInfo();
 
   // Wrapper to keep the state value and the ref in sync
   const setUpdateStatus = useCallback(
-    (status: UpdateStatus) => {
+    (status: EASUpdateStatus) => {
       logger.debug('update status changed', {status});
       updateStatusRef.current = status;
       setUpdateStatusState(status);

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -24,7 +24,7 @@ const updateAvailable = async (): Promise<boolean> => {
 };
 
 // When returning to foreground, don't look for updates more frequently than every 5 minutes
-const UPDATE_REFRESH_INTERVAL_MS = 0; // 5 * 60 * 1000;
+const UPDATE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const updateAvailableDebounced = _.debounce(updateAvailable, UPDATE_REFRESH_INTERVAL_MS, {leading: true});
 
 // When this hook is mounted, it will do the following:

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -55,8 +55,6 @@ export const useEASUpdateStatus = () => {
         setUpdateStatus('checking-for-update');
         // the debounced method should block until the timeout elapses
         const updateAvailable = await checkUpdateAvailable();
-        // check again and make sure we're still in the idle state before
-        // changing to the update-available state
         if (updateAvailable) {
           setUpdateStatus('update-available');
         } else {

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -69,11 +69,11 @@ export const useEASUpdateStatus = () => {
         }
       }
     })();
-  }, [appState, netInfo, setUpdateStatus, updateStatusRef]);
+  }, [appState, netInfo, setUpdateStatus]);
 
   useEffect(() => {
     void (async () => {
-      if (updateStatusRef.current === 'update-available') {
+      if (updateStatusState === 'update-available') {
         logger.info('update available, downloading');
         setUpdateStatus('downloading-update');
         try {
@@ -86,7 +86,7 @@ export const useEASUpdateStatus = () => {
         }
       }
     })();
-  }, [updateStatusRef, setUpdateStatus]);
+  }, [updateStatusState, setUpdateStatus]);
 
   return updateStatusState;
 };

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -13,7 +13,7 @@ const checkUpdateAvailable = async (): Promise<boolean> => {
   try {
     const result = await Updates.checkForUpdateAsync();
     if (result.isAvailable) {
-      logger.info('update available, downloading');
+      logger.info('update available!');
       return true;
     }
   } catch (error) {
@@ -51,7 +51,7 @@ export const useEASUpdateStatus = () => {
   useEffect(() => {
     void (async () => {
       if (updateStatusRef.current === 'idle' && appState === 'active' && netInfo.isConnected && netInfo.isInternetReachable) {
-        logger.debug('appState changed to active, checking for updates');
+        logger.trace('appState changed to active, checking for updates');
         setUpdateStatus('checking-for-update');
         // the debounced method should block until the timeout elapses
         const updateAvailable = await checkUpdateAvailable();

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -62,7 +62,7 @@ export const useEASUpdateStatus = () => {
         const updateAvailable = (await updateAvailableDebounced()) || false;
         // check again and make sure we're still in the idle state before
         // changing to the update-available state
-        if (updateAvailable && updateStatusRef.current === 'idle') {
+        if (updateAvailable) {
           setUpdateStatus('update-available');
         } else {
           setUpdateStatus('idle');


### PR DESCRIPTION
This implements flow 3 of in-app updates (pictured below)
- we check for updates when (1) we come back to the foreground and (2) we're online
- if an update is available, we download it
- if the download succeeds, we throw up an alert and then apply the update

`useEASUpdateStatus` is the hook that manages the update state machine
`MapScreen` uses that hook to decide when to pop up an alert
`AboutScreen` was updated to display the update group id (which is the same for both Android and iOS, unlike the update ID) 

Debugging this was a PITA, because dev builds don't support Expo updates. While I was iterating, I ended up drawing a color-coded border around the main screen so I could see what state I was getting stuck in. That might be an interesting feature flag option, actually.

https://github.com/NWACus/avy/assets/101196/1ad93eaf-f01e-4157-8c23-28c9ad61d20f

![image](https://github.com/NWACus/avy/assets/101196/9d3aa348-8517-4b84-acd4-ecc0bd138546)
