### PR TITLE
Set Sentry and PostHog versions based on update build time

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import {ActivityIndicator, AppState, AppStateStatus, Image, Platform, StatusBar, StyleSheet, UIManager, useColorScheme, View} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 
+import * as Application from 'expo-application';
 import * as BackgroundFetch from 'expo-background-fetch';
 import Constants from 'expo-constants';
 import * as TaskManager from 'expo-task-manager';
@@ -65,7 +66,7 @@ import {formatRequestedTime, RequestedTime} from 'utils/date';
 import * as messages from 'compiled-lang/en.json';
 import {Center} from 'components/core';
 import KillSwitchMonitor from 'components/KillSwitchMonitor';
-import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
+import {getUpdateTimeAsVersionString} from 'hooks/useEASUpdateStatus';
 import {filterLoggedData} from 'logging/filterLoggedData';
 import {startupUpdateCheck, UpdateStatus} from 'Updates';
 
@@ -132,7 +133,12 @@ if (Sentry?.init) {
   } else {
     Sentry.init({
       dsn,
-      release: getUpdateGroupId(),
+      // Set the dist value to the app binary and build. This should not vary often.
+      // Example: 1.0.0 (54)
+      dist: `${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})`,
+      // Set the release to a version string based on the update build date (e.g. 2021.02.31.09.30).
+      // Then Sentry can clearly tell when versions are increasing.
+      release: getUpdateTimeAsVersionString(),
       enableInExpoDevelopment: Boolean(process.env.EXPO_PUBLIC_SENTRY_IN_DEV),
       enableWatchdogTerminationTracking: true,
       beforeSend: async (event, hint) => {

--- a/App.tsx
+++ b/App.tsx
@@ -65,6 +65,7 @@ import {formatRequestedTime, RequestedTime} from 'utils/date';
 import * as messages from 'compiled-lang/en.json';
 import {Center} from 'components/core';
 import KillSwitchMonitor from 'components/KillSwitchMonitor';
+import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {filterLoggedData} from 'logging/filterLoggedData';
 import {startupUpdateCheck, UpdateStatus} from 'Updates';
 
@@ -131,6 +132,7 @@ if (Sentry?.init) {
   } else {
     Sentry.init({
       dsn,
+      release: getUpdateGroupId(),
       enableInExpoDevelopment: Boolean(process.env.EXPO_PUBLIC_SENTRY_IN_DEV),
       enableWatchdogTerminationTracking: true,
       beforeSend: async (event, hint) => {

--- a/App.tsx
+++ b/App.tsx
@@ -134,8 +134,8 @@ if (Sentry?.init) {
     Sentry.init({
       dsn,
       // Set the dist value to the app binary and build. This should not vary often.
-      // Example: 1.0.0 (54)
-      dist: `${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})`,
+      // Example: 1.0.0.54
+      dist: `${Application.nativeApplicationVersion || '0.0.0'}.${Application.nativeBuildVersion || '0'}`,
       // Set the release to a version string based on the update build date (e.g. 2021.02.31.09.30).
       // Then Sentry can clearly tell when versions are increasing.
       release: getUpdateTimeAsVersionString(),

--- a/components/KillSwitchMonitor.tsx
+++ b/components/KillSwitchMonitor.tsx
@@ -13,6 +13,7 @@ import {Outcome} from 'components/content/Outcome';
 import {VStack} from 'components/core';
 import {BodyBlack} from 'components/text';
 import {useAppState} from 'hooks/useAppState';
+import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {logger} from 'logger';
 
 type KillSwitchMonitorProps = {
@@ -38,6 +39,7 @@ const KillSwitchMonitor: React.FC<KillSwitchMonitorProps> = ({children}) => {
           // Posthog automatically captures `Application.nativeBuildVersion` as `App Build`, but stores it as a string.
           // We additionally capture it as a number here, so that we can use < and > in feature flag rules.
           buildNumber: Number.parseInt(Application.nativeBuildVersion || '0'),
+          updateGroupId: getUpdateGroupId(),
           releaseChannel: Updates.releaseChannel,
         },
       });

--- a/components/KillSwitchMonitor.tsx
+++ b/components/KillSwitchMonitor.tsx
@@ -13,7 +13,7 @@ import {Outcome} from 'components/content/Outcome';
 import {VStack} from 'components/core';
 import {BodyBlack} from 'components/text';
 import {useAppState} from 'hooks/useAppState';
-import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
+import {getUpdateGroupId, getUpdateTimeAsVersionString} from 'hooks/useEASUpdateStatus';
 import {logger} from 'logger';
 
 type KillSwitchMonitorProps = {
@@ -40,6 +40,7 @@ const KillSwitchMonitor: React.FC<KillSwitchMonitorProps> = ({children}) => {
           // We additionally capture it as a number here, so that we can use < and > in feature flag rules.
           buildNumber: Number.parseInt(Application.nativeBuildVersion || '0'),
           updateGroupId: getUpdateGroupId(),
+          updateBuildTime: getUpdateTimeAsVersionString(),
           releaseChannel: Updates.releaseChannel,
         },
       });

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -13,12 +13,10 @@ import {Ionicons} from '@expo/vector-icons';
 import {ActionList} from 'components/content/ActionList';
 import {Center, HStack, View, VStack} from 'components/core';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
-import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
+import {getUpdateGroupId, getUpdateTimeAsVersionString} from 'hooks/useEASUpdateStatus';
 import {MenuStackParamList} from 'routes';
-import {toISOStringUTC} from 'utils/date';
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
-  const buildDate = Updates.createdAt || new Date();
   const [updateGroupId] = useState(getUpdateGroupId());
   return (
     <View style={StyleSheet.absoluteFillObject}>
@@ -47,7 +45,7 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
         <HStack space={4} px={32}>
           <VStack py={8} space={4}>
             <BodyXSm>
-              Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {toISOStringUTC(buildDate)} |{' '}
+              Avy version {Application.nativeApplicationVersion} ({Application.nativeBuildVersion}) | {getUpdateTimeAsVersionString()} |{' '}
               {(process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a').slice(0, 7)}
             </BodyXSm>
             {updateGroupId && (
@@ -66,7 +64,7 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
               void (async () => {
                 await Clipboard.setStringAsync(
                   `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
-Build date ${toISOStringUTC(buildDate)}
+Build date ${getUpdateTimeAsVersionString()}
 Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
 Update group ID ${updateGroupId} (channel: ${Updates.channel || 'development'})
 Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})`,

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -1,7 +1,5 @@
 import React, {useState} from 'react';
 
-import _ from 'lodash';
-
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {Platform, StyleSheet} from 'react-native';
 
@@ -15,16 +13,9 @@ import {Ionicons} from '@expo/vector-icons';
 import {ActionList} from 'components/content/ActionList';
 import {Center, HStack, View, VStack} from 'components/core';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
+import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {MenuStackParamList} from 'routes';
 import {toISOStringUTC} from 'utils/date';
-
-const getUpdateGroupId = (): string => {
-  const metadata: unknown = Updates.manifest?.metadata;
-  if (metadata && typeof metadata === 'object') {
-    return _.get(metadata, 'updateGroup', 'n/a');
-  }
-  return 'n/a';
-};
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
   const buildDate = Updates.createdAt || new Date();

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -8,6 +8,14 @@ import {logger as parentLogger} from 'logger';
 
 const logger = parentLogger.child({component: 'useEASUpdate'});
 
+export const getUpdateGroupId = (): string => {
+  const metadata: unknown = Updates.manifest?.metadata;
+  if (metadata && typeof metadata === 'object') {
+    return _.get(metadata, 'updateGroup', 'n/a');
+  }
+  return 'n/a';
+};
+
 const checkUpdateAvailable = async (): Promise<boolean> => {
   logger.trace('checking for updates');
   try {

--- a/hooks/useEASUpdateStatus.ts
+++ b/hooks/useEASUpdateStatus.ts
@@ -1,10 +1,13 @@
 import React, {useCallback, useEffect} from 'react';
 
+import _ from 'lodash';
+
 import * as Updates from 'expo-updates';
 
 import {useNetInfo} from '@react-native-community/netinfo';
 import {useAppState} from 'hooks/useAppState';
 import {logger as parentLogger} from 'logger';
+import {formatInTimeZone} from 'utils/date';
 
 const logger = parentLogger.child({component: 'useEASUpdate'});
 
@@ -14,6 +17,11 @@ export const getUpdateGroupId = (): string => {
     return _.get(metadata, 'updateGroup', 'n/a');
   }
   return 'n/a';
+};
+
+export const getUpdateTimeAsVersionString = (): string => {
+  const updateDate = Updates.createdAt || new Date();
+  return formatInTimeZone(updateDate, 'UTC', 'yyyy.MM.dd.HH.mm');
 };
 
 const checkUpdateAvailable = async (): Promise<boolean> => {


### PR DESCRIPTION
From the error reporting and tracking perspective, the update version is the really crucial thing we care about. App binary version is interesting, but far less important.

This PR makes that update version take primacy in Sentry, and exposes it in the about screen and in PostHog as well.

Here's the date string on the about page:

<img width="328" alt="image" src="https://github.com/NWACus/avy/assets/101196/16cf89b2-c76a-4812-9cc3-faf01dc2a3e3">

Here's the date string in the version data copied:

```
Avy version 2.29.6 (2.29.6)
Build date 2023.11.03.17.07
Git revision 11f1c99
Update group ID n/a (channel: development)
Update ID n/a (platform: ios)
```

Here's the date string showing up in PostHog as `updateBuildTime`:

<img width="693" alt="image" src="https://github.com/NWACus/avy/assets/101196/cf4eaddc-ab53-4390-987f-4121ba750800">

Here's the date string showing up in Sentry as `release`:

<img width="781" alt="image" src="https://github.com/NWACus/avy/assets/101196/d2d8fa58-61f3-49e9-8f53-1c3027b01312">
