### PR TITLE
Fix Android build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "expo-mail-composer": "~12.3.0",
     "expo-splash-screen": "~0.20.5",
     "expo-status-bar": "~1.6.0",
+    "expo-system-ui": "~2.4.0",
     "expo-updates": "~0.18.17",
     "expo-web-browser": "~12.3.2",
     "get-graphql-schema": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9119,6 +9119,14 @@ expo-structured-headers@~3.3.0:
   resolved "https://registry.yarnpkg.com/expo-structured-headers/-/expo-structured-headers-3.3.0.tgz#9f0b041a1d243a22a4a23d9eb19f02ace3c5258c"
   integrity sha512-t+h5Zqaukd3Tn97LaWPpibVsmiC/TFP8F+8sAUliwCSMzgcb5TATRs2NcAB+JcIr8EP3JJDyYXJrZle1cjs4mQ==
 
+expo-system-ui@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/expo-system-ui/-/expo-system-ui-2.4.0.tgz#bf809172726cf661ab4f526129eb427bb5f6e4d4"
+  integrity sha512-uaBAYeQtFzyE8WVcch2V3G243xvOf7vJkLzrIJ3rJ8NA3uZRmxF0lMMe75oMrAaLVXyr1Z+ZE6UZwh7x49FuIg==
+  dependencies:
+    "@react-native/normalize-color" "^2.0.0"
+    debug "^4.3.2"
+
 expo-task-manager@~11.3.0:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/expo-task-manager/-/expo-task-manager-11.3.0.tgz#880ad617f4c0c92ad5bb5025debc4ad855955427"


### PR DESCRIPTION
This warning is SUPER buried and might not even be a problem, but you can see it in our Android build logs in the cloud:

<img width="911" alt="image" src="https://github.com/NWACus/avy/assets/101196/7eae654d-51d1-4aa8-a1a3-d58215c1b716">
