### PR TITLE
Update obs placeholder text, remove unnecessary style support from TextField

### DIFF
--- a/components/form/TextField.tsx
+++ b/components/form/TextField.tsx
@@ -1,6 +1,5 @@
 import {View, ViewProps, VStack} from 'components/core';
 import {BodySmBlack, BodyXSm} from 'components/text';
-import {merge} from 'lodash';
 import React from 'react';
 import {useController} from 'react-hook-form';
 import {View as RNView, TextInput, TextInputProps} from 'react-native';
@@ -11,7 +10,7 @@ export type KeysMatching<T, V> = {[K in keyof T]-?: T[K] extends V ? K : never}[
 interface TextFieldProps extends ViewProps {
   name: string;
   label: string;
-  textInputProps?: TextInputProps;
+  textInputProps?: Omit<TextInputProps, 'style'>;
   disabled?: boolean;
 }
 
@@ -21,27 +20,25 @@ const textInputDefaultStyle = {
   fontFamily: 'Lato_400Regular',
 };
 
-export const TextField = React.forwardRef<RNView, TextFieldProps>(
-  ({name, label, textInputProps: {style: textInputStyle, ...otherTextInputProps} = {}, disabled, ...props}, ref) => {
-    const {field, fieldState} = useController({name});
-    return (
-      <VStack width="100%" space={4} {...props} ref={ref}>
-        <BodySmBlack>{label}</BodySmBlack>
-        <View p={8} borderWidth={2} borderColor={colorLookup('border.base')} borderRadius={4}>
-          <TextInput
-            onBlur={field.onBlur}
-            onChangeText={field.onChange}
-            value={field.value as string} // TODO(skuznets): determine why the generics here don't collapse to string itself ...
-            style={merge({}, textInputDefaultStyle, textInputStyle)}
-            placeholderTextColor={colorLookup('text.secondary')}
-            editable={!disabled}
-            {...otherTextInputProps}
-          />
-        </View>
-        {/* TODO: animate the appearance/disappearance of the error string */}
-        {fieldState.error && <BodyXSm color={colorLookup('error.900')}>{fieldState.error.message}</BodyXSm>}
-      </VStack>
-    );
-  },
-);
+export const TextField = React.forwardRef<RNView, TextFieldProps>(({name, label, textInputProps = {}, disabled, ...props}, ref) => {
+  const {field, fieldState} = useController({name});
+  return (
+    <VStack width="100%" space={4} {...props} ref={ref}>
+      <BodySmBlack>{label}</BodySmBlack>
+      <View p={8} borderWidth={2} borderColor={colorLookup('border.base')} borderRadius={4}>
+        <TextInput
+          onBlur={field.onBlur}
+          onChangeText={field.onChange}
+          value={field.value as string} // TODO(skuznets): determine why the generics here don't collapse to string itself ...
+          style={textInputDefaultStyle}
+          placeholderTextColor={colorLookup('text.tertiary')}
+          editable={!disabled}
+          {...textInputProps}
+        />
+      </View>
+      {/* TODO: animate the appearance/disappearance of the error string */}
+      {fieldState.error && <BodyXSm color={colorLookup('error.900')}>{fieldState.error.message}</BodyXSm>}
+    </VStack>
+  );
+});
 TextField.displayName = 'TextField';

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -489,11 +489,12 @@ export const SimpleForm: React.FC<{
                           }
                         }}
                         textInputProps={{
-                          placeholder: `• Signs of instability
-• Snowpack test results
+                          placeholder: `• Signs of instability?
+• Amount of new snow/total snow?
+• Weather observations?
+• Snowpack test results?
 • How cautiously or aggressively did you travel?
-• Weather observations
-• Overall impression of stability`,
+• Overall impression of stability?`,
                           multiline: true,
                         }}
                         disabled={disableFormControls}


### PR DESCRIPTION
View this diff with whitespace changes ignored. 

Updates placeholder text to the blessed version. Removes support for `style` on TextInputProps. Updates placeholder text color to look less like actual text:

before | after
--- | ---
![image](https://github.com/NWACus/avy/assets/101196/229321be-9004-4222-8e85-74c2ec6a9b1c) | ![image](https://github.com/NWACus/avy/assets/101196/899cf06e-a613-435c-9ca5-3e1df0999de3)
