### PR TITLE
Add option to pause at startup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -72,3 +72,8 @@ EXPO_PUBLIC_POSTHOG_API_KEY=
 # Render cluster ids on the weather station map, useful for adjusting params
 #
 # EXPO_PUBLIC_WEATHER_STATION_MAP_CLUSTER_DEBUG=1
+
+#
+# Pause the app on startup to so a profiler can be attached. Disabled by default.
+#
+# EXPO_PUBLIC_PAUSE_ON_STARTUP=true

--- a/App.tsx
+++ b/App.tsx
@@ -65,9 +65,12 @@ import {formatRequestedTime, RequestedTime} from 'utils/date';
 
 import {TRACE} from 'browser-bunyan';
 import * as messages from 'compiled-lang/en.json';
-import {Center} from 'components/core';
+import {Button} from 'components/content/Button';
+import {Center, VStack} from 'components/core';
 import KillSwitchMonitor from 'components/KillSwitchMonitor';
+import {Body, BodyBlack, Title3Black} from 'components/text';
 import {getUpdateTimeAsVersionString} from 'hooks/useEASUpdateStatus';
+import {useToggle} from 'hooks/useToggle';
 import {filterLoggedData} from 'logging/filterLoggedData';
 import {startupUpdateCheck, UpdateStatus} from 'Updates';
 
@@ -360,6 +363,8 @@ const BaseApp: React.FunctionComponent<{
       });
   }, [setUpdateStatus, logger]);
 
+  const [startupPaused, {off: unpauseStartup}] = useToggle(process.env.EXPO_PUBLIC_PAUSE_ON_STARTUP === 'true');
+
   if (!fontsLoaded || updateStatus !== 'ready') {
     // Here, we render a view that looks exactly like the splash screen but now has an activity indicator
     return (
@@ -384,6 +389,21 @@ const BaseApp: React.FunctionComponent<{
           <ActivityIndicator size="large" style={{marginTop: 200}} />
         </Center>
       </View>
+    );
+  }
+
+  if (startupPaused) {
+    return (
+      <Center bg="magenta" width="100%" height="100%" justifyContent="center" alignItems="center" px={64}>
+        <VStack space={16}>
+          <Title3Black>Waiting for startup delay...</Title3Black>
+          <Body>You’re seeing this because EXPO_PUBLIC_PAUSE_ON_STARTUP is set.</Body>
+          <Body>Attach your profiler now.</Body>
+          <Button onPress={unpauseStartup} buttonStyle="primary">
+            <BodyBlack>Let’s go</BodyBlack>
+          </Button>
+        </VStack>
+      </Center>
     );
   }
 


### PR DESCRIPTION
It's impossible to profile the first map render without adding some kind of delay. Every time you restart the app, connections are broken between the app and the dev tools, and the app gets to the map before you can reconnect them.

With this PR, you can set `EXPO_PUBLIC_PAUSE_ON_STARTUP` and the app will render a fullscreen view until you're ready to proceed:

![Simulator Screenshot - iPhone 14 Pro Max - 2023-11-06 at 11 29 06](https://github.com/NWACus/avy/assets/101196/6d9fcbd8-15d8-4d2c-90f2-457f36672a68)
