### PR TITLE
Add screen tracking and user ID to Mixpanel

### DIFF
--- a/Preferences.tsx
+++ b/Preferences.tsx
@@ -4,6 +4,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {merge} from 'lodash';
 import React, {createContext, ReactNode, useContext, useEffect, useState} from 'react';
+import uuid from 'react-native-uuid';
 import * as Sentry from 'sentry-expo';
 import {useAsyncEffect} from 'use-async-effect';
 import {z} from 'zod';
@@ -15,6 +16,10 @@ const preferencesSchema = z.object({
   center: avalancheCenterIDSchema.default('NWAC'),
   hasSeenCenterPicker: z.boolean().default(false),
   secretMenuCollapsed: z.boolean().default(true),
+  mixpanelUserId: z
+    .string()
+    .uuid()
+    .default(uuid.v4() as string),
 });
 
 export type Preferences = z.infer<typeof preferencesSchema>;

--- a/mixpanel.ts
+++ b/mixpanel.ts
@@ -1,4 +1,8 @@
+import * as Application from 'expo-application';
+
 import ExpoMixpanelAnalytics from '@bothrs/expo-mixpanel-analytics';
+
+import {getUpdateGroupId, getUpdateTimeAsVersionString} from 'hooks/useEASUpdateStatus';
 import {logger as globalLogger} from 'logger';
 
 const logger = globalLogger.child({module: 'mixpanel'});
@@ -76,5 +80,12 @@ const initialize = (): ExpoMixpanelAnalytics => {
 };
 
 const mixpanel = initialize();
+mixpanel.register({
+  update_group_id: getUpdateGroupId(),
+  update_version: getUpdateTimeAsVersionString(),
+  application_version: Application.nativeApplicationVersion || 'n/a',
+  application_build: Application.nativeBuildVersion || 'n/a',
+  git_revision: process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a',
+});
 
 export default mixpanel;


### PR DESCRIPTION
- Create an analytics ID for each install and store it in preferences
- Track screen visits