### PR TITLE
Straighten out mixpanel IP address stuff

### DIFF
--- a/mixpanel.ts
+++ b/mixpanel.ts
@@ -49,10 +49,7 @@ class MixpanelWrapper {
     this._enqueue(() => {
       const augmentedProps = {
         ...props,
-        // Mixpanel has a bug in their HTTP API: you have to send both `ip` and `$ip` or geolocation will not work.
-        // Reported this to support, no idea if they'll fix it.
         ip: this._ipAddress,
-        $ip: this._ipAddress,
         offline,
       };
       logger.debug('track', {name, props: augmentedProps});


### PR DESCRIPTION
You have to attach `ip` but you should not expect to see it show up directly in your events.

> As you've discovered, in order to enrich your events with geolocation data, you need to track an ip event property on your event. Mixpanel will use the  ip address in order to grab geolocation data. However, Mixpanel drops the ip address at ingestion and does not store it at rest to protect a user's privacy. (IP address can be considered PII in some countries so we avoid storing that altogether)

Confirmed this event showed up with geolocation data set, but no visible IP address:

<img width="1168" alt="image" src="https://github.com/NWACus/avy/assets/101196/f5ee12b4-d773-44ea-bf75-c633cd2d0efe">
