### PR TITLE
Version Policy Updates

### DIFF
--- a/.github/workflows/publish-build.yaml
+++ b/.github/workflows/publish-build.yaml
@@ -1,10 +1,6 @@
 name: publish-build
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - preview
-      - release
 
 defaults:
   run:

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - preview
-      # - release
+        - release
       - main
 
 defaults:

--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -1,11 +1,6 @@
 name: publish-update
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - preview
-        - release
-      - main
 
 defaults:
   run:

--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
       "backgroundColor": "#152E57"
     },
     "runtimeVersion": {
-      "policy": "sdkVersion"
+      "policy": "appVersion"
     },
     "jsEngine": "hermes",
     "updates": {


### PR DESCRIPTION
app.json: set runtime version policy

Our app contains dependencies outside of the Expo SDK which ship native
code. Therefore, we will be diligent to bump the runtime version of the
app whenever one of those dependencies changes. We futhermore require
that updates we ship only target the version of the app that they were
built on top of, to ensure that users on older native versions do not
receive OTA updates that are incompatible with their native layer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

.github: turn on OTA update publishing for release branch

We turned this off when we had to update code in the release branch that
changed native code but did not yet have a mechanism to conditionally
build OTA bundles only when no native code changed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

