### PR TITLE
.github: bring update publishing in line with builds

### DIFF
--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -7,11 +7,7 @@ defaults:
     shell: bash
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yaml # use the callable ci job to run CI checks
-
   publish-update-bundle:
-    needs: [ci]
     runs-on: ubuntu-latest
     env:
       SENTRY_AUTH_TOKEN: $ {{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
We don't need to run CI before publishing OTA updates any more than we need to run it before publishing binary builds - only passing PRs can merge into the branch in the first place, so this is not useful.