### PR TITLE
observations: send errors from ImagePicker to Sentry

### DIFF
--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -10,6 +10,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {FieldErrors, FormProvider, useForm, useWatch} from 'react-hook-form';
 import {ColorValue, KeyboardAvoidingView, Platform, View as RNView, ScrollView, findNodeHandle} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import * as Sentry from 'sentry-expo';
 
 import {ClientContext, ClientProps} from 'clientContext';
 import {Button} from 'components/content/Button';
@@ -124,6 +125,7 @@ export const SimpleForm: React.FC<{
         }
       } catch (error) {
         logger.error('ImagePicker error', {error});
+        Sentry.Native.captureMessage(`ImagePicker encountered an error: ${JSON.stringify(error)}`);
         // Are we offline? Things might be ok if they go online again.
         const {networkStatus} = getUploader().getState();
         Toast.show({


### PR DESCRIPTION
If we only log these errors, there is no visibility into what's happening.