### PR TITLE
Support `specific` instability distribution

### DIFF
--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -457,6 +457,7 @@ export const SimpleForm: React.FC<{
                           label="How widespread was the cracking?"
                           items={[
                             {value: InstabilityDistribution.Isolated, label: 'Isolated'},
+                            {value: InstabilityDistribution.Specific, label: 'Specific'},
                             {value: InstabilityDistribution.Widespread, label: 'Widespread'},
                           ]}
                           prompt=" "

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -765,6 +765,7 @@ export const FormatDangerConfidence = (value: DangerConfidence): string => {
 };
 export const InstabilityDistribution = {
   Isolated: 'isolated',
+  Specific: 'specific',
   Widespread: 'widespread',
   Low: 'low',
 } as const;


### PR DESCRIPTION
This was causing parse errors, which in turn led the obs list to not load.

This is a NAC form option that we never supported:

<img width="438" alt="image" src="https://github.com/NWACus/avy/assets/101196/1bbf701e-71c1-4d18-a24d-ed14f3f9e1d1">
