### PR TITLE
Remove `organization` from uploaded obs

### DIFF
--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -212,7 +212,6 @@ export class ObservationUploader {
           extraData: {
             url,
             center_id,
-            organization: center_id,
             observer_type: 'public',
             media: [],
           },

--- a/components/observations/uploader/Task.ts
+++ b/components/observations/uploader/Task.ts
@@ -41,7 +41,6 @@ const taskQueueEntrySchema = z.discriminatedUnion('type', [
       extraData: z.object({
         url: z.string().url(),
         center_id: avalancheCenterIDSchema,
-        organization: avalancheCenterIDSchema,
         observer_type: z.literal('public'),
         media: z.array(mediaItemSchema),
       }),

--- a/components/observations/uploader/Task.ts
+++ b/components/observations/uploader/Task.ts
@@ -41,6 +41,7 @@ const taskQueueEntrySchema = z.discriminatedUnion('type', [
       extraData: z.object({
         url: z.string().url(),
         center_id: avalancheCenterIDSchema,
+        organization: avalancheCenterIDSchema.optional(),
         observer_type: z.literal('public'),
         media: z.array(mediaItemSchema),
       }),


### PR DESCRIPTION
Fixes #586. Note that the schema change is backwards compatible, in case someone has a pending task persisted on disk with an `organization` field in it.