### PR TITLE
Sticky headers on the weather table

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -92,3 +92,8 @@ EXPO_PUBLIC_MIXPANEL_TOKEN=
 # Initialize with Tamagui support. Disabled by default.
 #
 # EXPO_PUBLIC_TAMAGUI_ENABLED=true
+
+#
+# Enable the new weather data table implementation. See also the feature flag `new-weather-table`
+#
+# EXPO_PUBLIC_NEW_WEATHER_TABLE=false

--- a/components/content/DataGrid.tsx
+++ b/components/content/DataGrid.tsx
@@ -1,0 +1,153 @@
+import React, {useRef} from 'react';
+import {Animated} from 'react-native';
+
+import {View} from 'components/core';
+
+interface DataGridProps<ItemT, RowT, ColT> {
+  data: ItemT[][];
+  columnHeaderData: ColT[];
+  rowHeaderData: RowT[];
+
+  columnWidths: number[];
+  rowHeights: number[];
+
+  renderCell: (renderData: {item: ItemT; rowIndex: number; columnIndex: number}) => React.ReactNode;
+  renderRowHeader: (renderData: {item: RowT; rowIndex: number}) => React.ReactNode;
+  renderColumnHeader: (renderData: {item: ColT; columnIndex: number}) => React.ReactNode;
+  renderCornerHeader: () => React.ReactNode;
+}
+
+export function DataGrid<ItemT, RowT, ColT>({
+  data,
+  columnWidths,
+  rowHeights,
+  renderCell,
+  rowHeaderData,
+  renderRowHeader,
+  columnHeaderData,
+  renderColumnHeader,
+  renderCornerHeader,
+}: DataGridProps<ItemT, RowT, ColT>) {
+  const width = columnWidths.reduce((a, b) => a + b, 0);
+  const height = rowHeights.reduce((a, b) => a + b, 0);
+  const columns = columnWidths.length - 1;
+  const rows = rowHeights.length - 1;
+  const scrollX = useRef(new Animated.Value(0)).current;
+  const scrollY = useRef(new Animated.Value(0)).current;
+  const headerHeight = rowHeights[0];
+  const headerWidth = columnWidths[0];
+
+  return (
+    <Animated.ScrollView
+      horizontal
+      bounces={false}
+      style={{width: '100%', height: '100%'}}
+      // snapToOffsets={columnWidths.slice(1)}
+      onScroll={Animated.event(
+        [
+          {
+            nativeEvent: {
+              contentOffset: {
+                x: scrollX,
+              },
+            },
+          },
+        ],
+        {useNativeDriver: true},
+      )}
+      scrollEventThrottle={1}>
+      <Animated.ScrollView
+        bounces={false}
+        style={{width: '100%', height: '100%'}}
+        // snapToOffsets={rowHeights.slice(1)}
+        onScroll={Animated.event(
+          [
+            {
+              nativeEvent: {
+                contentOffset: {
+                  y: scrollY,
+                },
+              },
+            },
+          ],
+          {useNativeDriver: true},
+        )}
+        scrollEventThrottle={1}>
+        <View style={{width: width, height: height}}>
+          {new Array(rows).fill(0).map((_, rowIndex) =>
+            new Array(columns).fill(0).map((_, columnIndex) => (
+              <View
+                key={`${rowIndex}-${columnIndex}`}
+                style={{
+                  width: columnWidths[columnIndex + 1],
+                  height: rowHeights[rowIndex + 1],
+                  position: 'absolute',
+                  top: rowHeights[0] + rowHeights.slice(1, rowIndex + 1).reduce((a, b) => a + b, 0),
+                  left: columnWidths[0] + columnWidths.slice(1, columnIndex + 1).reduce((a, b) => a + b, 0),
+                }}>
+                {renderCell({item: data[rowIndex][columnIndex], rowIndex, columnIndex})}
+              </View>
+            )),
+          )}
+          <Animated.View
+            style={{
+              width: width - columnWidths[0],
+              height: rowHeights[0],
+              position: 'absolute',
+              top: 0,
+              left: headerWidth, // Animated.add(scrollX, rowHeaderWidth),
+              flexDirection: 'row',
+              justifyContent: 'flex-start',
+              alignItems: 'center',
+              transform: [{translateY: scrollY}],
+            }}>
+            {columnHeaderData.map((item, columnIndex) => (
+              <View
+                key={columnIndex}
+                style={{
+                  width: columnWidths[columnIndex + 1],
+                  height: rowHeights[0],
+                }}>
+                {renderColumnHeader({item, columnIndex})}
+              </View>
+            ))}
+          </Animated.View>
+          <Animated.View
+            style={{
+              width: columnWidths[0],
+              height: height - rowHeights[0],
+              position: 'absolute',
+              top: headerHeight, // Animated.add(scrollY, columnHeaderHeight),
+              left: 0,
+              flexDirection: 'column',
+              justifyContent: 'flex-start',
+              alignItems: 'stretch',
+              transform: [{translateX: scrollX}],
+            }}>
+            {rowHeaderData.map((item, rowIndex) => (
+              <View
+                key={rowIndex}
+                style={{
+                  width: columnWidths[0],
+                  height: rowHeights[rowIndex + 1],
+                }}>
+                {renderRowHeader({item, rowIndex})}
+              </View>
+            ))}
+          </Animated.View>
+          <Animated.View
+            style={{
+              width: headerWidth,
+              height: headerHeight,
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              transform: [{translateX: scrollX}, {translateY: scrollY}],
+            }}>
+            {renderCornerHeader()}
+          </Animated.View>
+        </View>
+      </Animated.ScrollView>
+    </Animated.ScrollView>
+  );
+}

--- a/components/content/DataGrid.tsx
+++ b/components/content/DataGrid.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import {Animated} from 'react-native';
+import {Animated, useWindowDimensions} from 'react-native';
 
 import {View} from 'components/core';
 
@@ -19,8 +19,8 @@ interface DataGridProps<ItemT, RowT, ColT> {
 
 export function DataGrid<ItemT, RowT, ColT>({
   data,
-  columnWidths,
-  rowHeights,
+  columnWidths: unscaledColumnWidths,
+  rowHeights: unscaledRowHeights,
   renderCell,
   rowHeaderData,
   renderRowHeader,
@@ -28,6 +28,10 @@ export function DataGrid<ItemT, RowT, ColT>({
   renderColumnHeader,
   renderCornerHeader,
 }: DataGridProps<ItemT, RowT, ColT>) {
+  const fontScale = useWindowDimensions().fontScale;
+  const columnWidths = unscaledColumnWidths.map(width => Math.round(width * fontScale));
+  const rowHeights = unscaledRowHeights.map(height => Math.round(height * fontScale));
+
   const width = columnWidths.reduce((a, b) => a + b, 0);
   const height = rowHeights.reduce((a, b) => a + b, 0);
   const scrollX = useRef(new Animated.Value(0)).current;

--- a/components/core/Center.tsx
+++ b/components/core/Center.tsx
@@ -2,7 +2,7 @@ import {merge} from 'lodash';
 import * as React from 'react';
 
 import {View, ViewProps} from 'components/core/View';
-import {Animated, ViewStyle} from 'react-native';
+import {ViewStyle} from 'react-native';
 
 const baseStyle: ViewStyle = {
   display: 'flex',
@@ -20,6 +20,3 @@ export const Center: React.FC<ViewProps> = ({children, style: originalStyle = {}
   );
 };
 Center.displayName = 'Center';
-
-export const AnimatedCenter = Animated.createAnimatedComponent(Center);
-AnimatedCenter.displayName = 'AnimatedCenter';

--- a/components/core/Center.tsx
+++ b/components/core/Center.tsx
@@ -2,7 +2,7 @@ import {merge} from 'lodash';
 import * as React from 'react';
 
 import {View, ViewProps} from 'components/core/View';
-import {ViewStyle} from 'react-native';
+import {Animated, ViewStyle} from 'react-native';
 
 const baseStyle: ViewStyle = {
   display: 'flex',
@@ -19,3 +19,7 @@ export const Center: React.FC<ViewProps> = ({children, style: originalStyle = {}
     </View>
   );
 };
+Center.displayName = 'Center';
+
+export const AnimatedCenter = Animated.createAnimatedComponent(Center);
+AnimatedCenter.displayName = 'AnimatedCenter';

--- a/components/core/HStack.tsx
+++ b/components/core/HStack.tsx
@@ -2,7 +2,7 @@ import {merge} from 'lodash';
 import * as React from 'react';
 
 import {View, ViewProps} from 'components/core/View';
-import {Animated, ViewStyle} from 'react-native';
+import {ViewStyle} from 'react-native';
 
 const baseStyle: ViewStyle = {
   flexDirection: 'row',
@@ -26,6 +26,3 @@ export const HStack: React.FC<HStackProps> = ({children, style: originalStyle = 
   );
 };
 HStack.displayName = 'HStack';
-
-export const AnimatedHStack = Animated.createAnimatedComponent(HStack);
-AnimatedHStack.displayName = 'AnimatedHStack';

--- a/components/core/HStack.tsx
+++ b/components/core/HStack.tsx
@@ -2,7 +2,7 @@ import {merge} from 'lodash';
 import * as React from 'react';
 
 import {View, ViewProps} from 'components/core/View';
-import {ViewStyle} from 'react-native';
+import {Animated, ViewStyle} from 'react-native';
 
 const baseStyle: ViewStyle = {
   flexDirection: 'row',
@@ -25,3 +25,7 @@ export const HStack: React.FC<HStackProps> = ({children, style: originalStyle = 
     </View>
   );
 };
+HStack.displayName = 'HStack';
+
+export const AnimatedHStack = Animated.createAnimatedComponent(HStack);
+AnimatedHStack.displayName = 'AnimatedHStack';

--- a/components/core/VStack.tsx
+++ b/components/core/VStack.tsx
@@ -2,7 +2,7 @@ import {merge} from 'lodash';
 import * as React from 'react';
 
 import {View, ViewProps} from 'components/core/View';
-import {View as RNView, ViewStyle} from 'react-native';
+import {Animated, View as RNView, ViewStyle} from 'react-native';
 
 const baseStyle: ViewStyle = {
   flexDirection: 'column',
@@ -26,3 +26,6 @@ export const VStack = React.forwardRef<RNView, VStackProps>(({children, style: o
   );
 });
 VStack.displayName = 'VStack';
+
+export const AnimatedVStack = Animated.createAnimatedComponent(VStack);
+AnimatedVStack.displayName = 'AnimatedVStack';

--- a/components/core/VStack.tsx
+++ b/components/core/VStack.tsx
@@ -2,7 +2,7 @@ import {merge} from 'lodash';
 import * as React from 'react';
 
 import {View, ViewProps} from 'components/core/View';
-import {Animated, View as RNView, ViewStyle} from 'react-native';
+import {View as RNView, ViewStyle} from 'react-native';
 
 const baseStyle: ViewStyle = {
   flexDirection: 'column',
@@ -26,6 +26,3 @@ export const VStack = React.forwardRef<RNView, VStackProps>(({children, style: o
   );
 });
 VStack.displayName = 'VStack';
-
-export const AnimatedVStack = Animated.createAnimatedComponent(VStack);
-AnimatedVStack.displayName = 'AnimatedVStack';

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {View as RNView, ViewProps as RNViewProps, ViewStyle as RNViewStyle} from 'react-native';
+import {Animated, View as RNView, ViewProps as RNViewProps, ViewStyle as RNViewStyle} from 'react-native';
 
 import {colorLookup} from 'theme';
 
@@ -181,4 +181,7 @@ export const View = React.forwardRef<RNView, ViewProps>(({children, style = {}, 
     </RNView>
   );
 });
-View.displayName = 'View';
+View.displayName = 'AvyViewWrapper';
+
+export const AnimatedView = Animated.createAnimatedComponent(View);
+AnimatedView.displayName = 'AnimatedAvyViewWrapper';

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {Animated, View as RNView, ViewProps as RNViewProps, ViewStyle as RNViewStyle} from 'react-native';
+import {View as RNView, ViewProps as RNViewProps, ViewStyle as RNViewStyle} from 'react-native';
 
 import {colorLookup} from 'theme';
 
@@ -182,6 +182,3 @@ export const View = React.forwardRef<RNView, ViewProps>(({children, style = {}, 
   );
 });
 View.displayName = 'AvyViewWrapper';
-
-export const AnimatedView = Animated.createAnimatedComponent(View);
-AnimatedView.displayName = 'AnimatedAvyViewWrapper';

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -329,11 +329,11 @@ function NewWeatherDataTable({columns: columnsWithTime, timeseries}: {columns: c
         bg="blue2"
         borderBottomWidth={1}
         borderColor={colorLookup('text.tertiary')}>
-        <BodyXSmBlack color="white">Time</BodyXSmBlack>
-        <BodyXSmBlack color="white">PST</BodyXSmBlack>
+        <BodyXSmBlack color="white">{formatVariable(times.variable)}</BodyXSmBlack>
+        <BodyXSmBlack color="white">{formatUnits(times.variable, timeseries.UNITS)}</BodyXSmBlack>
       </VStack>
     ),
-    [],
+    [times.variable, timeseries.UNITS],
   );
 
   const columnHeaderData = useMemo(

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -168,6 +168,7 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
     return result;
   }, [tableColumns, times]);
 
+  // Passed to DataGrid to render an individual cell
   const renderCell = useCallback(
     ({rowIndex, item}: {rowIndex: number; item: string}) => (
       <Center flex={1} backgroundColor={colorLookup(rowIndex % 2 ? 'light.100' : 'light.300')}>
@@ -176,6 +177,8 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
     ),
     [],
   );
+
+  // Passed to DataGrid to render an individual row header (in this case, the time)
   const renderRowHeader = useCallback(
     ({item, rowIndex}: {rowIndex: number; item: string}) => (
       <Center flex={1} backgroundColor={colorLookup(rowIndex % 2 ? 'light.100' : 'light.300')} borderRightWidth={1} borderColor={colorLookup('text.tertiary')}>
@@ -184,6 +187,8 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
     ),
     [],
   );
+
+  // Passed to DataGrid to render an individual column header (in this case, the label, units and elevation)
   const renderColumnHeader = useCallback(
     ({
       item: {name, units, elevation},
@@ -210,6 +215,8 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
     ),
     [],
   );
+
+  // Passed to DataGrid to render the top-left corner cell. Shows the "Time" label and "PST" units
   const renderCornerHeader = useCallback(
     () => (
       <VStack
@@ -370,7 +377,7 @@ export const WeatherStationsDetail: React.FC<Props> = ({center_id, name, station
         {timeseries.STATION.length === 0 ? <Body>No data found.</Body> : <TimeSeriesTable timeSeries={timeseries} />}
         {/* TODO(skuznets): For some reason, the table is running off the bottom of the view, and I just don't have time to keep debugging this.
              Adding the placeholder here does the trick. :dizzy_face: */}
-        <View height={72} />
+        <View height={16} />
       </VStack>
     </VStack>
   );

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -78,6 +78,7 @@ const shortUnitsMap: Record<string, string> = {
   inches: 'in',
   degrees: 'deg',
   millibar: 'mbar',
+  'MJ/m**2': 'MJ/m²',
 };
 
 const shortUnits = (units: string): string => shortUnitsMap[units] || units;
@@ -247,7 +248,7 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
           elevation: column.elevation?.toString() || '',
         }))}
         rowHeaderData={times.map(time => formatDateTime(time))}
-        columnWidths={[70, ...tableColumns.map(({field}) => (shortFieldMap[field].length > 4 ? 50 : 40))]}
+        columnWidths={[70, ...tableColumns.map(({field}) => (Math.max(shortFieldMap[field].length, shortUnits(timeSeries.UNITS[field]).length) > 4 ? 50 : 40))]}
         rowHeights={[60, ...times.map(() => 30)]}
         renderCell={renderCell}
         renderRowHeader={renderRowHeader}

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -247,7 +247,7 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
           elevation: column.elevation?.toString() || '',
         }))}
         rowHeaderData={times.map(time => formatDateTime(time))}
-        columnWidths={[75, ...tableColumns.map(() => 50)]}
+        columnWidths={[70, ...tableColumns.map(({field}) => (shortFieldMap[field].length > 4 ? 50 : 40))]}
         rowHeights={[60, ...times.map(() => 30)]}
         renderCell={renderCell}
         renderRowHeader={renderRowHeader}

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -1,19 +1,19 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
-
-import {uniq} from 'lodash';
+import React, {useCallback, useMemo, useState} from 'react';
+import {ScrollView} from 'react-native';
 
 import {useNavigation} from '@react-navigation/native';
+import {compareDesc, format} from 'date-fns';
+import {uniq} from 'lodash';
+import {useFeatureFlag} from 'posthog-react-native';
+
 import {ButtonBar} from 'components/content/ButtonBar';
 import {DataGrid} from 'components/content/DataGrid';
 import {InfoTooltip} from 'components/content/InfoTooltip';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {Center, Divider, HStack, View, VStack} from 'components/core';
 import {Body, BodyBlack, bodySize, BodyXSm, BodyXSmBlack} from 'components/text';
-import {compareDesc, format} from 'date-fns';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useWeatherStationTimeseries} from 'hooks/useWeatherStationTimeseries';
-import {useFeatureFlag} from 'posthog-react-native';
-import {ScrollView} from 'react-native';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, StationNote, WeatherStationSource, WeatherStationTimeseries} from 'types/nationalAvalancheCenter';
 import {parseRequestedTimeString, RequestedTimeString, utcDateToLocalDateString} from 'utils/date';
@@ -129,7 +129,7 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
     [tableColumns],
   );
 
-  useEffect(() => {
+  useMemo(() => {
     // Compute an accumulated precipitation column if we have hourly precipitation data
     const precip = tableColumns.find(column => column.field === 'precip_accum_one_hour');
     if (precip) {


### PR DESCRIPTION
This PR changes the weather table - not massively, but noticeably. The new behavior is **off by default** but can be enabled in two ways:
1. set `EXPO_PUBLIC_NEW_WEATHER_TABLE=true` in your `.env` file while developing
2. or flip the `new-weather-table` feature flag in posthog

The changes are:
1. row and column headers are sticky
2. ~column widths are uniform. This might not be a long-term requirement, but it's definitely gonna be more challenging to make the column header widths line up with the data widths when they're no longer lined up in a single `VStack`.~ now applying a rough heuristic size based on label length

Marking as draft for now, I want to do a little more side-by-side testing. Feel free to give feedback/ask questions though.

Still TODO:
- [x] support font scaling
- [x] use same approach for NAC weather data table

before | after 
--- | ---
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-11-28 at 12 13 15](https://github.com/NWACus/avy/assets/101196/238d7451-5deb-487f-932c-1ce70e51b78f) | ![Simulator Screen Recording - iPhone 14 Pro Max - 2023-11-28 at 12 12 39](https://github.com/NWACus/avy/assets/101196/c053b86c-987d-4260-a12f-8e3b93156398)

