### PR TITLE
avalancheCenters: only fetch the metadata we need

### DIFF
--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -20,8 +20,8 @@ export const AvalancheCenterSelector: React.FunctionComponent<{
   const route = useRoute<NativeStackScreenProps<MenuStackParamList, 'avalancheCenterSelector'>['route']>();
   const capabilitiesResult = useAvalancheCenterCapabilities();
   const capabilities = capabilitiesResult.data;
-  const metadataResults = useAllAvalancheCenterMetadata(capabilities);
-  const availableCenters = route.params.debugMode ? AvalancheCenters.AllCenters : AvalancheCenters.SupportedCenters;
+  const whichCenters = route.params.debugMode ? AvalancheCenters.AllCenters : AvalancheCenters.SupportedCenters;
+  const metadataResults = useAllAvalancheCenterMetadata(capabilities, whichCenters);
   const setAvalancheCenterWrapper = React.useCallback(
     (center: AvalancheCenterID) => {
       setAvalancheCenter(center);
@@ -51,7 +51,7 @@ export const AvalancheCenterSelector: React.FunctionComponent<{
       <AvalancheCenterList
         selectedCenter={currentCenterId}
         setSelectedCenter={setAvalancheCenterWrapper}
-        data={avalancheCenterList(availableCenters, metadata)}
+        data={avalancheCenterList(metadata)}
         width="100%"
         height="100%"
         bg="white"

--- a/components/avalancheCenterList.ts
+++ b/components/avalancheCenterList.ts
@@ -32,15 +32,8 @@ export const filterToSupportedCenters = (ids: AvalancheCenterID[]): AvalancheCen
   return ids.filter(id => supportedCenters.includes(id));
 };
 
-export const avalancheCenterList = (centers: AvalancheCenters, metadata: AvalancheCenter[]): AvalancheCenterListData[] => {
-  let whichCenters: AvalancheCenter[] = [];
-  if (centers === AvalancheCenters.SupportedCenters) {
-    whichCenters = metadata.filter(center => supportedAvalancheCenters.some(supported => supported.center === center.id));
-  } else {
-    whichCenters = metadata;
-  }
-
-  return whichCenters
+export const avalancheCenterList = (metadata: AvalancheCenter[]): AvalancheCenterListData[] => {
+  return metadata
     .map(center => ({
       center: center,
       description: supportedAvalancheCenters.find(supported => supported.center === center.id)?.description,

--- a/components/modals/AvalancheCenterSelectionModal.tsx
+++ b/components/modals/AvalancheCenterSelectionModal.tsx
@@ -30,7 +30,7 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
   }, [onClose, selectedCenter]);
   const capabilitiesResult = useAvalancheCenterCapabilities();
   const capabilities = capabilitiesResult.data;
-  const metadataResults = useAllAvalancheCenterMetadata(capabilities);
+  const metadataResults = useAllAvalancheCenterMetadata(capabilities, AvalancheCenters.SupportedCenters);
   const loading = incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities;
   const metadata: AvalancheCenter[] = [];
   for (const result of metadataResults) {
@@ -61,11 +61,7 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
                   <Body textAlign="center">You can change this anytime in settings.</Body>
                 </Center>
                 <ScrollView>
-                  <AvalancheCenterList
-                    selectedCenter={selectedCenter}
-                    setSelectedCenter={setSelectedCenter}
-                    data={avalancheCenterList(AvalancheCenters.SupportedCenters, metadata)}
-                  />
+                  <AvalancheCenterList selectedCenter={selectedCenter} setSelectedCenter={setSelectedCenter} data={avalancheCenterList(metadata)} />
                 </ScrollView>
               </VStack>
               <Divider />

--- a/hooks/useAllAvalancheCenterMetadata.ts
+++ b/hooks/useAllAvalancheCenterMetadata.ts
@@ -4,13 +4,13 @@ import {useQueries, useQueryClient, UseQueryOptions} from '@tanstack/react-query
 import {AxiosError} from 'axios';
 
 import {ClientContext, ClientProps} from 'clientContext';
-import {filterToKnownCenters} from 'components/avalancheCenterList';
+import {AvalancheCenters, filterToKnownCenters, filterToSupportedCenters} from 'components/avalancheCenterList';
 import AvalancheCenterMetadataQuery from 'hooks/useAvalancheCenterMetadata';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {AllAvalancheCenterCapabilities, AvalancheCenter, AvalancheCenterID} from 'types/nationalAvalancheCenter';
 import {ZodError} from 'zod';
 
-export const useAllAvalancheCenterMetadata = (capabilities: AllAvalancheCenterCapabilities | undefined) => {
+export const useAllAvalancheCenterMetadata = (capabilities: AllAvalancheCenterCapabilities | undefined, whichCenters: AvalancheCenters) => {
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const queryClient = useQueryClient();
@@ -20,9 +20,18 @@ export const useAllAvalancheCenterMetadata = (capabilities: AllAvalancheCenterCa
     knownCenters.push(...filterToKnownCenters(capabilities.centers.map(center => center.id)));
   }
 
+  const filteredCenters: AvalancheCenterID[] = [];
+  switch (whichCenters) {
+    case AvalancheCenters.AllCenters:
+      filteredCenters.push(...knownCenters);
+      break;
+    case AvalancheCenters.SupportedCenters:
+      filteredCenters.push(...filterToSupportedCenters(knownCenters));
+  }
+
   return useQueries<UseQueryOptions<AvalancheCenter, AxiosError | ZodError>[]>({
-    queries: knownCenters
-      ? knownCenters.map(center => {
+    queries: filteredCenters
+      ? filteredCenters.map(center => {
           return {
             queryKey: AvalancheCenterMetadataQuery.queryKey(nationalAvalancheCenterHost, center),
             queryFn: async (): Promise<AvalancheCenter> => AvalancheCenterMetadataQuery.fetchQuery(queryClient, nationalAvalancheCenterHost, center, logger),


### PR DESCRIPTION
We're finding that we can't trust avalanche center metadata to not be broken, so we need to make sure that only supported centers are loaded and we don't run into issues with failures loading centers we're not going to display.