### PR TITLE
weatherStationTimeseries: don't ask for calculated diffs on nwac

### DIFF
--- a/hooks/useWeatherStationTimeseries.ts
+++ b/hooks/useWeatherStationTimeseries.ts
@@ -109,7 +109,7 @@ export const fetchWeatherStationTimeseries = async (
     endDate: toSnowboundStringUTC(endDate),
     output: 'records',
     token: token,
-    calcDiff: true,
+    calcDiff: !Object.values(stations).includes(WeatherStationSource.NWAC), // TODO: the old-school NWAC "NOW" views don't want calculated diffs, but if we ever move them to normal tables, we will
   });
 
   const parseResult = weatherStationTimeseriesSchema.safeParse(data);


### PR DESCRIPTION
The NWAC website has besoke views of weather data, which require that calculated differences are not requested from the Snobound endpoint. If we ever move to make the app show weather data in line with the rest of the NAC centers, we can remove this logic and always ask for diffs.