### PR TITLE
Fix problem with obs date > submitted date

### DIFF
--- a/components/observations/uploader/uploadObservation.ts
+++ b/components/observations/uploader/uploadObservation.ts
@@ -8,12 +8,17 @@ import {apiDateString} from 'utils/date';
 export async function uploadObservation(id: string, data: ObservationTaskData): Promise<Observation> {
   const {formData, extraData} = data;
   const {url, ...params} = extraData;
+  // The user only picks a date, not a time. The time defaults to whatever the current time is in the user's timezone.
+  // If the time is late enough, it might be in the next day when converted to UTC. By setting the time to noon in the user's
+  // local timezone, we mitigate this problem.
+  const adjustedDate = new Date(formData.start_date);
+  adjustedDate.setHours(12, 0, 0, 0);
   const payload: Partial<Observation> = {
     ...formData,
     ...params,
     obs_source: 'public',
     // Date has to be a plain-old YYYY-MM-DD string
-    start_date: apiDateString(formData.start_date),
+    start_date: apiDateString(adjustedDate),
     status: 'published',
   };
   try {

--- a/components/observations/uploader/uploadObservation.ts
+++ b/components/observations/uploader/uploadObservation.ts
@@ -1,24 +1,20 @@
 import axios from 'axios';
+import {format} from 'date-fns';
 
 import {ObservationTaskData} from 'components/observations/uploader/Task';
 import {logger} from 'logger';
 import {Observation} from 'types/nationalAvalancheCenter';
-import {apiDateString} from 'utils/date';
 
 export async function uploadObservation(id: string, data: ObservationTaskData): Promise<Observation> {
   const {formData, extraData} = data;
   const {url, ...params} = extraData;
-  // The user only picks a date, not a time. The time defaults to whatever the current time is in the user's timezone.
-  // If the time is late enough, it might be in the next day when converted to UTC. By setting the time to noon in the user's
-  // local timezone, we mitigate this problem.
-  const adjustedDate = new Date(formData.start_date);
-  adjustedDate.setHours(12, 0, 0, 0);
   const payload: Partial<Observation> = {
     ...formData,
     ...params,
     obs_source: 'public',
-    // Date has to be a plain-old YYYY-MM-DD string
-    start_date: apiDateString(adjustedDate),
+    // Date has to be a plain-old YYYY-MM-DD string. This format is the same format used by
+    // `apiDateString`, but that function also converts to UTC, which we don't want to do here (#584)
+    start_date: format(formData.start_date, 'yyyy-MM-dd'),
     status: 'published',
   };
   try {


### PR DESCRIPTION
I tested this fix by manually setting my computer clock to 7 PM MST, which is past midnight in UTC.

without the fix | with the fix
--- | ---
<img width="596" alt="image" src="https://github.com/NWACus/avy/assets/101196/a757efaf-cb6a-4be4-bc6d-5aa3e669c4b7"> | <img width="574" alt="image" src="https://github.com/NWACus/avy/assets/101196/b911b052-844e-4662-a606-928539490457">

Fixes #584 