### PR TITLE
Fix Typescript issues in View property setting

### DIFF
--- a/components/core/Divider.tsx
+++ b/components/core/Divider.tsx
@@ -16,7 +16,7 @@ export const Divider: React.FC<DividerProps> = ({children, style: originalStyle 
     height: direction === 'vertical' ? '100%' : size,
     // Set a default background color if any of the bg props aren't passed.
     // If backgroundColor is set via the `style` prop, it will still take precedence
-    backgroundColor: props.bg || props.bgColor || props.backgroundColor ? undefined : colorLookup('light.300'),
+    backgroundColor: props.bg || props.backgroundColor ? undefined : colorLookup('light.300'),
   };
   merge(style, originalStyle);
   return (

--- a/components/core/View.test.tsx
+++ b/components/core/View.test.tsx
@@ -8,57 +8,75 @@ describe('View', () => {
   it("sets top-level properties on the wrapped View's style property", () => {
     render(<View width={100} height={'100%'} backgroundColor="red" testID="foo" />);
     const view = screen.getByTestId('foo');
-    expect(view.props.style).toEqual({
-      backgroundColor: 'red',
-      width: 100,
-      height: '100%',
-    });
+    expect(view.props.style).toEqual([
+      undefined,
+      {
+        backgroundColor: 'red',
+        width: 100,
+        height: '100%',
+      },
+    ]);
   });
 
   it('top-level properties overwrite the inner `style`, even when specified before the `style` prop', () => {
     render(<View width={100} style={{width: 50, backgroundColor: 'blue'}} testID="foo" />);
     const view = screen.getByTestId('foo');
-    expect(view.props.style).toEqual({
-      backgroundColor: 'blue',
-      width: 100,
-    });
+    expect(view.props.style).toEqual([
+      {
+        backgroundColor: 'blue',
+        width: 50,
+      },
+      {width: 100},
+    ]);
   });
 
   it('top-level properties overwrite the inner `style`, when specified after the `style` prop', () => {
     render(<View style={{width: 50, backgroundColor: 'blue'}} backgroundColor="red" testID="foo" />);
     const view = screen.getByTestId('foo');
-    expect(view.props.style).toEqual({
-      backgroundColor: 'red',
-      width: 50,
-    });
+    expect(view.props.style).toEqual([
+      {
+        backgroundColor: 'blue',
+        width: 50,
+      },
+      {backgroundColor: 'red'},
+    ]);
   });
 
   it('property shorthand can overwrite `style` props', () => {
     render(<View style={{backgroundColor: 'blue'}} bg="red" testID="foo" />);
     const view = screen.getByTestId('foo');
-    expect(view.props.style).toEqual({
-      backgroundColor: 'red',
-    });
+    expect(view.props.style).toEqual([
+      {
+        backgroundColor: 'blue',
+      },
+      {
+        backgroundColor: 'red',
+      },
+    ]);
   });
 
-  it('when multiple property aliases target the same property, last one wins', () => {
-    render(<View style={{backgroundColor: 'blue'}} bg="red" backgroundColor="pink" bgColor="yellow" testID="foo" />);
+  it('property aliases are preferred over full property names', () => {
+    render(<View style={{backgroundColor: 'blue'}} bg="red" backgroundColor="pink" testID="foo" />);
     const view = screen.getByTestId('foo');
-    expect(view.props.style).toEqual({
-      backgroundColor: 'yellow',
-    });
+    expect(view.props.style).toEqual([
+      {
+        backgroundColor: 'blue',
+      },
+      {
+        backgroundColor: 'red',
+      },
+    ]);
 
-    render(<View style={{backgroundColor: 'blue'}} bgColor="yellow" backgroundColor="pink" bg="red" testID="foo" />);
+    render(<View style={{backgroundColor: 'blue'}} backgroundColor="pink" bg="red" testID="foo" />);
     const view2 = screen.getByTestId('foo');
-    expect(view2.props.style).toEqual({
-      backgroundColor: 'red',
-    });
-
-    render(<View style={{backgroundColor: 'blue'}} bgColor="yellow" bg="red" backgroundColor="pink" testID="foo" />);
-    const view3 = screen.getByTestId('foo');
-    expect(view3.props.style).toEqual({
-      backgroundColor: 'pink',
-    });
+    expect(view2.props.style).toEqual([
+      {
+        backgroundColor: 'blue',
+      },
+      {
+        backgroundColor: 'red',
+      },
+    ]);
   });
 
   it('throws errors for invalid dimension values', () => {

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -249,12 +249,14 @@ const validateProp = (prop: ViewStyleProp, value: unknown): void => {
   }
 };
 
-// Given an object and a set of keys, return an array of two objects:
-// 1. An object containing only the keys in the keySet
-// 2. An object containing only the keys not in the keySet
-function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, string>): [Pick<T, K>, Pick<T, Exclude<keyof T, K>>] {
+/**
+ * Given an object and a set of keys, return an array of two objects:
+ * 1. An object containing only the keys in the keySet
+ * 2. An object containing only the keys not in the keySet
+ */
+function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, string>): [Pick<T, K>, Omit<T, K>] {
   const pick = {} as Pick<T, K>;
-  const unpick = {} as Pick<T, Exclude<keyof T, K>>;
+  const unpick = {} as Omit<T, K>;
   (Object.keys(obj) as (keyof T)[]).forEach(k => {
     if (k in keySet) {
       const kk = k as K;

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -87,83 +87,83 @@ interface ViewAliasProps {
 type ViewAliasProp = keyof ViewAliasProps;
 type ViewStyleProp = keyof ViewStyleProps;
 
-const viewStylePropKeyset: Record<ViewStyleProp | ViewAliasProp, boolean> = {
-  backgroundColor: true,
+const viewStyleProps: Record<ViewStyleProp | ViewAliasProp, ViewStyleProp | ViewAliasProp> = {
+  backgroundColor: 'backgroundColor',
 
-  position: true,
-  top: true,
-  left: true,
-  right: true,
-  bottom: true,
-  zIndex: true,
+  position: 'position',
+  top: 'top',
+  left: 'left',
+  right: 'right',
+  bottom: 'bottom',
+  zIndex: 'zIndex',
 
-  padding: true,
-  paddingHorizontal: true,
-  paddingVertical: true,
-  paddingTop: true,
-  paddingLeft: true,
-  paddingRight: true,
-  paddingBottom: true,
+  padding: 'padding',
+  paddingHorizontal: 'paddingHorizontal',
+  paddingVertical: 'paddingVertical',
+  paddingTop: 'paddingTop',
+  paddingLeft: 'paddingLeft',
+  paddingRight: 'paddingRight',
+  paddingBottom: 'paddingBottom',
 
-  margin: true,
-  marginHorizontal: true,
-  marginVertical: true,
-  marginTop: true,
-  marginLeft: true,
-  marginRight: true,
-  marginBottom: true,
+  margin: 'margin',
+  marginHorizontal: 'marginHorizontal',
+  marginVertical: 'marginVertical',
+  marginTop: 'marginTop',
+  marginLeft: 'marginLeft',
+  marginRight: 'marginRight',
+  marginBottom: 'marginBottom',
 
-  alignContent: true,
-  alignItems: true,
-  alignSelf: true,
-  flex: true,
-  flexBasis: true,
-  flexDirection: true,
-  flexGrow: true,
-  flexShrink: true,
-  flexWrap: true,
-  justifyContent: true,
+  alignContent: 'alignContent',
+  alignItems: 'alignItems',
+  alignSelf: 'alignSelf',
+  flex: 'flex',
+  flexBasis: 'flexBasis',
+  flexDirection: 'flexDirection',
+  flexGrow: 'flexGrow',
+  flexShrink: 'flexShrink',
+  flexWrap: 'flexWrap',
+  justifyContent: 'justifyContent',
 
-  aspectRatio: true,
-  width: true,
-  height: true,
-  maxHeight: true,
-  maxWidth: true,
-  minHeight: true,
-  minWidth: true,
+  aspectRatio: 'aspectRatio',
+  width: 'width',
+  height: 'height',
+  maxHeight: 'maxHeight',
+  maxWidth: 'maxWidth',
+  minHeight: 'minHeight',
+  minWidth: 'minWidth',
 
-  borderBottomLeftRadius: true,
-  borderBottomRightRadius: true,
-  borderTopLeftRadius: true,
-  borderTopRightRadius: true,
-  borderRadius: true,
-  borderBottomWidth: true,
-  borderLeftWidth: true,
-  borderRightWidth: true,
-  borderTopWidth: true,
-  borderWidth: true,
-  borderColor: true,
+  borderBottomLeftRadius: 'borderBottomLeftRadius',
+  borderBottomRightRadius: 'borderBottomRightRadius',
+  borderTopLeftRadius: 'borderTopLeftRadius',
+  borderTopRightRadius: 'borderTopRightRadius',
+  borderRadius: 'borderRadius',
+  borderBottomWidth: 'borderBottomWidth',
+  borderLeftWidth: 'borderLeftWidth',
+  borderRightWidth: 'borderRightWidth',
+  borderTopWidth: 'borderTopWidth',
+  borderWidth: 'borderWidth',
+  borderColor: 'borderColor',
 
-  display: true,
-  overflow: true,
+  display: 'display',
+  overflow: 'overflow',
 
-  bg: true,
+  bg: 'bg',
 
-  p: true,
-  px: true,
-  py: true,
-  pt: true,
-  pl: true,
-  pr: true,
-  pb: true,
+  p: 'p',
+  px: 'px',
+  py: 'py',
+  pt: 'pt',
+  pl: 'pl',
+  pr: 'pr',
+  pb: 'pb',
 
-  m: true,
-  mx: true,
-  my: true,
-  mt: true,
-  ml: true,
-  mr: true,
-  mb: true,
+  m: 'm',
+  mx: 'mx',
+  my: 'my',
+  mt: 'mt',
+  ml: 'ml',
+  mr: 'mr',
+  mb: 'mb',
 } as const;
 
 const propAliasMapping: Record<keyof ViewAliasProps, keyof ViewStyleProps> = {
@@ -185,11 +185,6 @@ const propAliasMapping: Record<keyof ViewAliasProps, keyof ViewStyleProps> = {
   mr: 'marginRight',
   mb: 'marginBottom',
 } as const;
-
-const viewAliasPropKeyset = Object.keys(propAliasMapping).reduce((acc, aliasProp) => {
-  acc[aliasProp as ViewAliasProp] = true;
-  return acc;
-}, {} as Record<ViewAliasProp, boolean>);
 
 const unaliasAliasProps = (props: ViewAliasProps): ViewStyleProps => {
   const unaliasedProps: ViewStyleProps = {
@@ -253,7 +248,7 @@ const validateProp = (prop: ViewStyleProp, value: unknown): void => {
   }
 };
 
-function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, boolean>): [Pick<T, K>, Pick<T, Exclude<keyof T, K>>] {
+function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, string>): [Pick<T, K>, Pick<T, Exclude<keyof T, K>>] {
   const pick = {} as Pick<T, K>;
   const unpick = {} as Pick<T, Exclude<keyof T, K>>;
   (Object.keys(obj) as (keyof T)[]).forEach(k => {
@@ -270,8 +265,8 @@ function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, bo
 
 export interface ViewProps extends RNViewProps, ViewStyleProps, ViewAliasProps {}
 export const View = React.forwardRef<RNView, ViewProps>(({children, style, ...props}, ref) => {
-  const [allStyleProps, viewProps] = split(props, viewStylePropKeyset);
-  const [aliasedProps, unaliasedStyleProps] = split(allStyleProps, viewAliasPropKeyset);
+  const [allStyleProps, viewProps] = split(props, viewStyleProps);
+  const [aliasedProps, unaliasedStyleProps] = split(allStyleProps, propAliasMapping);
   const stylesFromProps = {
     ...unaliasedStyleProps,
     ...unaliasAliasProps(aliasedProps),

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -206,6 +206,7 @@ const unaliasAliasProps = (props: ViewAliasProps): ViewStyleProps => {
     marginRight: props.mr,
     marginBottom: props.mb,
   };
+  // Remove any undefined fields from unaliasedProps before returning it
   (Object.keys(unaliasedProps) as ViewStyleProp[]).forEach(key => unaliasedProps[key] === undefined && delete unaliasedProps[key]);
   return unaliasedProps;
 };
@@ -248,6 +249,9 @@ const validateProp = (prop: ViewStyleProp, value: unknown): void => {
   }
 };
 
+// Given an object and a set of keys, return an array of two objects:
+// 1. An object containing only the keys in the keySet
+// 2. An object containing only the keys not in the keySet
 function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, string>): [Pick<T, K>, Pick<T, Exclude<keyof T, K>>] {
   const pick = {} as Pick<T, K>;
   const unpick = {} as Pick<T, Exclude<keyof T, K>>;

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -1,101 +1,173 @@
 import * as React from 'react';
 
 import {View as RNView, ViewProps as RNViewProps, ViewStyle as RNViewStyle} from 'react-native';
-
 import {colorLookup} from 'theme';
 
-class ViewStyleProps {
-  constructor(
-    readonly backgroundColor?: RNViewStyle['backgroundColor'],
+interface ViewStyleProps {
+  backgroundColor?: RNViewStyle['backgroundColor'];
 
-    readonly position?: RNViewStyle['position'],
-    readonly top?: RNViewStyle['top'],
-    readonly left?: RNViewStyle['left'],
-    readonly right?: RNViewStyle['right'],
-    readonly bottom?: RNViewStyle['bottom'],
-    readonly zIndex?: RNViewStyle['zIndex'],
+  position?: RNViewStyle['position'];
+  top?: RNViewStyle['top'];
+  left?: RNViewStyle['left'];
+  right?: RNViewStyle['right'];
+  bottom?: RNViewStyle['bottom'];
+  zIndex?: RNViewStyle['zIndex'];
 
-    readonly padding?: RNViewStyle['padding'],
-    readonly paddingHorizontal?: RNViewStyle['paddingHorizontal'],
-    readonly paddingVertical?: RNViewStyle['paddingVertical'],
-    readonly paddingTop?: RNViewStyle['paddingTop'],
-    readonly paddingLeft?: RNViewStyle['paddingLeft'],
-    readonly paddingRight?: RNViewStyle['paddingRight'],
-    readonly paddingBottom?: RNViewStyle['paddingBottom'],
+  padding?: RNViewStyle['padding'];
+  paddingHorizontal?: RNViewStyle['paddingHorizontal'];
+  paddingVertical?: RNViewStyle['paddingVertical'];
+  paddingTop?: RNViewStyle['paddingTop'];
+  paddingLeft?: RNViewStyle['paddingLeft'];
+  paddingRight?: RNViewStyle['paddingRight'];
+  paddingBottom?: RNViewStyle['paddingBottom'];
 
-    readonly margin?: RNViewStyle['margin'],
-    readonly marginHorizontal?: RNViewStyle['marginHorizontal'],
-    readonly marginVertical?: RNViewStyle['marginVertical'],
-    readonly marginTop?: RNViewStyle['marginTop'],
-    readonly marginLeft?: RNViewStyle['marginLeft'],
-    readonly marginRight?: RNViewStyle['marginRight'],
-    readonly marginBottom?: RNViewStyle['marginBottom'],
+  margin?: RNViewStyle['margin'];
+  marginHorizontal?: RNViewStyle['marginHorizontal'];
+  marginVertical?: RNViewStyle['marginVertical'];
+  marginTop?: RNViewStyle['marginTop'];
+  marginLeft?: RNViewStyle['marginLeft'];
+  marginRight?: RNViewStyle['marginRight'];
+  marginBottom?: RNViewStyle['marginBottom'];
 
-    readonly alignContent?: RNViewStyle['alignContent'],
-    readonly alignItems?: RNViewStyle['alignItems'],
-    readonly alignSelf?: RNViewStyle['alignSelf'],
-    readonly flex?: RNViewStyle['flex'],
-    readonly flexBasis?: RNViewStyle['flexBasis'],
-    readonly flexDirection?: RNViewStyle['flexDirection'],
-    readonly flexGrow?: RNViewStyle['flexGrow'],
-    readonly flexShrink?: RNViewStyle['flexShrink'],
-    readonly flexWrap?: RNViewStyle['flexWrap'],
-    readonly justifyContent?: RNViewStyle['justifyContent'],
+  alignContent?: RNViewStyle['alignContent'];
+  alignItems?: RNViewStyle['alignItems'];
+  alignSelf?: RNViewStyle['alignSelf'];
+  flex?: RNViewStyle['flex'];
+  flexBasis?: RNViewStyle['flexBasis'];
+  flexDirection?: RNViewStyle['flexDirection'];
+  flexGrow?: RNViewStyle['flexGrow'];
+  flexShrink?: RNViewStyle['flexShrink'];
+  flexWrap?: RNViewStyle['flexWrap'];
+  justifyContent?: RNViewStyle['justifyContent'];
 
-    readonly aspectRatio?: RNViewStyle['aspectRatio'],
-    readonly width?: RNViewStyle['width'],
-    readonly height?: RNViewStyle['height'],
-    readonly maxHeight?: RNViewStyle['maxHeight'],
-    readonly maxWidth?: RNViewStyle['maxWidth'],
-    readonly minHeight?: RNViewStyle['minHeight'],
-    readonly minWidth?: RNViewStyle['minWidth'],
+  aspectRatio?: RNViewStyle['aspectRatio'];
+  width?: RNViewStyle['width'];
+  height?: RNViewStyle['height'];
+  maxHeight?: RNViewStyle['maxHeight'];
+  maxWidth?: RNViewStyle['maxWidth'];
+  minHeight?: RNViewStyle['minHeight'];
+  minWidth?: RNViewStyle['minWidth'];
 
-    readonly borderBottomLeftRadius?: RNViewStyle['borderBottomLeftRadius'],
-    readonly borderBottomRightRadius?: RNViewStyle['borderBottomRightRadius'],
-    readonly borderTopLeftRadius?: RNViewStyle['borderTopLeftRadius'],
-    readonly borderTopRightRadius?: RNViewStyle['borderTopRightRadius'],
-    readonly borderRadius?: RNViewStyle['borderRadius'],
-    readonly borderBottomWidth?: RNViewStyle['borderBottomWidth'],
-    readonly borderLeftWidth?: RNViewStyle['borderLeftWidth'],
-    readonly borderRightWidth?: RNViewStyle['borderRightWidth'],
-    readonly borderTopWidth?: RNViewStyle['borderTopWidth'],
-    readonly borderWidth?: RNViewStyle['borderWidth'],
-    readonly borderColor?: RNViewStyle['borderColor'],
+  borderBottomLeftRadius?: RNViewStyle['borderBottomLeftRadius'];
+  borderBottomRightRadius?: RNViewStyle['borderBottomRightRadius'];
+  borderTopLeftRadius?: RNViewStyle['borderTopLeftRadius'];
+  borderTopRightRadius?: RNViewStyle['borderTopRightRadius'];
+  borderRadius?: RNViewStyle['borderRadius'];
+  borderBottomWidth?: RNViewStyle['borderBottomWidth'];
+  borderLeftWidth?: RNViewStyle['borderLeftWidth'];
+  borderRightWidth?: RNViewStyle['borderRightWidth'];
+  borderTopWidth?: RNViewStyle['borderTopWidth'];
+  borderWidth?: RNViewStyle['borderWidth'];
+  borderColor?: RNViewStyle['borderColor'];
 
-    readonly display?: RNViewStyle['display'],
-    readonly overflow?: RNViewStyle['overflow'],
-  ) {}
+  display?: RNViewStyle['display'];
+  overflow?: RNViewStyle['overflow'];
 }
 
-class ViewAliasProps {
-  constructor(
-    readonly bg?: RNViewStyle['backgroundColor'],
-    readonly bgColor?: RNViewStyle['backgroundColor'],
+interface ViewAliasProps {
+  bg?: ViewStyleProps['backgroundColor'];
 
-    readonly p?: RNViewStyle['padding'],
-    readonly px?: RNViewStyle['paddingHorizontal'],
-    readonly py?: RNViewStyle['paddingVertical'],
-    readonly pt?: RNViewStyle['paddingTop'],
-    readonly pl?: RNViewStyle['paddingLeft'],
-    readonly pr?: RNViewStyle['paddingRight'],
-    readonly pb?: RNViewStyle['paddingBottom'],
+  p?: ViewStyleProps['padding'];
+  px?: ViewStyleProps['paddingHorizontal'];
+  py?: ViewStyleProps['paddingVertical'];
+  pt?: ViewStyleProps['paddingTop'];
+  pl?: ViewStyleProps['paddingLeft'];
+  pr?: ViewStyleProps['paddingRight'];
+  pb?: ViewStyleProps['paddingBottom'];
 
-    readonly m?: RNViewStyle['margin'],
-    readonly mx?: RNViewStyle['marginHorizontal'],
-    readonly my?: RNViewStyle['marginVertical'],
-    readonly mt?: RNViewStyle['marginTop'],
-    readonly ml?: RNViewStyle['marginLeft'],
-    readonly mr?: RNViewStyle['marginRight'],
-    readonly mb?: RNViewStyle['marginBottom'],
-  ) {}
+  m?: ViewStyleProps['margin'];
+  mx?: ViewStyleProps['marginHorizontal'];
+  my?: ViewStyleProps['marginVertical'];
+  mt?: ViewStyleProps['marginTop'];
+  ml?: ViewStyleProps['marginLeft'];
+  mr?: ViewStyleProps['marginRight'];
+  mb?: ViewStyleProps['marginBottom'];
 }
 
-type ViewStyleProp = keyof ViewStyleProps | keyof ViewAliasProps;
-const viewStylePropKeys: ViewStyleProp[] = (Object.keys(new ViewStyleProps()) as ViewStyleProp[]).concat(Object.keys(new ViewAliasProps()) as ViewStyleProp[]);
+type ViewAliasProp = keyof ViewAliasProps;
+type ViewStyleProp = keyof ViewStyleProps;
+
+const viewStylePropKeyset: Record<ViewStyleProp | ViewAliasProp, boolean> = {
+  backgroundColor: true,
+
+  position: true,
+  top: true,
+  left: true,
+  right: true,
+  bottom: true,
+  zIndex: true,
+
+  padding: true,
+  paddingHorizontal: true,
+  paddingVertical: true,
+  paddingTop: true,
+  paddingLeft: true,
+  paddingRight: true,
+  paddingBottom: true,
+
+  margin: true,
+  marginHorizontal: true,
+  marginVertical: true,
+  marginTop: true,
+  marginLeft: true,
+  marginRight: true,
+  marginBottom: true,
+
+  alignContent: true,
+  alignItems: true,
+  alignSelf: true,
+  flex: true,
+  flexBasis: true,
+  flexDirection: true,
+  flexGrow: true,
+  flexShrink: true,
+  flexWrap: true,
+  justifyContent: true,
+
+  aspectRatio: true,
+  width: true,
+  height: true,
+  maxHeight: true,
+  maxWidth: true,
+  minHeight: true,
+  minWidth: true,
+
+  borderBottomLeftRadius: true,
+  borderBottomRightRadius: true,
+  borderTopLeftRadius: true,
+  borderTopRightRadius: true,
+  borderRadius: true,
+  borderBottomWidth: true,
+  borderLeftWidth: true,
+  borderRightWidth: true,
+  borderTopWidth: true,
+  borderWidth: true,
+  borderColor: true,
+
+  display: true,
+  overflow: true,
+
+  bg: true,
+
+  p: true,
+  px: true,
+  py: true,
+  pt: true,
+  pl: true,
+  pr: true,
+  pb: true,
+
+  m: true,
+  mx: true,
+  my: true,
+  mt: true,
+  ml: true,
+  mr: true,
+  mb: true,
+} as const;
 
 const propAliasMapping: Record<keyof ViewAliasProps, keyof ViewStyleProps> = {
   bg: 'backgroundColor',
-  bgColor: 'backgroundColor',
 
   p: 'padding',
   px: 'paddingHorizontal',
@@ -113,6 +185,35 @@ const propAliasMapping: Record<keyof ViewAliasProps, keyof ViewStyleProps> = {
   mr: 'marginRight',
   mb: 'marginBottom',
 } as const;
+
+const viewAliasPropKeyset = Object.keys(propAliasMapping).reduce((acc, aliasProp) => {
+  acc[aliasProp as ViewAliasProp] = true;
+  return acc;
+}, {} as Record<ViewAliasProp, boolean>);
+
+const unaliasAliasProps = (props: ViewAliasProps): ViewStyleProps => {
+  const unaliasedProps: ViewStyleProps = {
+    backgroundColor: props.bg,
+
+    padding: props.p,
+    paddingHorizontal: props.px,
+    paddingVertical: props.py,
+    paddingTop: props.pt,
+    paddingLeft: props.pl,
+    paddingRight: props.pr,
+    paddingBottom: props.pb,
+
+    margin: props.m,
+    marginHorizontal: props.mx,
+    marginVertical: props.my,
+    marginTop: props.mt,
+    marginLeft: props.ml,
+    marginRight: props.mr,
+    marginBottom: props.mb,
+  };
+  (Object.keys(unaliasedProps) as ViewStyleProp[]).forEach(key => unaliasedProps[key] === undefined && delete unaliasedProps[key]);
+  return unaliasedProps;
+};
 
 const dimensionalProps: ViewStyleProp[] = [
   'bottom',
@@ -152,31 +253,41 @@ const validateProp = (prop: ViewStyleProp, value: unknown): void => {
   }
 };
 
-export interface ViewProps extends RNViewProps, ViewStyleProps, ViewAliasProps {}
-export const View = React.forwardRef<RNView, ViewProps>(({children, style = {}, ...props}, ref) => {
-  const resolvedProps: ViewProps = {style};
-  Object.entries(props).forEach(([key, value]) => {
-    const prop = propAliasMapping[key as keyof ViewAliasProps] || key;
-    if (viewStylePropKeys.includes(prop)) {
-      if (['backgroundColor'].includes(prop) && typeof value === 'string') {
-        value = colorLookup(value);
-      }
-      validateProp(prop, value);
-      if (style) {
-        // TODO(bsharon): this needs to be cleaned up to be accordant with typescript ...
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        style[prop] = value;
-      }
+function split<T extends object, K extends keyof T>(obj: T, keySet: Record<K, boolean>): [Pick<T, K>, Pick<T, Exclude<keyof T, K>>] {
+  const pick = {} as Pick<T, K>;
+  const unpick = {} as Pick<T, Exclude<keyof T, K>>;
+  (Object.keys(obj) as (keyof T)[]).forEach(k => {
+    if (k in keySet) {
+      const kk = k as K;
+      pick[kk] = obj[kk];
     } else {
-      // TODO(bsharon): this needs to be cleaned up to be accordant with typescript ...
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      resolvedProps[prop] = value;
+      const kk = k as Exclude<keyof T, K>;
+      unpick[kk] = obj[kk];
     }
   });
+  return [pick, unpick];
+}
+
+export interface ViewProps extends RNViewProps, ViewStyleProps, ViewAliasProps {}
+export const View = React.forwardRef<RNView, ViewProps>(({children, style, ...props}, ref) => {
+  const [allStyleProps, viewProps] = split(props, viewStylePropKeyset);
+  const [aliasedProps, unaliasedStyleProps] = split(allStyleProps, viewAliasPropKeyset);
+  const stylesFromProps = {
+    ...unaliasedStyleProps,
+    ...unaliasAliasProps(aliasedProps),
+  };
+
+  let styleProp: ViewStyleProp;
+  for (styleProp in stylesFromProps) {
+    validateProp(styleProp, stylesFromProps[styleProp]);
+  }
+
+  if (typeof stylesFromProps['backgroundColor'] === 'string') {
+    stylesFromProps['backgroundColor'] = colorLookup(stylesFromProps['backgroundColor']);
+  }
+
   return (
-    <RNView {...resolvedProps} ref={ref}>
+    <RNView {...viewProps} style={[style, stylesFromProps]} ref={ref}>
       {children}
     </RNView>
   );


### PR DESCRIPTION
- Remove warning suppression from View.tsx
- Remove `bgColor` alias - we only need `backgroundColor` or `bg`
- React Native style prop can be an array, so I leverage that - now the original style object is passed through unchanged, and an additional style object is created with any props passed as top-level props

There's a minor downside in that all the style props have to get written twice in View.tsx (so not DRY), but I haven't had to add a new one since I created that file way back when, so I don't think that's a major issue.

#452 remains open because of unrelated other instances of `ts-ignore`