### PR TITLE
weather_data: display MESOWEST as Synoptic Data

### DIFF
--- a/components/weather_data/WeatherStationFilterForm.tsx
+++ b/components/weather_data/WeatherStationFilterForm.tsx
@@ -260,7 +260,7 @@ export const WeatherStationFilterForm: React.FunctionComponent<WeatherStationFil
                       radio
                       items={[
                         {value: WeatherStationSource.NWAC, label: WeatherStationSource.NWAC.toUpperCase()},
-                        {value: WeatherStationSource.MESOWEST, label: WeatherStationSource.MESOWEST.toUpperCase()},
+                        {value: WeatherStationSource.MESOWEST, label: 'Synoptic Data'},
                         {value: WeatherStationSource.SNOTEL, label: WeatherStationSource.SNOTEL.toUpperCase()},
                       ]}
                     />

--- a/components/weather_data/WeatherStationMap.tsx
+++ b/components/weather_data/WeatherStationMap.tsx
@@ -412,7 +412,7 @@ export const WeatherStationCard: React.FunctionComponent<{
             </HStack>
             <HStack space={2}>
               <BodySmSemibold>
-                {station.properties.source.toUpperCase()} | {station.properties.elevation} ft
+                {formatSource(station.properties.source)} | {station.properties.elevation} ft
                 {latestObservationDateString && ' | '}
                 {latestObservationDateString}
               </BodySmSemibold>
@@ -446,6 +446,14 @@ export const WeatherStationCard: React.FunctionComponent<{
   },
 );
 WeatherStationCard.displayName = 'WeatherStationCard';
+
+const formatSource = (source: WeatherStationSource): string => {
+  if (source === WeatherStationSource.MESOWEST) {
+    return 'Synoptic Data';
+  } else {
+    return source.toUpperCase();
+  }
+};
 
 const iconSize = 24;
 const strokeWidth = 5;


### PR DESCRIPTION
The ownership of MESOWEST data-loggers has been transferred and while the Snowbound API catches up with new source values, etc, we can get the labels correct on the front-end.