### PR TITLE
components/forecast: show toasts correctly

### DIFF
--- a/components/forecast/SynopsisTab.tsx
+++ b/components/forecast/SynopsisTab.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react';
 
 import {formatDistanceToNow, isAfter} from 'date-fns';
 
-import {useNavigation} from '@react-navigation/native';
+import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {Card} from 'components/content/Card';
 import {Carousel, images} from 'components/content/carousel';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
@@ -38,20 +38,28 @@ export const SynopsisTab: React.FunctionComponent<SynopsisTabProps> = ({center_i
     });
   }, [navigation]);
 
-  React.useEffect(() => {
-    if (synopsis?.expires_time) {
-      const expires_time = new Date(synopsis.expires_time);
-      if (isAfter(new Date(), expires_time)) {
-        Toast.show({
-          type: 'error',
-          text1: `This blog expired ${formatDistanceToNow(expires_time)} ago.`,
-          autoHide: false,
-          position: 'bottom',
-          onPress: () => Toast.hide(),
-        });
+  useFocusEffect(
+    useCallback(() => {
+      if (synopsis?.expires_time) {
+        const expires_time = new Date(synopsis.expires_time);
+        if (isAfter(new Date(), expires_time)) {
+          setTimeout(
+            // entirely unclear why this needs to be in a setTimeout, but nothing works without it
+            () =>
+              Toast.show({
+                type: 'error',
+                text1: `This blog expired ${formatDistanceToNow(expires_time)} ago.`,
+                autoHide: false,
+                position: 'bottom',
+                onPress: () => Toast.hide(),
+              }),
+            0,
+          );
+        }
       }
-    }
-  }, [synopsis]);
+      return () => Toast.hide();
+    }, [synopsis]),
+  );
 
   if (incompleteQueryState(synopsisResult) || !synopsis) {
     return <QueryState results={[synopsisResult]} />;

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -89,7 +89,9 @@ export const prefetchAllActiveForecasts = async (
       .filter(zone => zone.status === 'active')
       .forEach(zone => {
         void (async () => {
-          void NWACWeatherForecastQuery.prefetch(queryClient, nwacHost, zone.id, currentDateTime, logger);
+          if (center_id === 'NWAC') {
+            void NWACWeatherForecastQuery.prefetch(queryClient, nwacHost, zone.id, currentDateTime, logger);
+          }
           void AvalancheWarningQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);
           if (process.env.EXPO_PUBLIC_ENABLE_CONDITIONS_BLOG && metadata.config?.blog) {
             void SynopsisQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);


### PR DESCRIPTION
network: only prefetch NWAC forecasts when center is NWAC

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

components/forecast: show toasts correctly

For whatever reason, `useTimeout()` needs to be used when calling
`Toast.show()` in a hook. Without that, we weren't seeing any of these
show up, ever. In addition, we now use the `useFocusEffect()` hook from
`react-navigation` for a much more robust approach to showing and hiding
this toast when folks navigate around the app while the toast is open.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

