### PR TITLE
fix some date-time handling bits as always

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -17,6 +17,7 @@ import {AnimatedCards, AnimatedDrawerState, AnimatedMapWithDrawerController, CAR
 import {AvalancheCenterSelectionModal} from 'components/modals/AvalancheCenterSelectionModal';
 import {BodySm, BodySmSemibold, Title3Black} from 'components/text';
 import {isAfter} from 'date-fns';
+import {toDate} from 'date-fns-tz';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useMapLayerAvalancheForecasts} from 'hooks/useMapLayerAvalancheForecasts';
@@ -26,7 +27,7 @@ import {usePreferences} from 'Preferences';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {HomeStackNavigationProps, TabNavigationProps} from 'routes';
 import {AvalancheCenterID, DangerLevel, ForecastPeriod, MapLayerFeature, ProductType} from 'types/nationalAvalancheCenter';
-import {formatRequestedTime, RequestedTime, utcDateToLocalTimeString} from 'utils/date';
+import {formatRequestedTime, RequestedTime, requestedTimeToUTCDate, utcDateToLocalTimeString} from 'utils/date';
 
 export interface MapProps {
   center: AvalancheCenterID;
@@ -181,7 +182,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
       forecast &&
         forecast.forecast_zone?.forEach(({id}) => {
           if (zonesById[id]) {
-            if (forecast.expires_time && isAfter(new Date(), new Date(forecast.expires_time))) {
+            if (forecast.expires_time && isAfter(requestedTimeToUTCDate(requestedTime), toDate(new Date(forecast.expires_time), {timeZone: 'UTC'}))) {
               zonesById[id].danger_level = DangerLevel.GeneralInformation;
             } else if (forecast.product_type === ProductType.Forecast) {
               const currentDanger = forecast.danger.find(d => d.valid_day === ForecastPeriod.Current);

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -74,7 +74,7 @@ const fetchAvalancheForecastFragments = async (nationalAvalancheCenterHost: stri
   const url = `${nationalAvalancheCenterHost}/v2/public/products`;
   const params = {
     avalanche_center_id: center_id,
-    date_start: apiDateString(sub(date, {days: 2})),
+    date_start: apiDateString(sub(date, {days: 7})),
     date_end: apiDateString(add(date, {days: 1})),
   };
   const what = 'avalanche forecast fragments';


### PR DESCRIPTION
avalancheForecastFragment: search for longer

In the Olympics, for example, we often see only one forecast a week. In
order to make sure our time machine works as expected, we need to search
longer back into the past.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

avalancheForecastFragment: match NAC semantics

When no active forecast exists for the zone at the specified time, the
NAC latest-forecast API just gives the most recent one. Match that.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

AvalancheForecastZoneMap: shade zones based on the requested time

When we're in the time machine, we want to show the map as it would have
appeared that day, so we need to check to see if the forecast is expired
against the requested time, not the current time.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

