### PR TITLE
Don't crash if an observation has a PDF attached

### DIFF
--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -129,6 +129,7 @@ export enum MediaType {
   Video = 'video',
   External = 'external',
   Photo = 'photo',
+  PDF = 'pdf',
   None = '',
 }
 
@@ -341,7 +342,22 @@ export const externalMediaSchema = imageMediaSchema.extend({
 });
 export type ExternalMediaItem = z.infer<typeof externalMediaSchema>;
 
-export const mediaItemSchema = z.discriminatedUnion('type', [emptyMediaSchema, nullMediaSchema, imageMediaSchema, videoMediaSchema, externalMediaSchema, photoMediaSchema]);
+export const pdfMediaSchema = z.object({
+  type: z.literal(MediaType.PDF),
+  url: z.object({
+    original: z.string().url(),
+  }),
+});
+
+export const mediaItemSchema = z.discriminatedUnion('type', [
+  emptyMediaSchema,
+  nullMediaSchema,
+  imageMediaSchema,
+  videoMediaSchema,
+  externalMediaSchema,
+  photoMediaSchema,
+  pdfMediaSchema,
+]);
 export type MediaItem = z.infer<typeof mediaItemSchema>;
 
 export const avalancheCenterWeatherConfigurationSchema = z.object({

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -130,6 +130,7 @@ export enum MediaType {
   External = 'external',
   Photo = 'photo',
   PDF = 'pdf',
+  Unknown = 'unknown',
   None = '',
 }
 
@@ -349,15 +350,15 @@ export const pdfMediaSchema = z.object({
   }),
 });
 
-export const mediaItemSchema = z.discriminatedUnion('type', [
-  emptyMediaSchema,
-  nullMediaSchema,
-  imageMediaSchema,
-  videoMediaSchema,
-  externalMediaSchema,
-  photoMediaSchema,
-  pdfMediaSchema,
-]);
+const unknownMediaSchema = z.object({
+  type: z.literal(MediaType.Unknown),
+});
+
+export const mediaItemSchema = z
+  .discriminatedUnion('type', [emptyMediaSchema, nullMediaSchema, imageMediaSchema, videoMediaSchema, externalMediaSchema, photoMediaSchema, pdfMediaSchema, unknownMediaSchema])
+  .catch({
+    type: MediaType.Unknown,
+  });
 export type MediaItem = z.infer<typeof mediaItemSchema>;
 
 export const avalancheCenterWeatherConfigurationSchema = z.object({

--- a/types/nationalAvalancheCenter/tests/mediaitem.test.ts
+++ b/types/nationalAvalancheCenter/tests/mediaitem.test.ts
@@ -1,0 +1,29 @@
+import {MediaType, mediaItemSchema} from 'types/nationalAvalancheCenter/schemas';
+
+describe('MediaItem parsing', () => {
+  it('parses a PDF media item as type pdf', () => {
+    const item = {
+      id: 'c0644e6a-92b3-11ee-9bd0-c3e82ed6f997',
+      center_id: 'snfac',
+      url: {
+        original: 'https://avalanche-org-media-staging.s3.us-west-2.amazonaws.com/alpine_meadows_656de600952a3.pdf',
+      },
+      type: 'pdf',
+      status: 'published',
+      title: 'Apline Meadows',
+      caption: 'Apline Meadows',
+      taken_by: null,
+      forecast_zone_id: ['293'],
+      location: null,
+      category: null,
+      date_taken: null,
+      date_created: '2023-12-04T14:45:20+00:00',
+      date_updated: '2023-12-04T14:45:21+00:00',
+      source: null,
+      access: null,
+      favorite: false,
+    };
+    const mediaItem = mediaItemSchema.parse(item);
+    expect(mediaItem.type).toEqual(MediaType.PDF);
+  });
+});

--- a/types/nationalAvalancheCenter/tests/mediaitem.test.ts
+++ b/types/nationalAvalancheCenter/tests/mediaitem.test.ts
@@ -4,26 +4,24 @@ describe('MediaItem parsing', () => {
   it('parses a PDF media item as type pdf', () => {
     const item = {
       id: 'c0644e6a-92b3-11ee-9bd0-c3e82ed6f997',
-      center_id: 'snfac',
       url: {
         original: 'https://avalanche-org-media-staging.s3.us-west-2.amazonaws.com/alpine_meadows_656de600952a3.pdf',
       },
       type: 'pdf',
-      status: 'published',
-      title: 'Apline Meadows',
-      caption: 'Apline Meadows',
-      taken_by: null,
-      forecast_zone_id: ['293'],
-      location: null,
-      category: null,
-      date_taken: null,
-      date_created: '2023-12-04T14:45:20+00:00',
-      date_updated: '2023-12-04T14:45:21+00:00',
-      source: null,
-      access: null,
-      favorite: false,
     };
     const mediaItem = mediaItemSchema.parse(item);
     expect(mediaItem.type).toEqual(MediaType.PDF);
+  });
+
+  it('parses an unrecognized media type as `unknown`', () => {
+    const item = {
+      id: 'c0644e6a-92b3-11ee-9bd0-c3e82ed6f997',
+      url: {
+        original: 'https://avalanche-org-media-staging.s3.us-west-2.amazonaws.com/alpine_meadows_656de600952a3.pdf',
+      },
+      type: 'foo',
+    };
+    const mediaItem = mediaItemSchema.parse(item);
+    expect(mediaItem.type).toEqual(MediaType.Unknown);
   });
 });


### PR DESCRIPTION
This isn't implemented on the NAC side yet, but they're going to start allowing people to attach PDFs to observations. This PR doesn't add support for displaying PDFs - it just does the bare minimum to keep the app from crashing when it tries to parse one of these new responses. I added a test to verify that it parses correctly.

I also added a fallback path, so if a new type gets added in the future it won't break the app - it will just get parsed as type `unknown`. 

@thechrislundy can you look at `types/nationalAvalancheCenter/tests/mediaitem.test.ts` and make sure that the structure of the object matches what you will be sending?

cc @stevekuznetsov @charlotteguard we'll want to push this out OTA soon