### PR TITLE
Use same analytics ID for PostHog & Mixpanel, and show it in the About page

### DIFF
--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -14,9 +14,13 @@ import {ActionList} from 'components/content/ActionList';
 import {Center, HStack, View, VStack} from 'components/core';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
 import {getUpdateGroupId, getUpdateTimeAsVersionString} from 'hooks/useEASUpdateStatus';
+import {usePreferences} from 'Preferences';
 import {MenuStackParamList} from 'routes';
 
 export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about'>) => {
+  const {
+    preferences: {mixpanelUserId},
+  } = usePreferences();
   const [updateGroupId] = useState(getUpdateGroupId());
   const openUrl = useCallback(({data}: {data: string}) => void WebBrowser.openBrowserAsync(data), []);
   const copyVersionInfoToClipboard = useCallback(() => {
@@ -26,10 +30,11 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
 Build date ${getUpdateTimeAsVersionString()}
 Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
 Update group ID ${updateGroupId} (channel: ${Updates.channel || 'development'})
-Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})`,
+Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})
+User ID ${mixpanelUserId || 'n/a'}`,
       );
     })();
-  }, [updateGroupId]);
+  }, [mixpanelUserId, updateGroupId]);
 
   return (
     <View style={StyleSheet.absoluteFillObject}>
@@ -66,6 +71,7 @@ Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})`,
                 Update: {updateGroupId} ({Updates.channel || 'development'})
               </BodyXSm>
             )}
+            {mixpanelUserId && <BodyXSm>User ID: {mixpanelUserId}</BodyXSm>}
           </VStack>
           <Ionicons.Button name="copy-outline" size={12} color="black" style={{backgroundColor: 'white'}} iconStyle={{marginRight: 0}} onPress={copyVersionInfoToClipboard} />
         </HStack>


### PR DESCRIPTION
This fixes #607. With this, we can get a user ID from someone and add them to a PostHog cohort, which in turn can be used to control a feature flag.

Here's my user ID displayed in the about page:

<img width="295" alt="image" src="https://github.com/NWACus/avy/assets/101196/e3cf61bb-395f-4ec5-ac3c-821d22750d1d">

---

And here's that user ID in the "Early access" cohort in PostHog:

<img width="1173" alt="image" src="https://github.com/NWACus/avy/assets/101196/0f7ff8a6-46f8-40e6-9383-92d7032c12f7">

---

And here's the feature flag rule for a user in the cohort:

<img width="794" alt="image" src="https://github.com/NWACus/avy/assets/101196/8f563e4e-87bc-42c4-9c69-6c8cae01ee9f">

---

And here's the flag being returned as true for my user:

<img width="1279" alt="image" src="https://github.com/NWACus/avy/assets/101196/1f04f635-9c00-4650-aafd-6767ea7399b7">

---

And (finally!) here's me running the new weather table because the feature flag is on:

<img width="374" alt="image" src="https://github.com/NWACus/avy/assets/101196/f23c1159-a860-48b5-87c5-569c91c8843e">
