### PR TITLE
Preserve user ID when clearing preferences

### DIFF
--- a/Preferences.test.tsx
+++ b/Preferences.test.tsx
@@ -91,6 +91,7 @@ describe('Preferences', () => {
       const {result, waitForNextUpdate} = renderHook(() => usePreferences(), {wrapper: PreferencesProvider});
       expect(result.current.preferences.mixpanelUserId).toBeUndefined();
       await waitForNextUpdate();
+      // The center is invalid, so preferences parsing will fail. The previous user id is lost, and we get a different UUID in its place.
       expect(result.current.preferences.mixpanelUserId).toMatch(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/);
       expect(result.current.preferences.mixpanelUserId).not.toEqual(userId);
     });

--- a/Preferences.tsx
+++ b/Preferences.tsx
@@ -40,7 +40,7 @@ interface PreferencesProviderProps {
 }
 
 export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({children}) => {
-  const [preferences, setFullPreferences] = useState<Preferences>(defaultPreferences);
+  const [preferences, setPreferences] = useState<Preferences>(defaultPreferences);
 
   useAsyncEffect(async () => {
     let storedPreferences = {};
@@ -52,7 +52,7 @@ export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({childre
       // But do log it to Sentry as it shouldn't happen
       Sentry.Native.captureException(e);
     }
-    setPreferences(
+    setPartialPreferences(
       merge(
         {},
         defaultPreferences,
@@ -69,16 +69,16 @@ export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({childre
     void AsyncStorage.setItem(PREFERENCES_KEY, JSON.stringify(preferences));
   }, [preferences]);
 
-  const setPreferences = (newPreferences: Partial<Preferences>) => {
-    setFullPreferences(merge({}, preferences, newPreferences));
+  const setPartialPreferences = (newPreferences: Partial<Preferences>) => {
+    setPreferences(merge({}, preferences, newPreferences));
   };
 
   const clearPreferences = () => {
     // Clear everything _except_ the mixpanelUserId. It might not be set yet, but if it is we don't want to lose it.
-    setFullPreferences({...defaultPreferences, mixpanelUserId: preferences.mixpanelUserId});
+    setPreferences({...defaultPreferences, mixpanelUserId: preferences.mixpanelUserId});
   };
 
-  return <PreferencesContext.Provider value={{preferences, setPreferences, clearPreferences}}>{children}</PreferencesContext.Provider>;
+  return <PreferencesContext.Provider value={{preferences, setPreferences: setPartialPreferences, clearPreferences}}>{children}</PreferencesContext.Provider>;
 };
 
 export const usePreferences = () => useContext(PreferencesContext);

--- a/Preferences.tsx
+++ b/Preferences.tsx
@@ -26,11 +26,13 @@ const defaultPreferences = preferencesSchema.parse({});
 interface PreferencesContextType {
   preferences: Preferences;
   setPreferences: (preferences: Partial<Preferences>) => void;
+  clearPreferences: () => void;
 }
 
 const PreferencesContext = createContext<PreferencesContextType>({
   preferences: defaultPreferences,
   setPreferences: () => undefined,
+  clearPreferences: () => undefined,
 });
 
 interface PreferencesProviderProps {
@@ -46,7 +48,7 @@ export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({childre
       storedPreferences = preferencesSchema.parse(JSON.parse((await AsyncStorage.getItem(PREFERENCES_KEY)) ?? '{}'));
     } catch (e) {
       // Error parsing preferences, ignore as we'll fall back to defaults
-      await clearPreferences();
+      await AsyncStorage.removeItem(PREFERENCES_KEY);
       // But do log it to Sentry as it shouldn't happen
       Sentry.Native.captureException(e);
     }
@@ -71,12 +73,16 @@ export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({childre
     setFullPreferences(merge({}, preferences, newPreferences));
   };
 
-  return <PreferencesContext.Provider value={{preferences, setPreferences}}>{children}</PreferencesContext.Provider>;
+  const clearPreferences = () => {
+    // Clear everything _except_ the mixpanelUserId. It might not be set yet, but if it is we don't want to lose it.
+    setFullPreferences({...defaultPreferences, mixpanelUserId: preferences.mixpanelUserId});
+  };
+
+  return <PreferencesContext.Provider value={{preferences, setPreferences, clearPreferences}}>{children}</PreferencesContext.Provider>;
 };
 
 export const usePreferences = () => useContext(PreferencesContext);
 
-export const clearPreferences = async () => {
-  await AsyncStorage.removeItem(PREFERENCES_KEY);
+export const resetPreferencesForTests = async () => {
   await AsyncStorage.setItem(PREFERENCES_KEY, JSON.stringify(defaultPreferences));
 };

--- a/components/screens/menu/SecretMenu.tsx
+++ b/components/screens/menu/SecretMenu.tsx
@@ -56,7 +56,7 @@ import {
 import {QUERY_CACHE_ASYNC_STORAGE_KEY} from 'data/asyncStorageKeys';
 import {logFilePath, logger} from 'logger';
 import {sendMail} from 'network/sendMail';
-import {clearPreferences, usePreferences} from 'Preferences';
+import {usePreferences} from 'Preferences';
 import Toast from 'react-native-toast-message';
 import {colorLookup} from 'theme';
 import {RequestedTime, requestedTimeToUTCDate, toISOStringUTC} from 'utils/date';
@@ -74,7 +74,7 @@ export const SecretMenu: React.FC<SecretMenuProps> = ({staging, setStaging}) => 
 
     logger.info({environment: staging ? 'production' : 'staging'}, 'switching environment');
   }, [staging, setStaging]);
-  const {preferences, setPreferences} = usePreferences();
+  const {preferences, setPreferences, clearPreferences} = usePreferences();
   return (
     <CollapsibleCard
       startsCollapsed={preferences.secretMenuCollapsed}


### PR DESCRIPTION
We use the "Reset preferences" option in the Secret Menu when we're testing and we want to go through startup flows again. But the unique user ID assigned when the user first runs the app is not a thing we should clear every time - we should keep it if possible! That way, we can consistently map events, feature flags etc to the same ID even after preferences are cleared.