### PR TITLE
Add title to uploaded images

### DIFF
--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -519,6 +519,7 @@ const imageUploadTask = (): TaskQueueEntry => ({
       exif: {Orientation: 1},
     },
     name: `created ${new Date().toLocaleTimeString()}`,
+    title: 'Public Observation: Snoqualmie Pass',
     center_id: 'NWAC',
     photoUsage: MediaUsage.Credit,
   },

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -192,6 +192,7 @@ export class ObservationUploader {
                 : undefined,
             },
             name: name ?? '',
+            title: `Public Observation: ${observationFormData.location_name}`,
             center_id: center_id,
             photoUsage: photoUsage ?? MediaUsage.Credit,
           },

--- a/components/observations/uploader/Task.ts
+++ b/components/observations/uploader/Task.ts
@@ -26,6 +26,7 @@ const taskQueueEntrySchema = z.discriminatedUnion('type', [
           .optional(),
       }),
       name: z.string(),
+      title: z.string(),
       center_id: avalancheCenterIDSchema,
       photoUsage: z.nativeEnum(MediaUsage),
     }),

--- a/components/observations/uploader/uploadImage.ts
+++ b/components/observations/uploader/uploadImage.ts
@@ -50,7 +50,6 @@ const loadImageData = async ({uri, width, height}: PickedImage): Promise<{imageD
 };
 
 export const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage, title}: UploadImageOptions): Promise<MediaItem> => {
-  console.log('uploadImage', JSON.stringify(image, null, 2));
   const {imageDataBase64, filename, mimeType} = await loadImageData(image);
 
   const payload = {

--- a/components/observations/uploader/uploadImage.ts
+++ b/components/observations/uploader/uploadImage.ts
@@ -17,6 +17,7 @@ interface UploadImageOptions {
   center_id: AvalancheCenterID;
   image: PickedImage;
   name: string;
+  title: string;
   photoUsage: MediaUsage;
 }
 
@@ -48,7 +49,8 @@ const loadImageData = async ({uri, width, height}: PickedImage): Promise<{imageD
   return {imageDataBase64: result.base64 ?? '', filename, mimeType: 'image/jpeg'};
 };
 
-export const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage}: UploadImageOptions): Promise<MediaItem> => {
+export const uploadImage = async (taskId: string, {apiPrefix, image, name, center_id, photoUsage, title}: UploadImageOptions): Promise<MediaItem> => {
+  console.log('uploadImage', JSON.stringify(image, null, 2));
   const {imageDataBase64, filename, mimeType} = await loadImageData(image);
 
   const payload = {
@@ -60,6 +62,7 @@ export const uploadImage = async (taskId: string, {apiPrefix, image, name, cente
     taken_by: name,
     access: photoUsage,
     source: 'public',
+    title,
     // TODO would be nice to tag images that came from this app, but haven't figured that out yet
   };
 


### PR DESCRIPTION
This plumbs through `title` so that it shows up in the NAC media dashboard. Tested end-to-end by uploading a private ob with photos attached and verified that the title shows up as `Public Observation: <<location name>>`.

<img width="930" alt="image" src="https://github.com/NWACus/avy/assets/101196/bca53b4b-8729-4e08-be08-1404db982d2e">

cc @stevekuznetsov @charlotteguard 