### PR TITLE
Set 'Date taken' field for images uploaded to NAC

### DIFF
--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -185,9 +185,8 @@ export class ObservationUploader {
               height: image.height,
               exif: image.exif
                 ? {
-                    // The type of ImagePickerAsset.exif is (unfortunately) Record<string, any>
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    Orientation: image.exif.Orientation,
+                    Orientation: typeof image.exif.Orientation === 'string' || typeof image.exif.Orientation === 'number' ? image.exif.Orientation : undefined,
+                    DateTimeOriginal: typeof image.exif.DateTimeOriginal === 'string' ? image.exif.DateTimeOriginal : undefined,
                   }
                 : undefined,
             },

--- a/components/observations/uploader/Task.ts
+++ b/components/observations/uploader/Task.ts
@@ -22,6 +22,7 @@ const taskQueueEntrySchema = z.discriminatedUnion('type', [
         exif: z
           .object({
             Orientation: z.number().or(z.string()).optional(),
+            DateTimeOriginal: z.string().optional(),
           })
           .optional(),
       }),

--- a/components/observations/uploader/uploadImage.test.ts
+++ b/components/observations/uploader/uploadImage.test.ts
@@ -1,0 +1,35 @@
+import {captureDateFromExif} from 'components/observations/uploader/uploadImage';
+
+describe('captureDateFromExif', () => {
+  it('should return null if exif is undefined', () => {
+    const result = captureDateFromExif(undefined);
+    expect(result).toBeNull();
+  });
+
+  it('should return null if exif.DateTimeOriginal is undefined', () => {
+    const exif = {
+      Orientation: 1,
+    };
+    const result = captureDateFromExif(exif);
+    expect(result).toBeNull();
+  });
+
+  test.each(['2023-12-14', '2023/12/14', '2023/12/14T20:15:05.250Z', '2023:12:14', '2023-12-14T20:15:05.250Z'])(
+    `should return null if exif.DateTimeOriginal does not follow the expected format (input: %s)`,
+    DateTimeOriginal => {
+      const exif = {
+        DateTimeOriginal,
+      };
+      const result = captureDateFromExif(exif);
+      expect(result).toBeNull();
+    },
+  );
+
+  it('should return the date string if exif.DateTimeOriginal is defined correctly', () => {
+    const exif = {
+      DateTimeOriginal: '2023:12:14 11:39:48',
+    };
+    const result = captureDateFromExif(exif);
+    expect(result).toBe('2023-12-14');
+  });
+});


### PR DESCRIPTION
When we resize images before uploading, we lose EXIF metadata (AFAIK this statement is true for the Avy app _and_ for the web). A general solution for preserving the metadata is going to be hard and would require a *lot* of testing, but luckily the NAC API exposes a param for passing `date_taken` when uploading the image. So we grab the capture date from the original image's EXIF data (which is returned from the Expo image picker) and then we set the `date_taken` param appropriately.

The `captureDateFromExif` function is intentionally very conservative and failure-tolerant (and has tests to back that up). The worst case is that we fall back to the current behavior, where the "Date taken" field isn't set at all.

Here's an image I uploaded that has the "Date taken" field set correctly. It's a pretty great picture, I know.

<img width="955" alt="image" src="https://github.com/NWACus/avy/assets/101196/fbdd808b-2f37-4332-83a3-aab273f1fd6f">

cc @ccorey @stevekuznetsov @thechrislundy 
