### PR TITLE
Run the newest version of Expo Doctor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,4 +59,4 @@ jobs:
       - name: 🏗 Setup build environment
         uses: ./.github/actions/setup
       - name: 👩‍⚕️ Expo Doctor
-        run: npx expo-doctor
+        run: EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx expo-doctor@latest


### PR DESCRIPTION
This should fix CI failures, now that https://github.com/expo/expo/pull/25822 is landed