### PR TITLE
Campaigns: support multiple locations, mixpanel tracking, better type safety

### DIFF
--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -23,7 +23,6 @@ import {FontAwesome, MaterialCommunityIcons, MaterialIcons} from '@expo/vector-i
 import {useNavigation} from '@react-navigation/native';
 import {compareDesc, parseISO} from 'date-fns';
 import * as Linking from 'expo-linking';
-import {useFeatureFlag} from 'posthog-react-native';
 
 import {colorFor} from 'components/AvalancheDangerTriangle';
 import {Button} from 'components/content/Button';
@@ -35,7 +34,7 @@ import {NACIcon} from 'components/icons/nac-icons';
 import {ObservationFilterConfig, ObservationsFilterForm, createDefaultFilterConfig, filtersForConfig, matchesZone} from 'components/observations/ObservationsFilterForm';
 import {usePendingObservations} from 'components/observations/uploader/usePendingObservations';
 import {Body, BodyBlack, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
-import {campaignManager} from 'data/campaigns/campaignManager';
+import useCampaign from 'data/campaigns/useCampaign';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
 import {useNWACObservations} from 'hooks/useNWACObservations';
@@ -79,13 +78,12 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal}] = useToggle(false);
   const mapResult = useMapLayer(center_id);
   const mapLayer = mapResult.data;
-  const [campaignActive] = useState(campaignManager.campaignActive('campaign-q4-2023'));
-  const campaignFeatureFlag = !!useFeatureFlag('campaign-q4-2023');
-  const showCampaign = campaignActive && campaignFeatureFlag && center_id === 'NWAC';
+  const [showCampaign, trackCampaign] = useCampaign('campaign-q4-2023', 'observation-list-view');
   const openCampaignLink = useCallback(() => {
+    trackCampaign();
     const url = 'https://give.nwac.us/campaign/nwacs-year-end-fundraiser/c536433';
     Linking.openURL(url).catch((error: Error) => logger.error('Error opening URL', {error, url}));
-  }, []);
+  }, [trackCampaign]);
 
   // Filter inputs changed via render props should overwrite our current state
   useEffect(() => {

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -34,7 +34,7 @@ import {NACIcon} from 'components/icons/nac-icons';
 import {ObservationFilterConfig, ObservationsFilterForm, createDefaultFilterConfig, filtersForConfig, matchesZone} from 'components/observations/ObservationsFilterForm';
 import {usePendingObservations} from 'components/observations/uploader/usePendingObservations';
 import {Body, BodyBlack, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
-import useCampaign from 'data/campaigns/useCampaign';
+import {useCampaign} from 'data/campaigns/useCampaign';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
 import {useNWACObservations} from 'hooks/useNWACObservations';

--- a/data/campaigns/campaignManager.test.ts
+++ b/data/campaigns/campaignManager.test.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import {CAMPAIGN_DATA_KEY} from 'data/asyncStorageKeys';
-import {CampaignViewsSchema, ICampaignManager, createCampaignManagerForTests} from 'data/campaigns/campaignManager';
+import {AllCampaignsViewData, ICampaignManager, createCampaignManagerForTests} from 'data/campaigns/campaignManager';
 import CAMPAIGNS, {UNLIMITED_VIEWS_PER_DAY} from 'data/campaigns/campaigns';
 
 describe('campaignManager', () => {
@@ -55,7 +55,7 @@ describe('campaignManager', () => {
       const today = new Date('2023-12-15');
       await campaignManager.recordCampaignView(campaignId, 'home-screen', today);
 
-      const campaignViews = JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) || '{}') as CampaignViewsSchema;
+      const campaignViews = JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) || '{}') as AllCampaignsViewData;
       expect(campaignViews).toEqual({
         'test-enabled-campaign': {
           'home-screen': {
@@ -86,7 +86,7 @@ describe('campaignManager', () => {
       const today = new Date('2023-12-15');
       await campaignManager.recordCampaignView(campaignId, 'home-screen', today);
 
-      const campaignViews = JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) || '{}') as CampaignViewsSchema;
+      const campaignViews = JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) || '{}') as AllCampaignsViewData;
       expect(campaignViews).toEqual({
         'test-enabled-campaign': {
           'home-screen': {
@@ -158,7 +158,7 @@ describe('campaignManager', () => {
       const currentDate = new Date('2023-12-15');
       await campaignManager.recordCampaignView(campaignId, 'home-screen', currentDate);
 
-      const campaignViews = JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) || '{}') as CampaignViewsSchema;
+      const campaignViews = JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) || '{}') as AllCampaignsViewData;
       expect(campaignViews).toEqual({
         'test-enabled-campaign': {
           'home-screen': {

--- a/data/campaigns/campaignManager.ts
+++ b/data/campaigns/campaignManager.ts
@@ -2,16 +2,18 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {CAMPAIGN_DATA_KEY} from 'data/asyncStorageKeys';
-import CAMPAIGNS, {CampaignId} from 'data/campaigns/campaigns';
+import CAMPAIGNS, {CampaignId, UNLIMITED_VIEWS_PER_DAY} from 'data/campaigns/campaigns';
 import {differenceInCalendarDays} from 'date-fns';
 import {logger} from 'logger';
 import * as Sentry from 'sentry-expo';
 import {z} from 'zod';
 
-const campaignViewSchema = z.object({
-  lastDisplayed: z.coerce.date().optional(),
-  timesDisplayed: z.number(),
-});
+const campaignViewSchema = z.record(
+  z.object({
+    lastDisplayed: z.coerce.date().optional(),
+    timesDisplayed: z.number(),
+  }),
+);
 
 type CampaignViewSchema = z.infer<typeof campaignViewSchema>;
 
@@ -19,19 +21,15 @@ const campaignViewsSchema = z.record(campaignViewSchema);
 export type CampaignViewsSchema = z.infer<typeof campaignViewsSchema>;
 
 export interface ICampaignManager {
-  /** Given a date, checks if the given campaign is active for that date. Does not reflect
-   * view counts or lastDisplayed values. Use for less intrusive elements. */
-  campaignActive(campaignId: CampaignId, atDate?: Date): boolean;
-
   /** Given a date, calls campaignActive to see if the given campaign is active for that date,
    * and then checks `lastDisplayed` date and `viewsPerDay` to decide if the campaign should be shown.
-   * Used for more intrusive campaigns elements such as modals. */
-  shouldShowCampaign(campaignId: CampaignId, atDate?: Date): boolean;
+   */
+  shouldShowCampaign(campaignId: CampaignId, location: string, atDate?: Date): boolean;
 
   /** Records a campaign view for the given campaignId. Use along with shouldShowCampaign to track
    * views of more intrusive campaign elements.
    * @see shouldShowCampaign */
-  recordCampaignView(campaignId: CampaignId, atDate?: Date): Promise<void>;
+  recordCampaignView(campaignId: CampaignId, location: string, atDate?: Date): Promise<void>;
 }
 
 class CampaignManager implements ICampaignManager {
@@ -46,7 +44,7 @@ class CampaignManager implements ICampaignManager {
         // Filter out data from campaigns that don't exist anymore
         Object.entries(campaignViews).forEach(([campaignId, campaignView]) => {
           if (campaignId in CAMPAIGNS) {
-            this.campaignViews[campaignId as CampaignId] = campaignView;
+            this.campaignViews[campaignId] = campaignView;
           }
         });
       } catch (e) {
@@ -73,36 +71,34 @@ class CampaignManager implements ICampaignManager {
     await AsyncStorage.setItem(CAMPAIGN_DATA_KEY, JSON.stringify(this.campaignViews));
   }
 
-  campaignActive(campaignId: CampaignId, atDate: Date | undefined = undefined): boolean {
+  shouldShowCampaign(campaignId: CampaignId, location: string, atDate: Date | undefined = undefined): boolean {
     this.checkInitialized();
     const campaign = CAMPAIGNS[campaignId];
     const date = atDate ?? new Date();
-    return campaign.enabled && date >= campaign.startDate && date < campaign.endDate;
-  }
-
-  shouldShowCampaign(campaignId: CampaignId, atDate: Date | undefined = undefined): boolean {
-    this.checkInitialized();
-    const campaign = CAMPAIGNS[campaignId];
-    const date = atDate ?? new Date();
-    const campaignActive = this.campaignActive(campaignId, date);
+    const campaignActive = campaign.enabled && date >= campaign.startDate && date < campaign.endDate;
     if (!campaignActive) {
       return false;
     }
-    const campaignView = this.campaignViews[campaignId];
+    const campaignView = this.campaignViews[campaignId]?.[location];
     if (!campaignView || !campaignView.lastDisplayed) {
       return true;
     }
+    const viewsPerDay = campaign.locations[location].viewsPerDay ?? UNLIMITED_VIEWS_PER_DAY;
+    const moreViewsAllowed = viewsPerDay === UNLIMITED_VIEWS_PER_DAY || campaignView.timesDisplayed < viewsPerDay;
 
-    return differenceInCalendarDays(date, campaignView.lastDisplayed) >= 1 || campaignView.timesDisplayed < campaign.viewsPerDay;
+    return differenceInCalendarDays(date, campaignView.lastDisplayed) >= 1 || moreViewsAllowed;
   }
 
-  async recordCampaignView(campaignId: CampaignId, atDate: Date | undefined = undefined) {
+  async recordCampaignView(campaignId: CampaignId, location: string, atDate: Date | undefined = undefined) {
     this.checkInitialized();
 
     const date = atDate ?? new Date();
-    const campaignView = this.campaignViews[campaignId];
+    if (!this.campaignViews[campaignId]) {
+      this.campaignViews[campaignId] = {};
+    }
+    const campaignView = this.campaignViews[campaignId]?.[location];
     if (!campaignView) {
-      this.campaignViews[campaignId] = {
+      this.campaignViews[campaignId][location] = {
         lastDisplayed: date,
         timesDisplayed: 1,
       };

--- a/data/campaigns/campaignManager.ts
+++ b/data/campaigns/campaignManager.ts
@@ -2,49 +2,51 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {CAMPAIGN_DATA_KEY} from 'data/asyncStorageKeys';
-import CAMPAIGNS, {CampaignId, UNLIMITED_VIEWS_PER_DAY} from 'data/campaigns/campaigns';
+import CAMPAIGNS, {CampaignId, CampaignLocationId, UNLIMITED_VIEWS_PER_DAY} from 'data/campaigns/campaigns';
 import {differenceInCalendarDays} from 'date-fns';
 import {logger} from 'logger';
 import * as Sentry from 'sentry-expo';
 import {z} from 'zod';
 
-const campaignViewSchema = z.record(
-  z.object({
-    lastDisplayed: z.coerce.date().optional(),
-    timesDisplayed: z.number(),
-  }),
-);
+const campaignLocationViewDataSchema = z.object({
+  lastDisplayed: z.coerce.date().optional(),
+  timesDisplayed: z.number(),
+});
+type CampaignLocationViewData = z.infer<typeof campaignLocationViewDataSchema>;
 
-type CampaignViewSchema = z.infer<typeof campaignViewSchema>;
-
-const campaignViewsSchema = z.record(campaignViewSchema);
-export type CampaignViewsSchema = z.infer<typeof campaignViewsSchema>;
+const campaignViewDataSchema = z.record(campaignLocationViewDataSchema);
+const allCampaignsViewData = z.record(campaignViewDataSchema);
+export type AllCampaignsViewData = z.infer<typeof allCampaignsViewData>;
 
 export interface ICampaignManager {
   /** Given a date, calls campaignActive to see if the given campaign is active for that date,
    * and then checks `lastDisplayed` date and `viewsPerDay` to decide if the campaign should be shown.
    */
-  shouldShowCampaign(campaignId: CampaignId, location: string, atDate?: Date): boolean;
+  shouldShowCampaign<T extends CampaignId>(campaignId: T, location: CampaignLocationId<T>, atDate?: Date): boolean;
 
   /** Records a campaign view for the given campaignId. Use along with shouldShowCampaign to track
    * views of more intrusive campaign elements.
    * @see shouldShowCampaign */
-  recordCampaignView(campaignId: CampaignId, location: string, atDate?: Date): Promise<void>;
+  recordCampaignView<T extends CampaignId>(campaignId: T, location: CampaignLocationId<T>, atDate?: Date): Promise<void>;
 }
 
 class CampaignManager implements ICampaignManager {
   private initialized = false;
-  private campaignViews: Record<CampaignId, CampaignViewSchema> = {} as Record<CampaignId, CampaignViewSchema>;
+  private campaignViews: AllCampaignsViewData = {} as AllCampaignsViewData;
   private logger = logger.child({component: 'CampaignManager'});
 
   async initialize() {
     if (!this.initialized) {
       try {
-        const campaignViews = campaignViewsSchema.parse(JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) ?? '{}'));
-        // Filter out data from campaigns that don't exist anymore
+        const campaignViews = allCampaignsViewData.parse(JSON.parse((await AsyncStorage.getItem(CAMPAIGN_DATA_KEY)) ?? '{}'));
+        // Only extract data from campaigns that are currently in use
         Object.entries(campaignViews).forEach(([campaignId, campaignView]) => {
           if (campaignId in CAMPAIGNS) {
-            this.campaignViews[campaignId] = campaignView;
+            Object.entries(campaignView).forEach(([location, locationView]) => {
+              if (location in CAMPAIGNS[campaignId as CampaignId].locations) {
+                this.setCampaignViewData(campaignId as CampaignId, location as CampaignLocationId<CampaignId>, locationView);
+              }
+            });
           }
         });
       } catch (e) {
@@ -55,7 +57,6 @@ class CampaignManager implements ICampaignManager {
       }
       this.initialized = true;
     }
-    return this.campaignViews;
   }
 
   private checkInitialized() {
@@ -66,12 +67,36 @@ class CampaignManager implements ICampaignManager {
   }
 
   private async saveCampaignViews() {
-    this.checkInitialized();
-    // todo: debounce
     await AsyncStorage.setItem(CAMPAIGN_DATA_KEY, JSON.stringify(this.campaignViews));
   }
 
-  shouldShowCampaign(campaignId: CampaignId, location: string, atDate: Date | undefined = undefined): boolean {
+  private getCampaignViewData<T extends CampaignId>(campaignId: T, location: CampaignLocationId<T>): CampaignLocationViewData {
+    if (typeof location !== 'string') {
+      // this should never happen. typescript simultaneously can tell you that only selected strings are allowed for `location`,
+      // and yet also treats it as string | symbol | number when you try to index into an object with it. this check
+      // makes the compiler behave as expected.
+      throw new Error(`Invalid location type for ${location.toString()}`);
+    }
+
+    const data = this.campaignViews[campaignId]?.[location] || {lastDisplayed: undefined, timesDisplayed: 0};
+
+    // Return a copy of the data so that we don't accidentally mutate it
+    return {...data};
+  }
+
+  private setCampaignViewData<T extends CampaignId>(campaignId: T, location: CampaignLocationId<T>, data: CampaignLocationViewData): void {
+    if (typeof location !== 'string') {
+      // this should never happen. typescript simultaneously can tell you that only selected strings are allowed for `location`,
+      // and yet also treats it as string | symbol | number when you try to index into an object with it. this check
+      // makes the compiler behave as expected.
+      throw new Error(`Invalid location type for ${location.toString()}`);
+    }
+
+    this.campaignViews[campaignId] = this.campaignViews[campaignId] || {};
+    this.campaignViews[campaignId][location] = data;
+  }
+
+  shouldShowCampaign<T extends CampaignId>(campaignId: T, location: CampaignLocationId<T>, atDate: Date | undefined = undefined): boolean {
     this.checkInitialized();
     const campaign = CAMPAIGNS[campaignId];
     const date = atDate ?? new Date();
@@ -79,37 +104,31 @@ class CampaignManager implements ICampaignManager {
     if (!campaignActive) {
       return false;
     }
-    const campaignView = this.campaignViews[campaignId]?.[location];
-    if (!campaignView || !campaignView.lastDisplayed) {
+    const campaignView = this.getCampaignViewData(campaignId, location);
+    if (!campaignView.lastDisplayed) {
       return true;
     }
-    const viewsPerDay = campaign.locations[location].viewsPerDay ?? UNLIMITED_VIEWS_PER_DAY;
+
+    // Typescript gets really lost here trying to infer the type of campaign.locations[location]
+    const locationData = (campaign.locations as Record<string, {viewsPerDay: number}>)[location as string] ?? {viewsPerDay: UNLIMITED_VIEWS_PER_DAY};
+    const viewsPerDay = locationData.viewsPerDay;
     const moreViewsAllowed = viewsPerDay === UNLIMITED_VIEWS_PER_DAY || campaignView.timesDisplayed < viewsPerDay;
 
     return differenceInCalendarDays(date, campaignView.lastDisplayed) >= 1 || moreViewsAllowed;
   }
 
-  async recordCampaignView(campaignId: CampaignId, location: string, atDate: Date | undefined = undefined) {
+  async recordCampaignView<T extends CampaignId>(campaignId: T, location: CampaignLocationId<T>, atDate: Date | undefined = undefined) {
     this.checkInitialized();
 
     const date = atDate ?? new Date();
-    if (!this.campaignViews[campaignId]) {
-      this.campaignViews[campaignId] = {};
+    const campaignView = this.getCampaignViewData(campaignId, location);
+    const lastDisplayed = campaignView.lastDisplayed;
+    campaignView.lastDisplayed = date;
+    if (lastDisplayed && differenceInCalendarDays(date, lastDisplayed) >= 1) {
+      campaignView.timesDisplayed = 0;
     }
-    const campaignView = this.campaignViews[campaignId]?.[location];
-    if (!campaignView) {
-      this.campaignViews[campaignId][location] = {
-        lastDisplayed: date,
-        timesDisplayed: 1,
-      };
-    } else {
-      const lastDisplayed = campaignView.lastDisplayed;
-      campaignView.lastDisplayed = date;
-      if (lastDisplayed && differenceInCalendarDays(date, lastDisplayed) >= 1) {
-        campaignView.timesDisplayed = 0;
-      }
-      campaignView.timesDisplayed += 1;
-    }
+    campaignView.timesDisplayed += 1;
+    this.setCampaignViewData(campaignId, location, campaignView);
     await this.saveCampaignViews();
   }
 }

--- a/data/campaigns/campaigns.ts
+++ b/data/campaigns/campaigns.ts
@@ -1,13 +1,13 @@
-export const UNLIMITED_VIEWS_PER_DAY = -1;
+export const ALWAYS_SHOW = 0;
 
 /**
  * This object defines campaigns that can be shown to users. Each campaign has a start and end date, and a list of
- * locations where it can be shown. Each location has a maximum number of times the campaign can be shown per day.
+ * locations where it can be shown. Each location has a frequency, indicating how many milliseconds must elapse between showings.
  * Some locations are unobtrusive and will show the campaign every time, while others like a modal popup will only
- * show a fixed number of times per day.
+ * show at a slower rate.
  *
  * The campaign manager will keep track of how many times a campaign has been shown in each location, and will
- * automatically prevent the campaign from being shown more than the maximum number of times per day.
+ * automatically prevent the campaign from being shown faster than the frequency allows.
  *
  * It's recommended to use the `useCampaign` hook to check if a campaign should be shown, as it will handle all the common tasks involved:
  * - Checking the campaign feature flag
@@ -22,10 +22,10 @@ const CAMPAIGNS = {
     enabled: true,
     locations: {
       'observation-list-view': {
-        viewsPerDay: UNLIMITED_VIEWS_PER_DAY,
+        frequency: ALWAYS_SHOW,
       },
       'map-view': {
-        viewsPerDay: 1,
+        frequency: 8 * 60 * 60 * 1000, // 8 hours
       },
     },
   },
@@ -37,10 +37,10 @@ const CAMPAIGNS = {
     enabled: true,
     locations: {
       'home-screen': {
-        viewsPerDay: 3,
+        frequency: 2 * 60 * 60 * 1000, // 2 hours
       },
       'always-show': {
-        viewsPerDay: UNLIMITED_VIEWS_PER_DAY,
+        frequency: ALWAYS_SHOW,
       },
     },
   },
@@ -50,7 +50,7 @@ const CAMPAIGNS = {
     enabled: false,
     locations: {
       'home-screen': {
-        viewsPerDay: 3,
+        frequency: 2 * 60 * 60 * 1000, // 2 hours
       },
     },
   },

--- a/data/campaigns/campaigns.ts
+++ b/data/campaigns/campaigns.ts
@@ -1,5 +1,20 @@
 export const UNLIMITED_VIEWS_PER_DAY = -1;
 
+/**
+ * This object defines campaigns that can be shown to users. Each campaign has a start and end date, and a list of
+ * locations where it can be shown. Each location has a maximum number of times the campaign can be shown per day.
+ * Some locations are unobtrusive and will show the campaign every time, while others like a modal popup will only
+ * show a fixed number of times per day.
+ *
+ * The campaign manager will keep track of how many times a campaign has been shown in each location, and will
+ * automatically prevent the campaign from being shown more than the maximum number of times per day.
+ *
+ * It's recommended to use the `useCampaign` hook to check if a campaign should be shown, as it will handle all the common tasks involved:
+ * - Checking the campaign feature flag
+ * - Calling the campaign manager to get enabled state and track views
+ * - Sending mixpanel events for campaign views and interactions
+ * @see data/campaigns/useCampaign.ts
+ */
 const CAMPAIGNS = {
   'campaign-q4-2023': {
     startDate: new Date('2023-12-01'),

--- a/data/campaigns/campaigns.ts
+++ b/data/campaigns/campaigns.ts
@@ -1,9 +1,31 @@
-const CAMPAIGNS = {
+export type Campaign = {
+  startDate: Date;
+  endDate: Date;
+  enabled: boolean;
+  locations: Record<
+    string,
+    {
+      // -1 means unlimited
+      viewsPerDay: number;
+    }
+  >;
+};
+export type Campaigns = Record<string, Campaign>;
+export const UNLIMITED_VIEWS_PER_DAY = -1;
+
+const CAMPAIGNS: Campaigns = {
   'campaign-q4-2023': {
     startDate: new Date('2023-12-01'),
     endDate: new Date('2024-01-01'),
     enabled: true,
-    viewsPerDay: 1,
+    locations: {
+      'observation-list-view': {
+        viewsPerDay: UNLIMITED_VIEWS_PER_DAY,
+      },
+      'map-view': {
+        viewsPerDay: 1,
+      },
+    },
   },
 
   // These are for unit testing purposes only - don't remove them
@@ -11,13 +33,24 @@ const CAMPAIGNS = {
     startDate: new Date('2023-12-01'),
     endDate: new Date('2024-01-01'),
     enabled: true,
-    viewsPerDay: 3,
+    locations: {
+      'home-screen': {
+        viewsPerDay: 3,
+      },
+      'always-show': {
+        viewsPerDay: UNLIMITED_VIEWS_PER_DAY,
+      },
+    },
   },
   'test-disabled-campaign': {
     startDate: new Date('2023-12-01'),
     endDate: new Date('2024-01-01'),
     enabled: false,
-    viewsPerDay: 1,
+    locations: {
+      'home-screen': {
+        viewsPerDay: 3,
+      },
+    },
   },
 };
 

--- a/data/campaigns/campaigns.ts
+++ b/data/campaigns/campaigns.ts
@@ -1,19 +1,6 @@
-export type Campaign = {
-  startDate: Date;
-  endDate: Date;
-  enabled: boolean;
-  locations: Record<
-    string,
-    {
-      // -1 means unlimited
-      viewsPerDay: number;
-    }
-  >;
-};
-export type Campaigns = Record<string, Campaign>;
 export const UNLIMITED_VIEWS_PER_DAY = -1;
 
-const CAMPAIGNS: Campaigns = {
+const CAMPAIGNS = {
   'campaign-q4-2023': {
     startDate: new Date('2023-12-01'),
     endDate: new Date('2024-01-01'),
@@ -52,8 +39,10 @@ const CAMPAIGNS: Campaigns = {
       },
     },
   },
-};
+} as const;
 
-export type CampaignId = keyof typeof CAMPAIGNS;
+export type Campaigns = typeof CAMPAIGNS;
+export type CampaignId = keyof Campaigns;
+export type CampaignLocationId<T extends CampaignId> = keyof Campaigns[T]['locations'];
 
 export default CAMPAIGNS;

--- a/data/campaigns/useCampaign.test.ts
+++ b/data/campaigns/useCampaign.test.ts
@@ -28,8 +28,8 @@ describe('useCampaign', () => {
     expect(campaignEnabled).toBe(true);
 
     expect(mixpanel.track).toHaveBeenCalledWith('Campaign viewed', {
-      campaignId,
-      location,
+      campaign: campaignId,
+      'campaign-location': location,
     });
   });
 
@@ -82,8 +82,8 @@ describe('useCampaign', () => {
       const [campaignEnabled, trackInteraction] = result.current;
       expect(campaignEnabled).toBe(true);
       expect(mixpanel.track).toHaveBeenCalledWith('Campaign viewed', {
-        campaignId,
-        location,
+        campaign: campaignId,
+        'campaign-location': location,
       });
 
       // Calling track interaction should send a mixpanel event on the first call, but not on subsequent calls
@@ -93,8 +93,8 @@ describe('useCampaign', () => {
 
       expect(mixpanel.track).toHaveBeenCalledTimes(2);
       expect(mixpanel.track).toHaveBeenLastCalledWith('Campaign interaction', {
-        campaignId,
-        location,
+        campaign: campaignId,
+        'campaign-location': location,
       });
     });
   });

--- a/data/campaigns/useCampaign.test.ts
+++ b/data/campaigns/useCampaign.test.ts
@@ -1,7 +1,7 @@
 /* ESLint reads references to mixpanel.track as attempts to call it */
 /* eslint-disable @typescript-eslint/unbound-method */
 import {renderHook} from '@testing-library/react-hooks';
-import useCampaign from 'data/campaigns/useCampaign';
+import {useCampaign} from 'data/campaigns/useCampaign';
 import mixpanel from 'mixpanel';
 import {useFeatureFlag} from 'posthog-react-native';
 

--- a/data/campaigns/useCampaign.test.ts
+++ b/data/campaigns/useCampaign.test.ts
@@ -1,0 +1,101 @@
+/* ESLint reads references to mixpanel.track as attempts to call it */
+/* eslint-disable @typescript-eslint/unbound-method */
+import {renderHook} from '@testing-library/react-hooks';
+import useCampaign from 'data/campaigns/useCampaign';
+import mixpanel from 'mixpanel';
+import {useFeatureFlag} from 'posthog-react-native';
+
+jest.mock('mixpanel', () => ({
+  track: jest.fn(),
+}));
+
+jest.mock('posthog-react-native', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+}));
+
+describe('useCampaign', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true for an enabled campaign', () => {
+    const campaignId = 'test-enabled-campaign';
+    const location = 'home-screen';
+    const currentDate = new Date('2023-12-15');
+
+    const {result} = renderHook(() => useCampaign(campaignId, location, currentDate));
+    const [campaignEnabled] = result.current;
+    expect(campaignEnabled).toBe(true);
+
+    expect(mixpanel.track).toHaveBeenCalledWith('Campaign viewed', {
+      campaignId,
+      location,
+    });
+  });
+
+  it('should return false for an disabled campaign', () => {
+    const campaignId = 'test-disabled-campaign';
+    const location = 'home-screen';
+    const currentDate = new Date('2023-12-15');
+
+    const {result} = renderHook(() => useCampaign(campaignId, location, currentDate));
+    const [campaignEnabled] = result.current;
+    expect(campaignEnabled).toBe(false);
+
+    expect(mixpanel.track).not.toHaveBeenCalled();
+  });
+
+  it('should return false for an enabled campaign when feature flag is off', () => {
+    const campaignId = 'test-enabled-campaign';
+    const location = 'home-screen';
+    const currentDate = new Date('2023-12-15');
+
+    (useFeatureFlag as jest.Mock).mockReturnValueOnce(false);
+
+    const {result} = renderHook(() => useCampaign(campaignId, location, currentDate));
+    const [campaignEnabled] = result.current;
+    expect(campaignEnabled).toBe(false);
+
+    expect(mixpanel.track).not.toHaveBeenCalled();
+  });
+
+  describe('trackInteraction', () => {
+    it('should be a no-op if called when the campaign is disabled', () => {
+      const campaignId = 'test-disabled-campaign';
+      const location = 'home-screen';
+      const currentDate = new Date('2023-12-15');
+
+      const {result} = renderHook(() => useCampaign(campaignId, location, currentDate));
+      const [campaignEnabled, trackInteraction] = result.current;
+      expect(campaignEnabled).toBe(false);
+
+      trackInteraction();
+      expect(mixpanel.track).not.toHaveBeenCalled();
+    });
+
+    it('should send a single Mixpanel event if called when the campaign is enabled', () => {
+      const campaignId = 'test-enabled-campaign';
+      const location = 'home-screen';
+      const currentDate = new Date('2023-12-15');
+
+      const {result} = renderHook(() => useCampaign(campaignId, location, currentDate));
+      const [campaignEnabled, trackInteraction] = result.current;
+      expect(campaignEnabled).toBe(true);
+      expect(mixpanel.track).toHaveBeenCalledWith('Campaign viewed', {
+        campaignId,
+        location,
+      });
+
+      // Calling track interaction should send a mixpanel event on the first call, but not on subsequent calls
+      trackInteraction();
+      trackInteraction();
+      trackInteraction();
+
+      expect(mixpanel.track).toHaveBeenCalledTimes(2);
+      expect(mixpanel.track).toHaveBeenLastCalledWith('Campaign interaction', {
+        campaignId,
+        location,
+      });
+    });
+  });
+});

--- a/data/campaigns/useCampaign.ts
+++ b/data/campaigns/useCampaign.ts
@@ -21,7 +21,7 @@ export function useCampaign<T extends CampaignId>(
       campaignManager.recordCampaignView(campaignId, location).catch((error: Error) => {
         logger.error('Failed to record campaign view', {campaignId, location, error});
       });
-      mixpanel.track('Campaign viewed', {campaignId, location});
+      mixpanel.track('Campaign viewed', {campaign: campaignId, 'campaign-location': location});
     }
   }, [campaignEnabled, campaignId, location, showEventSent]);
 
@@ -29,7 +29,7 @@ export function useCampaign<T extends CampaignId>(
   const trackInteraction = useCallback(() => {
     if (!interactionEventSent.current && campaignEnabled) {
       interactionEventSent.current = true;
-      mixpanel.track('Campaign interaction', {campaignId, location});
+      mixpanel.track('Campaign interaction', {campaign: campaignId, 'campaign-location': location});
     }
   }, [campaignEnabled, campaignId, interactionEventSent, location]);
 

--- a/data/campaigns/useCampaign.ts
+++ b/data/campaigns/useCampaign.ts
@@ -1,0 +1,35 @@
+import {campaignManager} from 'data/campaigns/campaignManager';
+import {CampaignId} from 'data/campaigns/campaigns';
+import {logger} from 'logger';
+import mixpanel from 'mixpanel';
+import {useFeatureFlag} from 'posthog-react-native';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+const useCampaign = (campaignId: CampaignId, location: string, date: Date | undefined = undefined): [campaignEnabled: boolean, trackInteraction: () => void] => {
+  const campaignFeatureFlag = !!useFeatureFlag(campaignId);
+  const [shouldShowCampaign] = useState(campaignManager.shouldShowCampaign(campaignId, location, date ?? new Date()));
+  const campaignEnabled = shouldShowCampaign && campaignFeatureFlag;
+
+  const showEventSent = useRef(false);
+  useEffect(() => {
+    if (!showEventSent.current && campaignEnabled) {
+      showEventSent.current = true;
+      campaignManager.recordCampaignView(campaignId, location).catch((error: Error) => {
+        logger.error('Failed to record campaign view', {campaignId, location, error});
+      });
+      mixpanel.track('Campaign viewed', {campaignId, location});
+    }
+  }, [campaignEnabled, campaignId, location, showEventSent]);
+
+  const interactionEventSent = useRef(false);
+  const trackInteraction = useCallback(() => {
+    if (!interactionEventSent.current && campaignEnabled) {
+      interactionEventSent.current = true;
+      mixpanel.track('Campaign interaction', {campaignId, location});
+    }
+  }, [campaignEnabled, campaignId, interactionEventSent, location]);
+
+  return [campaignEnabled, trackInteraction];
+};
+
+export default useCampaign;

--- a/data/campaigns/useCampaign.ts
+++ b/data/campaigns/useCampaign.ts
@@ -1,11 +1,15 @@
 import {campaignManager} from 'data/campaigns/campaignManager';
-import {CampaignId} from 'data/campaigns/campaigns';
+import {CampaignId, CampaignLocationId} from 'data/campaigns/campaigns';
 import {logger} from 'logger';
 import mixpanel from 'mixpanel';
 import {useFeatureFlag} from 'posthog-react-native';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-const useCampaign = (campaignId: CampaignId, location: string, date: Date | undefined = undefined): [campaignEnabled: boolean, trackInteraction: () => void] => {
+export function useCampaign<T extends CampaignId>(
+  campaignId: T,
+  location: CampaignLocationId<T>,
+  date: Date | undefined = undefined,
+): [campaignEnabled: boolean, trackInteraction: () => void] {
   const campaignFeatureFlag = !!useFeatureFlag(campaignId);
   const [shouldShowCampaign] = useState(campaignManager.shouldShowCampaign(campaignId, location, date ?? new Date()));
   const campaignEnabled = shouldShowCampaign && campaignFeatureFlag;
@@ -30,6 +34,4 @@ const useCampaign = (campaignId: CampaignId, location: string, date: Date | unde
   }, [campaignEnabled, campaignId, interactionEventSent, location]);
 
   return [campaignEnabled, trackInteraction];
-};
-
-export default useCampaign;
+}

--- a/data/campaigns/useCampaign.ts
+++ b/data/campaigns/useCampaign.ts
@@ -1,4 +1,4 @@
-import {campaignManager} from 'data/campaigns/campaignManager';
+import {ICampaignManager, campaignManager} from 'data/campaigns/campaignManager';
 import {CampaignId, CampaignLocationId} from 'data/campaigns/campaigns';
 import {logger} from 'logger';
 import mixpanel from 'mixpanel';
@@ -8,22 +8,23 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 export function useCampaign<T extends CampaignId>(
   campaignId: T,
   location: CampaignLocationId<T>,
+  theCampaignManager: ICampaignManager = campaignManager,
   date: Date | undefined = undefined,
 ): [campaignEnabled: boolean, trackInteraction: () => void] {
   const campaignFeatureFlag = !!useFeatureFlag(campaignId);
-  const [shouldShowCampaign] = useState(campaignManager.shouldShowCampaign(campaignId, location, date ?? new Date()));
+  const [shouldShowCampaign] = useState(theCampaignManager.shouldShowCampaign(campaignId, location, date ?? new Date()));
   const campaignEnabled = shouldShowCampaign && campaignFeatureFlag;
 
   const showEventSent = useRef(false);
   useEffect(() => {
     if (!showEventSent.current && campaignEnabled) {
       showEventSent.current = true;
-      campaignManager.recordCampaignView(campaignId, location).catch((error: Error) => {
+      theCampaignManager.recordCampaignView(campaignId, location).catch((error: Error) => {
         logger.error('Failed to record campaign view', {campaignId, location, error});
       });
       mixpanel.track('Campaign viewed', {campaign: campaignId, 'campaign-location': location});
     }
-  }, [campaignEnabled, campaignId, location, showEventSent]);
+  }, [campaignEnabled, campaignId, location, showEventSent, theCampaignManager]);
 
   const interactionEventSent = useRef(false);
   const trackInteraction = useCallback(() => {


### PR DESCRIPTION
## Multiple locations
First change is that the campaign tracking now supports showing in multiple locations in the app. This comment describes things pretty well: https://github.com/NWACus/avy/blob/1c4e317e64ae2ce9ef529e83f1eeb009c6ede4b0/data/campaigns/campaigns.ts#L3-L17
(updated this to reflect that we're using `frequency` as opposed to `viewsPerDay`)

## Type safety
Now the compiler knows which campaigns and locations are valid:

<img width="722" alt="image" src="https://github.com/NWACus/avy/assets/101196/01a7349a-75f2-4b6a-9763-1c6867e8bee5">

## `useCampaign`
Added a hook to wrap up feature flag checking, mixpanel event sending, etc. Here's Mixpanel events sent for view and click:

<img width="761" alt="image" src="https://github.com/NWACus/avy/assets/101196/9ee88847-d740-4820-8d38-32a29082a596">
