### PR TITLE
Implement final(?) campaign designs, get modal working over map

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -148,7 +148,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
   useFocusEffect(
     useCallback(() => {
       // Bake in a delay before showing the campaign modal, so that it doesn't pop up before the map is drawn
-      const timeout = setTimeout(() => setScreenFocused(true), 2000);
+      const timeout = setTimeout(() => setScreenFocused(true), 200);
       return () => {
         clearTimeout(timeout);
         setScreenFocused(false);

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -1,12 +1,15 @@
 import React, {useCallback, useRef, useState} from 'react';
 
-import {useNavigation} from '@react-navigation/native';
+import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {View as RNView, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
 import AnimatedMapView, {PoiClickEvent, Region} from 'react-native-maps';
+
+import * as Linking from 'expo-linking';
 
 import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
 import {colorFor} from 'components/AvalancheDangerTriangle';
+import {CampaignModal} from 'components/content/CampaignModal';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {defaultMapRegionForGeometries, MapViewZone, mapViewZoneFor, ZoneMap} from 'components/content/ZoneMap';
 import {Center, HStack, View, VStack} from 'components/core';
@@ -16,6 +19,7 @@ import {TravelAdvice} from 'components/helpers/travelAdvice';
 import {AnimatedCards, AnimatedDrawerState, AnimatedMapWithDrawerController, CARD_MARGIN, CARD_WIDTH} from 'components/map/AnimatedCards';
 import {AvalancheCenterSelectionModal} from 'components/modals/AvalancheCenterSelectionModal';
 import {BodySm, BodySmSemibold, Title3Black} from 'components/text';
+import {useCampaign} from 'data/campaigns/useCampaign';
 import {isAfter} from 'date-fns';
 import {toDate} from 'date-fns-tz';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
@@ -132,6 +136,27 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     [setPreferences, navigation],
   );
 
+  // Begin Q4 2023 campaign code
+  const [showCampaign, trackCampaign] = useCampaign('campaign-q4-2023', 'map-view');
+  const openCampaignLink = useCallback(() => {
+    trackCampaign();
+    const url = 'https://give.nwac.us/campaign/nwacs-year-end-fundraiser/c536433';
+    Linking.openURL(url).catch((error: Error) => logger.error('Error opening URL', {error, url}));
+  }, [logger, trackCampaign]);
+
+  const [screenFocused, setScreenFocused] = useState(false);
+  useFocusEffect(
+    useCallback(() => {
+      // Bake in a delay before showing the campaign modal, so that it doesn't pop up before the map is drawn
+      const timeout = setTimeout(() => setScreenFocused(true), 2000);
+      return () => {
+        clearTimeout(timeout);
+        setScreenFocused(false);
+      };
+    }, [setScreenFocused]),
+  );
+  // End Q4 2023 campaign code
+
   if (incompleteQueryState(mapLayerResult, metadataResult, ...forecastResults, ...warningResults) || !mapLayer || !metadata) {
     return (
       <SafeAreaView edges={['top', 'left', 'right']}>
@@ -222,7 +247,8 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
         setSelectedZoneId={setSelectedZoneId}
         controller={controller}
       />
-      <AvalancheCenterSelectionModal visible={showAvalancheCenterSelectionModal} initialSelection={preferences.center} onClose={onSelectCenter} />
+      <AvalancheCenterSelectionModal visible={screenFocused && showAvalancheCenterSelectionModal} initialSelection={preferences.center} onClose={onSelectCenter} />
+      {screenFocused && !showAvalancheCenterSelectionModal && showCampaign && <CampaignModal onAction={openCampaignLink} />}
     </>
   );
 };

--- a/components/content/CampaignModal.tsx
+++ b/components/content/CampaignModal.tsx
@@ -1,0 +1,74 @@
+import {AntDesign} from '@expo/vector-icons';
+import {Button} from 'components/content/Button';
+import {Center, View, VStack} from 'components/core';
+import {BodyBlack} from 'components/text';
+import {useToggle} from 'hooks/useToggle';
+import React, {useCallback} from 'react';
+import {Image, Modal, TouchableOpacity, TouchableWithoutFeedback} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {colorLookup} from 'theme';
+
+export interface CampaignModalProps {
+  onAction?: () => void;
+}
+
+export const CampaignModal: React.FC<CampaignModalProps> = ({onAction = () => undefined}) => {
+  const [showModal, {off: hideModal}] = useToggle(true);
+  const activateCampaign = useCallback(() => {
+    hideModal();
+    onAction();
+  }, [hideModal, onAction]);
+
+  return (
+    // Pressing the Android back button dismisses the modal
+    <Modal visible={showModal} transparent animationType="fade" onRequestClose={hideModal}>
+      {/* Pressing anywhere outside the modal dismisses the modal */}
+      <TouchableWithoutFeedback onPress={hideModal}>
+        <View position="absolute" top={0} bottom={0} left={0} right={0} backgroundColor={'rgba(0, 0, 0, 0.55)'} padding={32}>
+          <SafeAreaView>
+            <Center width="100%" height="100%">
+              <VStack
+                alignItems="center"
+                justifyContent="center"
+                alignContent="center"
+                width="100%"
+                backgroundColor={colorLookup('NWAC-dark')}
+                borderRadius={16}
+                pt={80}
+                pb={16}
+                space={24}
+                style={{
+                  shadowColor: '#000',
+                  shadowOffset: {
+                    width: 0,
+                    height: 2,
+                  },
+                  shadowOpacity: 0.25,
+                  shadowRadius: 3.84,
+
+                  elevation: 5,
+                }}>
+                <TouchableOpacity onPress={hideModal} style={{position: 'absolute', right: 16, top: 16}}>
+                  <AntDesign name="close" size={24} color="white" />
+                </TouchableOpacity>
+                <View style={{position: 'relative', height: 160, width: '100%'}}>
+                  <Image
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    source={require('assets/campaigns/campaign-q4-2023/banner.png')}
+                    style={{height: undefined, width: undefined, aspectRatio: 2.74348422}}
+                    resizeMode="contain"
+                  />
+                </View>
+                <Center width="100%" px={16} alignItems="stretch">
+                  <Button buttonStyle="primary" onPress={activateCampaign}>
+                    <BodyBlack>Donate Today</BodyBlack>
+                  </Button>
+                </Center>
+              </VStack>
+            </Center>
+          </SafeAreaView>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -4,13 +4,11 @@ import {
   ActivityIndicator,
   ColorValue,
   GestureResponderEvent,
-  Image,
   LayoutAnimation,
   Modal,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
-  Pressable,
   ScrollView,
   SectionList,
   SectionListRenderItemInfo,
@@ -33,7 +31,7 @@ import {Center, Divider, HStack, VStack, View} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {ObservationFilterConfig, ObservationsFilterForm, createDefaultFilterConfig, filtersForConfig, matchesZone} from 'components/observations/ObservationsFilterForm';
 import {usePendingObservations} from 'components/observations/uploader/usePendingObservations';
-import {Body, BodyBlack, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
+import {Body, BodyBlack, BodySemibold, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
 import {useCampaign} from 'data/campaigns/useCampaign';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
@@ -207,6 +205,12 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
 
   const hasPendingObservations = pendingObservationsSection.data.length > 0;
   const sections: Section[] = [];
+  if (showCampaign) {
+    sections.push({
+      title: 'Campaign',
+      data: [],
+    });
+  }
   if (hasPendingObservations) {
     sections.push(pendingObservationsSection);
   }
@@ -276,13 +280,30 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
     }
   }, [moreDataAvailable, observationsSection.data.length, observations.length, observationsResult.isFetchingNextPage]);
   const renderSectionHeader = useCallback(
-    ({section: {title}}: {section: {title: string}}) =>
-      hasPendingObservations ? (
-        <View px={16} py={8}>
-          <BodySm>{title}</BodySm>
-        </View>
-      ) : null,
-    [hasPendingObservations],
+    ({section: {title}}: {section: {title: string}}) => {
+      if (title === 'Campaign') {
+        return (
+          <HStack mx={8} my={12} px={16} py={16} justifyContent="space-between" backgroundColor={colorLookup('NWAC-dark')} borderRadius={10}>
+            <VStack space={2}>
+              <BodySemibold color="white">❄️ NWAC Year End Giving</BodySemibold>
+              <BodySm color="white">The app relies on your support</BodySm>
+            </VStack>
+            <Button buttonStyle="primary" onPress={openCampaignLink}>
+              <BodyBlack color="white">Donate</BodyBlack>
+            </Button>
+          </HStack>
+        );
+      } else if (hasPendingObservations) {
+        return (
+          <View px={16} py={8}>
+            <BodySm>{title}</BodySm>
+          </View>
+        );
+      } else {
+        return null;
+      }
+    },
+    [hasPendingObservations, openCampaignLink],
   );
 
   const applyFilterRemoval = useCallback(
@@ -359,13 +380,6 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         </ScrollView>
       </HStack>
       <Divider />
-      {showCampaign && (
-        // banner.png is 2000 x 729, which is an aspect ratio of 2.74348422
-        <Pressable onPress={openCampaignLink}>
-          {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-          <Image source={require('assets/campaigns/campaign-q4-2023/banner.png')} style={{width: '100%', height: undefined, aspectRatio: 2.74348422}} resizeMode="contain" />
-        </Pressable>
-      )}
       <SectionList
         sections={sections}
         renderSectionHeader={renderSectionHeader}

--- a/components/screens/menu/SecretMenu.tsx
+++ b/components/screens/menu/SecretMenu.tsx
@@ -19,6 +19,7 @@ import {Divider, HStack, View, VStack} from 'components/core';
 import * as Clipboard from 'expo-clipboard';
 import Constants from 'expo-constants';
 import * as FileSystem from 'expo-file-system';
+import * as Updates from 'expo-updates';
 
 import {useQueryClient} from '@tanstack/react-query';
 import {ClientContext} from 'clientContext';
@@ -54,6 +55,7 @@ import {
   Title3Semibold,
 } from 'components/text';
 import {QUERY_CACHE_ASYNC_STORAGE_KEY} from 'data/asyncStorageKeys';
+import {clearCampaignViewData} from 'data/campaigns/campaignManager';
 import {logFilePath, logger} from 'logger';
 import {sendMail} from 'network/sendMail';
 import {usePreferences} from 'Preferences';
@@ -162,6 +164,12 @@ export const SecretMenu: React.FC<SecretMenuProps> = ({staging, setStaging}) => 
             </Button>
             <Button buttonStyle="normal" onPress={() => void clearPreferences()}>
               Reset preferences
+            </Button>
+            <Button buttonStyle="normal" onPress={() => void clearCampaignViewData()}>
+              Reset campaign view data
+            </Button>
+            <Button buttonStyle="normal" onPress={() => void Updates.reloadAsync()}>
+              Restart app
             </Button>
             <HStack justifyContent="space-between" alignItems="center" space={16}>
               <Body>Use staging environment</Body>

--- a/data/campaigns/useCampaign.ts
+++ b/data/campaigns/useCampaign.ts
@@ -1,9 +1,12 @@
+import {useFocusEffect} from '@react-navigation/native';
 import {ICampaignManager, campaignManager} from 'data/campaigns/campaignManager';
 import {CampaignId, CampaignLocationId} from 'data/campaigns/campaigns';
-import {logger} from 'logger';
+import {logger as globalLogger} from 'logger';
 import mixpanel from 'mixpanel';
 import {useFeatureFlag} from 'posthog-react-native';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
+
+const logger = globalLogger.child({component: 'useCampaign'});
 
 export function useCampaign<T extends CampaignId>(
   campaignId: T,
@@ -12,25 +15,34 @@ export function useCampaign<T extends CampaignId>(
   date: Date | undefined = undefined,
 ): [campaignEnabled: boolean, trackInteraction: () => void] {
   const campaignFeatureFlag = !!useFeatureFlag(campaignId);
-  const [shouldShowCampaign] = useState(theCampaignManager.shouldShowCampaign(campaignId, location, date ?? new Date()));
-  const campaignEnabled = shouldShowCampaign && campaignFeatureFlag;
+  const [campaignEnabled, setCampaignEnabled] = useState(false);
 
-  const showEventSent = useRef(false);
-  useEffect(() => {
-    if (!showEventSent.current && campaignEnabled) {
-      showEventSent.current = true;
-      theCampaignManager.recordCampaignView(campaignId, location).catch((error: Error) => {
-        logger.error('Failed to record campaign view', {campaignId, location, error});
-      });
-      mixpanel.track('Campaign viewed', {campaign: campaignId, 'campaign-location': location});
-    }
-  }, [campaignEnabled, campaignId, location, showEventSent, theCampaignManager]);
+  // When our parent screen is focused, check the status of the campaign. Keep the status constant until the screen is unfocused.
+  useFocusEffect(
+    useCallback(() => {
+      const shouldShowCampaign = theCampaignManager.shouldShowCampaign(campaignId, location, date);
+      setCampaignEnabled(shouldShowCampaign && campaignFeatureFlag);
+      if (shouldShowCampaign && campaignFeatureFlag) {
+        theCampaignManager.recordCampaignView(campaignId, location).catch((error: Error) => {
+          logger.error('Failed to record campaign view', {campaignId, location, error});
+        });
+        mixpanel.track('Campaign viewed', {campaign: campaignId, 'campaign-location': location});
+        logger.debug('Sent campaign view event', {campaignId, location});
+      }
+      return () => {
+        setCampaignEnabled(false);
+      };
+    }, [campaignFeatureFlag, campaignId, date, location, theCampaignManager]),
+  );
+
+  logger.debug('Campaign enabled', {campaignId, location, campaignFeatureFlag, campaignEnabled});
 
   const interactionEventSent = useRef(false);
   const trackInteraction = useCallback(() => {
     if (!interactionEventSent.current && campaignEnabled) {
       interactionEventSent.current = true;
       mixpanel.track('Campaign interaction', {campaign: campaignId, 'campaign-location': location});
+      logger.debug('Sent campaign interaction event', {campaignId, location});
     }
   }, [campaignEnabled, campaignId, interactionEventSent, location]);
 


### PR DESCRIPTION
This should be basically ready to go now, I think. Feature flag is still off so merging it should be safe.

- map modal displays at most every 8 hours (this can be tuned in `campaigns.ts`)
- campaign banner in obs list is smaller, can be scrolled away
- useCampaign hook returns a stable value as long as the active screen remains focused, so you can render with it

All the buttons and whatnot are wired up and sending events.

map | list
--- | ---
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-12-17 at 14 45 40](https://github.com/NWACus/avy/assets/101196/654cdbaa-22c0-47fd-af37-fc0b3061c8d8) | ![Simulator Screen Recording - iPhone 14 Pro Max - 2023-12-17 at 14 54 10](https://github.com/NWACus/avy/assets/101196/38c8bc47-2021-4ead-80d8-b9326a66d8d5)


