### PR TITLE
Add version to feedback emails

### DIFF
--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -35,14 +35,17 @@ import {
   TimeMachine,
   ToastPreview,
 } from 'components/screens/menu/SecretMenu';
+import {getVersionInfoFull} from 'components/screens/menu/Version';
 import {NWACObservationScreen, ObservationScreen} from 'components/screens/ObservationsScreen';
 import {Body, BodyBlack, Title3Black} from 'components/text';
 import {openCampaignLink} from 'data/campaigns/openCampaignLink';
 import {useCampaign} from 'data/campaigns/useCampaign';
 import {settingsMenuItems} from 'data/settingsMenuItems';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
+import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {sendMail} from 'network/sendMail';
+import {usePreferences} from 'Preferences';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, userFacingCenterId} from 'types/nationalAvalancheCenter';
 
@@ -93,8 +96,22 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
   const {data} = useAvalancheCenterMetadata(avalancheCenterId);
   const menuItems = settingsMenuItems[avalancheCenterId];
 
+  const {
+    preferences: {mixpanelUserId},
+  } = usePreferences();
+  const [updateGroupId] = getUpdateGroupId();
+
   const MenuScreen = function (_: NativeStackScreenProps<MenuStackParamList, 'menu'>) {
-    const sendMailHandler = useCallback(() => void sendMail({to: 'developer+app-feedback@nwac.us', subject: 'NWAC app feedback', logger}), []);
+    const sendMailHandler = useCallback(
+      () =>
+        void sendMail({
+          to: 'developer+app-feedback@nwac.us',
+          subject: 'NWAC app feedback',
+          footer: `Please do not delete, info below helps with debugging.\n\n ${getVersionInfoFull(mixpanelUserId, updateGroupId)}`,
+          logger,
+        }),
+      [],
+    );
     // begin Q4 2023 campaign
     const [showCampaign, trackCampaign] = useCampaign(avalancheCenterId, 'nwac-campaign-q4-2023', 'menu-screen');
     const onCampaignAction = useCallback(() => {

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useState} from 'react';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {Platform, StyleSheet} from 'react-native';
+import {StyleSheet} from 'react-native';
 
 import * as Application from 'expo-application';
 import * as Clipboard from 'expo-clipboard';
@@ -12,6 +12,7 @@ import {Ionicons} from '@expo/vector-icons';
 
 import {ActionList} from 'components/content/ActionList';
 import {Center, HStack, View, VStack} from 'components/core';
+import {getVersionInfoFull} from 'components/screens/menu/Version';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {usePreferences} from 'Preferences';
@@ -25,13 +26,7 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
   const openUrl = useCallback(({data}: {data: string}) => void WebBrowser.openBrowserAsync(data), []);
   const copyVersionInfoToClipboard = useCallback(() => {
     void (async () => {
-      await Clipboard.setStringAsync(
-        `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
-Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
-Update group ID ${updateGroupId} (channel: ${Updates.channel || 'development'})
-Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})
-User ID ${mixpanelUserId || 'n/a'}`,
-      );
+      await Clipboard.setStringAsync(getVersionInfoFull(mixpanelUserId, updateGroupId));
     })();
   }, [mixpanelUserId, updateGroupId]);
 

--- a/components/screens/menu/SecretMenu.tsx
+++ b/components/screens/menu/SecretMenu.tsx
@@ -2,7 +2,7 @@
 // We normally want to avoid using fat arrow functions in props as it can cause excessive re-rendering,
 // but for the debug menu we shouldn't be too worried about it. It never renders in production.
 
-import React, {ReactNode, useCallback} from 'react';
+import React, {ReactNode, useCallback, useState} from 'react';
 
 import DateTimePicker, {DateTimePickerEvent} from '@react-native-community/datetimepicker';
 import {Platform, ScrollView, SectionList, StyleSheet, Switch, TouchableOpacity} from 'react-native';
@@ -31,6 +31,7 @@ import {ConnectionLost, InternalError, NotFound} from 'components/content/QueryS
 import {ActionToast, ErrorToast, InfoToast, SuccessToast, WarningToast} from 'components/content/Toast';
 import {getUploader} from 'components/observations/uploader/ObservationsUploader';
 import {Keys} from 'components/screens/menu/Keys';
+import {getVersionInfoFull} from 'components/screens/menu/Version';
 import {
   AllCapsSm,
   AllCapsSmBlack,
@@ -56,6 +57,7 @@ import {
 } from 'components/text';
 import {QUERY_CACHE_ASYNC_STORAGE_KEY} from 'data/asyncStorageKeys';
 import {clearCampaignViewData} from 'data/campaigns/campaignManager';
+import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {logFilePath, logger} from 'logger';
 import {sendMail} from 'network/sendMail';
 import {usePreferences} from 'Preferences';
@@ -77,6 +79,7 @@ export const SecretMenu: React.FC<SecretMenuProps> = ({staging, setStaging}) => 
     logger.info({environment: staging ? 'production' : 'staging'}, 'switching environment');
   }, [staging, setStaging]);
   const {preferences, setPreferences, clearPreferences} = usePreferences();
+  const [updateGroupId] = useState(getUpdateGroupId());
   return (
     <CollapsibleCard
       startsCollapsed={preferences.secretMenuCollapsed}
@@ -127,6 +130,7 @@ export const SecretMenu: React.FC<SecretMenuProps> = ({staging, setStaging}) => 
                         to: 'developer+app-logs@nwac.us',
                         subject: 'NWAC app log files',
                         body: `\n\n---\n\nRun \`yarn bunyan ${logFilePath.split('/').slice(-1)[0]}\` to view.\nRun \`yarn bunyan --help\` for additional options.`,
+                        footer: getVersionInfoFull(preferences.mixpanelUserId, updateGroupId),
                         attachments: [logFilePath],
                         logger,
                       }))

--- a/components/screens/menu/Version.ts
+++ b/components/screens/menu/Version.ts
@@ -1,0 +1,13 @@
+import * as Application from 'expo-application';
+import * as Updates from 'expo-updates';
+import {Platform} from 'react-native';
+
+export const getVersionInfoFull = (mixpanelUserId: string | undefined, updateGroupId: string | undefined): string => {
+  const versionTestFull = `Avy version ${Application.nativeApplicationVersion || 'n/a'} (${Application.nativeBuildVersion || 'n/a'})
+Git revision ${process.env.EXPO_PUBLIC_GIT_REVISION || 'n/a'}
+Update group ID ${updateGroupId || 'n/a'} (channel: ${Updates.channel || 'development'})
+Update ID ${Updates.updateId || 'n/a'} (platform: ${Platform.OS})
+User ID ${mixpanelUserId || 'n/a'}`;
+
+  return versionTestFull;
+};

--- a/network/sendMail.ts
+++ b/network/sendMail.ts
@@ -11,12 +11,14 @@ interface SendMailProps {
   subject: string;
   logger: Logger;
   body?: string;
+  footer?: string;
   attachments?: string[];
 }
 
-export const sendMail = async ({to, subject, body, attachments, logger}: SendMailProps): Promise<boolean> => {
+export const sendMail = async ({to, subject, body, footer, attachments, logger}: SendMailProps): Promise<boolean> => {
   // MailComposer is not working correctly on iOS - use a mailto link on that platform
   // Filed https://github.com/expo/expo/issues/24613 to get an answer/resolution
+  body = `${body || ''}${footer ? `\n--\n ${footer}` : ''}`;
   if (Platform.OS === 'android') {
     try {
       if (await MailComposer.isAvailableAsync()) {


### PR DESCRIPTION
Also figured we can add to the log ones as well? but can remove if you do not think that is necessary. Tried to consolidate version into a separate file since we use it a few places. Still learning how this is all set up, let me know what you think!

what the email looks like (version is weird and no git revision since running locally in an emulator): 
![image](https://github.com/NWACus/avy/assets/9418602/90bdb695-ed0e-4fdc-b25a-7889ebddc91f)
