### PR TITLE
Fix status bar background color on Android

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -451,7 +451,7 @@ const BaseApp: React.FunctionComponent<{
             <NavigationContainer ref={navigationRef} onReady={trackNavigationChange} onStateChange={trackNavigationChange}>
               <KillSwitchMonitor>
                 <SelectProvider>
-                  <StatusBar barStyle="dark-content" />
+                  <StatusBar barStyle="dark-content" backgroundColor="white" />
                   <View style={StyleSheet.absoluteFill}>
                     <TabNavigator.Navigator initialRouteName="Home" screenOptions={tabNavigatorScreenOptions}>
                       <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId}} options={{title: 'Zones'}}>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -11,6 +11,7 @@ import {CampaignModal} from 'components/content/CampaignModal';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {defaultMapRegionForGeometries, MapViewZone, mapViewZoneFor, ZoneMap} from 'components/content/ZoneMap';
 import {Center, HStack, View, VStack} from 'components/core';
+import {FocusAwareStatusBar} from 'components/core/FocusAwareStatusBar';
 import {DangerScale} from 'components/DangerScale';
 import {pointInFeature} from 'components/helpers/geographicCoordinates';
 import {TravelAdvice} from 'components/helpers/travelAdvice';
@@ -215,6 +216,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
 
   return (
     <>
+      <FocusAwareStatusBar barStyle="light-content" translucent backgroundColor={'rgba(0, 0, 0, 0.35)'} />
       <ZoneMap
         ref={mapView}
         animated

--- a/components/core/FocusAwareStatusBar.tsx
+++ b/components/core/FocusAwareStatusBar.tsx
@@ -1,0 +1,10 @@
+import {useIsFocused} from '@react-navigation/native';
+import * as React from 'react';
+import {StatusBar, StatusBarProps} from 'react-native';
+
+// h/t https://reactnavigation.org/docs/status-bar/
+export function FocusAwareStatusBar(props: StatusBarProps) {
+  const isFocused = useIsFocused();
+
+  return isFocused ? <StatusBar {...props} /> : null;
+}


### PR DESCRIPTION
On Android, you can set the status bar color (and if you don't set it, it seems you might get anything). This change makes the bar color white everywhere except the map. For the map, it inverts the bar colors, so you get white text and a translucent dark background.

<img width="427" alt="image" src="https://github.com/NWACus/avy/assets/101196/0013d0d2-7f5e-4b04-b9e4-eef14486198b">
<img width="441" alt="image" src="https://github.com/NWACus/avy/assets/101196/e734a658-9fb8-4094-995f-fa40a270e2b2">
<img width="485" alt="image" src="https://github.com/NWACus/avy/assets/101196/cf3e59de-9f98-46e3-b0d5-9c6778b5c4e4">
