### PR TITLE
PostHog: track screen views and card interactions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -67,6 +67,7 @@ import {Center, VStack} from 'components/core';
 import {KillSwitchMonitor} from 'components/KillSwitchMonitor';
 import {TamaguiWrapper} from 'components/TamaguiWrapper';
 import {Body, BodyBlack, Title3Black} from 'components/text';
+import * as Updates from 'expo-updates';
 import {FeatureFlagsProvider} from 'FeatureFlags';
 import {useToggle} from 'hooks/useToggle';
 import {filterLoggedData} from 'logging/filterLoggedData';
@@ -98,6 +99,10 @@ const formatURI = (request: AxiosRequestConfig, options: {includePostData?: bool
   }
   return msg;
 };
+
+axios.defaults.headers.common['User-Agent'] = `avy/${Application.nativeApplicationVersion || '0.0.0'}.${Application.nativeBuildVersion || '0'}+${
+  Updates.channel || 'development'
+})-${process.env.EXPO_PUBLIC_GIT_REVISION || 'git-revision'}`;
 
 axios.interceptors.request.use(request => {
   const msg = 'sending request';

--- a/App.tsx
+++ b/App.tsx
@@ -102,7 +102,7 @@ const formatURI = (request: AxiosRequestConfig, options: {includePostData?: bool
 
 axios.defaults.headers.common['User-Agent'] = `avy/${Application.nativeApplicationVersion || '0.0.0'}.${Application.nativeBuildVersion || '0'}+${
   Updates.channel || 'development'
-})-${process.env.EXPO_PUBLIC_GIT_REVISION || 'git-revision'}`;
+}-${process.env.EXPO_PUBLIC_GIT_REVISION || 'git-revision'}`;
 
 axios.interceptors.request.use(request => {
   const msg = 'sending request';

--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -9,6 +9,7 @@ import {AvalancheCenterList} from 'components/content/AvalancheCenterList';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {useAllAvalancheCenterMetadata} from 'hooks/useAllAvalancheCenterMetadata';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
+import {usePostHog} from 'posthog-react-native';
 import {MenuStackParamList, TabNavigationProps} from 'routes';
 import {AvalancheCenter, AvalancheCenterID} from 'types/nationalAvalancheCenter';
 
@@ -34,6 +35,9 @@ export const AvalancheCenterSelector: React.FunctionComponent<{
     },
     [setAvalancheCenter, navigation],
   );
+  const postHog = usePostHog();
+
+  postHog?.screen('centerSelector');
 
   if (incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities) {
     return <QueryState results={[capabilitiesResult, ...metadataResults]} />;

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -24,6 +24,7 @@ import {useMapLayer} from 'hooks/useMapLayer';
 import {useMapLayerAvalancheForecasts} from 'hooks/useMapLayerAvalancheForecasts';
 import {useMapLayerAvalancheWarnings} from 'hooks/useMapLayerAvalancheWarnings';
 import {LoggerContext, LoggerProps} from 'loggerContext';
+import {usePostHog} from 'posthog-react-native';
 import {usePreferences} from 'Preferences';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {HomeStackNavigationProps, TabNavigationProps} from 'routes';
@@ -45,6 +46,12 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
   const warningResults = useMapLayerAvalancheWarnings(center, requestedTime, mapLayer);
 
   const topElements = React.useRef<RNView>(null);
+
+  const postHog = usePostHog();
+
+  postHog?.screen('avalancheForecastMap', {
+    center: center,
+  });
 
   const navigation = useNavigation<HomeStackNavigationProps & TabNavigationProps>();
   const [selectedZoneId, setSelectedZoneId] = useState<number | null>(null);

--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, ReactNode, useCallback, useState} from 'react';
+import React, {PropsWithChildren, ReactNode, useCallback, useEffect, useState} from 'react';
 
 import {ColorValue, TouchableOpacity, ViewStyle} from 'react-native';
 import Collapsible from 'react-native-collapsible';
@@ -6,6 +6,7 @@ import Collapsible from 'react-native-collapsible';
 import {FontAwesome} from '@expo/vector-icons';
 
 import {Divider, HStack, View, ViewProps, VStack} from 'components/core';
+import {usePostHog} from 'posthog-react-native';
 import {colorLookup} from 'theme';
 
 export interface CardProps extends ViewProps {
@@ -59,12 +60,14 @@ export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({
 };
 
 export interface CollapsibleCardProps extends CardProps {
+  identifier: string;
   noDivider?: boolean;
   startsCollapsed: boolean;
   collapsedStateChanged?: (collapsed: boolean) => void;
 }
 
 export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<CollapsibleCardProps>> = ({
+  identifier,
   startsCollapsed,
   collapsedStateChanged,
   header,
@@ -78,6 +81,10 @@ export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<Collapsi
     setIsCollapsed(!isCollapsed);
     collapsedStateChanged?.(!isCollapsed);
   }, [isCollapsed, collapsedStateChanged]);
+  const postHog = usePostHog();
+  useEffect(() => {
+    postHog?.capture('card', {identifier: identifier, isCollapsed: isCollapsed});
+  }, [identifier, postHog, isCollapsed]);
 
   return (
     <Card

--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -17,6 +17,7 @@ import {useRefresh} from 'hooks/useRefresh';
 import {useWeatherForecast} from 'hooks/useWeatherForecast';
 import {useWeatherStationsMetadata} from 'hooks/useWeatherStationsMetadata';
 import {isArray} from 'lodash';
+import {usePostHog} from 'posthog-react-native';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {RefreshControl, ScrollView} from 'react-native';
 import {HomeStackParamList, TabNavigationProps} from 'routes';
@@ -82,6 +83,13 @@ export const NACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, reque
   const onRefresh = useCallback(() => {
     void refresh();
   }, [refresh]);
+
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherForecastTab', {
+    center: center_id,
+    zone: zone.name,
+  });
 
   if (incompleteQueryState(avalancheCenterMetadataResult, avalancheForecastResult) || !metadata || !avalancheForecast) {
     return <QueryState results={[avalancheCenterMetadataResult, avalancheForecastResult]} />;
@@ -362,11 +370,23 @@ export const NWACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, requ
           </Card>
         ))}
         {actionListData.length > 0 && <ActionList pl={16} backgroundColor="white" header={<Title3Black>Weather Data</Title3Black>} actions={actionListData} />}
-        <CollapsibleCard marginTop={1} borderRadius={0} borderColor="white" header={<Title3Black>Weather Synopsis</Title3Black>} startsCollapsed={true}>
+        <CollapsibleCard
+          identifier={'weatherSynopsis'}
+          marginTop={1}
+          borderRadius={0}
+          borderColor="white"
+          header={<Title3Black>Weather Synopsis</Title3Black>}
+          startsCollapsed={true}>
           <HTML source={{html: nwacForecast.mountain_weather_forecast.synopsis_day1_day2}} />
         </CollapsibleCard>
         {nwacForecast.mountain_weather_forecast.extended_synopsis && (
-          <CollapsibleCard marginTop={1} borderRadius={0} borderColor="white" header={<Title3Black>Extended Synopsis</Title3Black>} startsCollapsed={true}>
+          <CollapsibleCard
+            identifier={'weatherExtendedSynopsis'}
+            marginTop={1}
+            borderRadius={0}
+            borderColor="white"
+            header={<Title3Black>Extended Synopsis</Title3Black>}
+            startsCollapsed={true}>
             <HTML source={{html: nwacForecast.mountain_weather_forecast.extended_synopsis}} />
           </CollapsibleCard>
         )}

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -7,10 +7,10 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {colorFor} from 'components/AvalancheDangerTriangle';
 import {Card, CardProps} from 'components/content/Card';
-import {Carousel, images} from 'components/content/carousel';
-import {incompleteQueryState, QueryState} from 'components/content/QueryState';
+import {QueryState, incompleteQueryState} from 'components/content/QueryState';
 import {ZoneMap} from 'components/content/ZoneMap';
-import {HStack, View, VStack} from 'components/core';
+import {Carousel, images} from 'components/content/carousel';
+import {HStack, VStack, View} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, bodySize} from 'components/text';
@@ -18,6 +18,7 @@ import {HTML} from 'components/text/HTML';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservation} from 'hooks/useNACObservation';
 import {useNWACObservation} from 'hooks/useNWACObservation';
+import {usePostHog} from 'posthog-react-native';
 import {LatLng, Marker} from 'react-native-maps';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
@@ -205,6 +206,12 @@ export const ObservationCard: React.FunctionComponent<{
     }
   }, [navigation, zone_name]);
   const emptyHandler = useCallback(() => undefined, []);
+  const postHog = usePostHog();
+
+  postHog?.screen('observation', {
+    center: observation.center_id,
+    id: observation.id,
+  });
 
   return (
     <View style={{...StyleSheet.absoluteFillObject, backgroundColor: 'white'}}>

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -16,6 +16,7 @@ import {Body, BodyBlack, BodySemibold, BodySmBlack, Title3Semibold, bodySize} fr
 import {geoContains} from 'd3-geo';
 import {endOfDay, isAfter, isBefore, parseISO} from 'date-fns';
 import {LoggerContext, LoggerProps} from 'loggerContext';
+import {usePostHog} from 'posthog-react-native';
 import {FieldErrors, FormProvider, useController, useForm, useFormContext} from 'react-hook-form';
 import {KeyboardAvoidingView, Platform, View as RNView, SafeAreaView, ScrollView, TouchableOpacity, findNodeHandle} from 'react-native';
 import {colorLookup} from 'theme';
@@ -255,6 +256,10 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
     // Returning true marks the event as processed
     return true;
   });
+
+  const postHog = usePostHog();
+
+  postHog?.screen('observationsFilter');
 
   const onResetHandler = useCallback(() => formContext.reset(initialFilterConfig), [formContext, initialFilterConfig]);
 

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -20,6 +20,7 @@ import {useNACObservations} from 'hooks/useNACObservations';
 import {useNWACObservations} from 'hooks/useNWACObservations';
 import {useRefresh} from 'hooks/useRefresh';
 import {useToggle} from 'hooks/useToggle';
+import {usePostHog} from 'posthog-react-native';
 import {
   ActivityIndicator,
   ColorValue,
@@ -71,6 +72,13 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal}] = useToggle(false);
   const mapResult = useMapLayer(center_id);
   const mapLayer = mapResult.data;
+
+  const postHog = usePostHog();
+
+  postHog?.screen('observations', {
+    center: center_id,
+    zone: additionalFilters && additionalFilters.zones && additionalFilters.zones.length > 0 ? additionalFilters.zones[0] : 'global',
+  });
 
   // Filter inputs changed via render props should overwrite our current state
   useEffect(() => {

--- a/components/observations/ObservationsPortal.tsx
+++ b/components/observations/ObservationsPortal.tsx
@@ -3,6 +3,7 @@ import Topo from 'assets/illustrations/topo.svg';
 import {Button} from 'components/content/Button';
 import {View, VStack} from 'components/core';
 import {Body, BodyBlack, Title3Black} from 'components/text';
+import {usePostHog} from 'posthog-react-native';
 import React, {useCallback} from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ObservationsStackNavigationProps} from 'routes';
@@ -19,6 +20,11 @@ export const ObservationsPortal: React.FC<{
     [center_id, navigation, requestedTime],
   );
   const onSubmit = useCallback(() => navigation.navigate('observationSubmit', {center_id}), [center_id, navigation]);
+  const postHog = usePostHog();
+
+  postHog?.screen('observationsPortal', {
+    center: center_id,
+  });
   return (
     <View width="100%" height="100%" bg="#F6F8FC">
       {/* SafeAreaView shouldn't inset from bottom edge because TabNavigator is sitting there */}

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -30,6 +30,7 @@ import {TaskStatus} from 'components/observations/uploader/Task';
 import {Body, BodyBlack, BodySemibold, BodySm, Title3Semibold} from 'components/text';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {LoggerContext, LoggerProps} from 'loggerContext';
+import {usePostHog} from 'posthog-react-native';
 import Toast from 'react-native-toast-message';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
@@ -69,6 +70,12 @@ export const SimpleForm: React.FC<{
     mode: 'onBlur',
     shouldFocusError: false,
     shouldUnregister: true,
+  });
+
+  const postHog = usePostHog();
+
+  postHog?.screen('observationForm', {
+    center: center_id,
   });
 
   useEffect(() => {

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -43,6 +43,7 @@ import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {sendMail} from 'network/sendMail';
+import {usePostHog} from 'posthog-react-native';
 import {usePreferences} from 'Preferences';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, userFacingCenterId} from 'types/nationalAvalancheCenter';
@@ -99,6 +100,10 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
     preferences: {mixpanelUserId},
   } = usePreferences();
   const [updateGroupId] = getUpdateGroupId();
+
+  const postHog = usePostHog();
+
+  postHog?.screen('menu');
 
   const MenuScreen = function (_: NativeStackScreenProps<MenuStackParamList, 'menu'>) {
     const sendMailHandler = useCallback(

--- a/components/screens/menu/AboutScreen.tsx
+++ b/components/screens/menu/AboutScreen.tsx
@@ -15,6 +15,7 @@ import {Center, HStack, View, VStack} from 'components/core';
 import {getVersionInfoFull} from 'components/screens/menu/Version';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
+import {usePostHog} from 'posthog-react-native';
 import {usePreferences} from 'Preferences';
 import {MenuStackParamList} from 'routes';
 
@@ -29,6 +30,10 @@ export const AboutScreen = (_: NativeStackScreenProps<MenuStackParamList, 'about
       await Clipboard.setStringAsync(getVersionInfoFull(mixpanelUserId, updateGroupId));
     })();
   }, [mixpanelUserId, updateGroupId]);
+
+  const postHog = usePostHog();
+
+  postHog?.screen('about');
 
   return (
     <View style={StyleSheet.absoluteFillObject}>

--- a/components/screens/menu/SecretMenu.tsx
+++ b/components/screens/menu/SecretMenu.tsx
@@ -80,6 +80,7 @@ export const SecretMenu: React.FC<SecretMenuProps> = ({staging, setStaging}) => 
   const [updateGroupId] = useState(getUpdateGroupId());
   return (
     <CollapsibleCard
+      identifier={'secretMenu'}
       startsCollapsed={preferences.secretMenuCollapsed}
       collapsedStateChanged={collapsed => setPreferences({secretMenuCollapsed: collapsed})}
       borderColor="white"

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -13,7 +13,7 @@ import {Column, formatDateTime} from 'components/weather_data/WeatherStationsDet
 import {compareDesc} from 'date-fns';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useWeatherStationTimeseries} from 'hooks/useWeatherStationTimeseries';
-import {useFeatureFlag} from 'posthog-react-native';
+import {useFeatureFlag, usePostHog} from 'posthog-react-native';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, StationNote, Variable, WeatherStationSource, WeatherStationTimeseries} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
@@ -40,6 +40,12 @@ export const WeatherStationDetail: React.FC<Props> = ({center_id, stationId, sou
   identifier[stationId] = source;
   const timeseriesResult = useWeatherStationTimeseries(metadata?.widget_config.stations?.token, identifier, requestedTimeDate, {days: days});
   const timeseries = timeseriesResult.data;
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherStation', {
+    center: center_id,
+    stationId: stationId,
+  });
 
   if (incompleteQueryState(avalancheCenterMetadataResult, timeseriesResult) || !metadata || !timeseries) {
     return <QueryState results={[avalancheCenterMetadataResult, timeseriesResult]} />;

--- a/components/weather_data/WeatherStationFilterForm.tsx
+++ b/components/weather_data/WeatherStationFilterForm.tsx
@@ -12,6 +12,7 @@ import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {BodyBlack, BodySemibold, Title3Semibold} from 'components/text';
 import {isAfter, isBefore, parseISO, sub} from 'date-fns';
 import {LoggerContext, LoggerProps} from 'loggerContext';
+import {usePostHog} from 'posthog-react-native';
 import {FieldErrors, FormProvider, useForm} from 'react-hook-form';
 import {KeyboardAvoidingView, Platform, View as RNView, SafeAreaView, ScrollView, TouchableOpacity, findNodeHandle} from 'react-native';
 import {colorLookup} from 'theme';
@@ -162,6 +163,9 @@ export const WeatherStationFilterForm: React.FunctionComponent<WeatherStationFil
   React.useEffect(() => {
     formContext.reset(currentFilterConfig);
   }, [formContext, currentFilterConfig]);
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherStationsFilter');
 
   const closeWithoutSaving = useCallback(() => {
     formContext.reset(initialFilterConfig);

--- a/components/weather_data/WeatherStationList.tsx
+++ b/components/weather_data/WeatherStationList.tsx
@@ -5,6 +5,7 @@ import {FilterPillButton} from 'components/observations/ObservationsListView';
 import {WeatherStationFilterConfig, WeatherStationFilterForm, filtersForConfig} from 'components/weather_data/WeatherStationFilterForm';
 import {WeatherStationCard} from 'components/weather_data/WeatherStationMap';
 import {useToggle} from 'hooks/useToggle';
+import {usePostHog} from 'posthog-react-native';
 import React, {useCallback, useMemo} from 'react';
 import {FlatList, ListRenderItemInfo, Modal, ScrollView, TouchableOpacity} from 'react-native';
 import {colorLookup} from 'theme';
@@ -29,6 +30,11 @@ export const WeatherStationList: React.FunctionComponent<{
   const currentTime = requestedTimeToUTCDate(parsedTime);
   const [filterConfig, setFilterConfig] = React.useState<WeatherStationFilterConfig>({...initialFilterConfig});
   const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal}] = useToggle(false);
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherStations', {
+    center: center_id,
+  });
 
   // when the initial filter inputs change, we should honor those
   React.useEffect(() => {

--- a/components/weather_data/WeatherStationMap.tsx
+++ b/components/weather_data/WeatherStationMap.tsx
@@ -21,6 +21,7 @@ import {BodySm, BodySmSemibold, BodyXSm, Title3Black} from 'components/text';
 import {formatData, formatUnits, orderStationVariables} from 'components/weather_data/WeatherStationDetail';
 import {useToggle} from 'hooks/useToggle';
 import {LoggerContext, LoggerProps} from 'loggerContext';
+import {usePostHog} from 'posthog-react-native';
 import {WeatherStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MapLayer, MapLayerFeature, Variable, WeatherStation, WeatherStationCollection, WeatherStationSource} from 'types/nationalAvalancheCenter';
@@ -74,6 +75,11 @@ export const WeatherStationMap: React.FunctionComponent<{
   const [ready, {on: setReady}] = useToggle(false);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const avalancheCenterMapRegion: Region = defaultMapRegionForGeometries(mapLayer?.features.map(feature => feature.geometry));
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherStationsMap', {
+    center: center_id,
+  });
 
   const topElements = React.useRef<RNView>(null);
 

--- a/components/weather_data/WeatherStationPage.tsx
+++ b/components/weather_data/WeatherStationPage.tsx
@@ -6,6 +6,7 @@ import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useToggle} from 'hooks/useToggle';
 import {useWeatherStationsMetadata} from 'hooks/useWeatherStationsMetadata';
+import {usePostHog} from 'posthog-react-native';
 import React from 'react';
 import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
@@ -19,6 +20,11 @@ interface Props {
 export const WeatherStationPage: React.FC<Props> = ({center_id, requestedTime}) => {
   const avalancheCenterMetadataResult = useAvalancheCenterMetadata(center_id);
   const metadata = avalancheCenterMetadataResult.data;
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherTab', {
+    center: center_id,
+  });
   if (incompleteQueryState(avalancheCenterMetadataResult) || !metadata) {
     return <QueryState results={[avalancheCenterMetadataResult]} />;
   }

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -4,7 +4,7 @@ import {ScrollView} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {compareDesc, format} from 'date-fns';
 import {uniq} from 'lodash';
-import {useFeatureFlag} from 'posthog-react-native';
+import {useFeatureFlag, usePostHog} from 'posthog-react-native';
 
 import {ButtonBar} from 'components/content/ButtonBar';
 import {DataGrid} from 'components/content/DataGrid';
@@ -319,6 +319,11 @@ export const WeatherStationsDetail: React.FC<Props> = ({center_id, name, station
   const requestedTimeDate = parseRequestedTimeString(requestedTime);
   const timeseriesResult = useWeatherStationTimeseries(metadata?.widget_config.stations?.token, stations, requestedTimeDate, {days: days});
   const timeseries = timeseriesResult.data;
+  const postHog = usePostHog();
+
+  postHog?.screen('weatherStations', {
+    center: center_id,
+  });
 
   React.useEffect(() => {
     navigation.setOptions({title: zoneName});


### PR DESCRIPTION
App.tx: set the user-agent on requests

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

PostHog: track screen views and card interactions

Yes, both PostHog and MixPanel have automatic integration with our
navigation library and touch targets, but our navigation parameters are
generally machine-comprehensible identifiers rather than human-readable
values; also, tracking every touch is not very useful as CSS-style
parent naming for components is pretty much incomprehensible for anyone
but the dev who wrote the component yesterday. We're also likely going
to switch to PostHog from MixPanel as the PostHog free tier allows for
an unlimited number of investigations, whereas MixPanel caps us at 5.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

