### PR TITLE
Schemas: add AvalancheProblemName.GlideAvalanche

### DIFF
--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -72,6 +72,7 @@ export enum AvalancheProblemName {
   WetSlab = 'Wet Slab',
   CorniceFall = 'Cornice Fall',
   Glide = 'Glide',
+  GlideAvalanches = 'Glide Avalanches',
 }
 
 export enum AvalancheProblemLikelihood {


### PR DESCRIPTION
Adds the `.GlideAvalanche` entry to the `enum AvalancheProblemName` to stop client from failing api data validation with this option in it.

Fixes: https://github.com/NWACus/avy/issues/669

Some additional things worth investigating:

 - Making schema validation errors set `isError: true` and `isLoading: false` on network requests.
 - Loosening some runtime validations (see NWACus/avy#657