### PR TITLE
Revert SDK 50 upgrade tsconfig changes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "allowJs": true,
-    "esModuleInterop": true,
-    "jsx": "react-native",
-    "lib": ["DOM", "ESNext"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "target": "ESNext",
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
     "declaration": true,
@@ -19,11 +10,12 @@
     "isolatedModules": true,
     "outDir": "dist",
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "jsx": "react-native"
   },
   "ts-node": {
     "compilerOptions": {}
   },
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js", "android"],
+  "exclude": ["node_modules", "android"],
   "extends": "expo/tsconfig.base"
 }


### PR DESCRIPTION
Changes were made in #674

There was a problem with `ts-node` picking up the tsconfig referred to in `extends`. #676 fixed the problem the `.tsconfig` can be reverted to what it was.