### PR TITLE
map: only overwrite danger when we get a newer forecast result

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -174,7 +174,12 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
       forecast &&
         forecast.forecast_zone?.forEach(({id}) => {
           if (zonesById[id]) {
-            if (forecast.expires_time && isAfter(requestedTimeToUTCDate(requestedTime), toDate(new Date(forecast.expires_time), {timeZone: 'UTC'}))) {
+            if (
+              forecast.expires_time &&
+              zonesById[id].end_date &&
+              isAfter(requestedTimeToUTCDate(requestedTime), toDate(new Date(forecast.expires_time), {timeZone: 'UTC'})) &&
+              isAfter(toDate(new Date(forecast.expires_time), {timeZone: 'UTC'}), toDate(new Date(zonesById[id].end_date || '2000-01-01'), {timeZone: 'UTC'}))
+            ) {
               zonesById[id].danger_level = DangerLevel.GeneralInformation;
             } else if (forecast.product_type === ProductType.Forecast) {
               const currentDanger = forecast.danger.find(d => d.valid_day === ForecastPeriod.Current);


### PR DESCRIPTION
When we ask the NAC for the absolutely latest forecast product for a zone, it is possible for one zone to have a product that is valid for many zones. If that product is older than other, more zone-specific products, this will poison our `forecastResults` and the order in which we process this data will matter. Never use stale results when we have more recent ones already from the map layer.