### PR TITLE
LocationField: round to 5 decimals on lat/long

### DIFF
--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -89,7 +89,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
       <TouchableOpacity onPress={toggleModal} disabled={disabled}>
         <HStack borderWidth={2} borderColor={colorLookup('border.base')} borderRadius={4} justifyContent="space-between" alignItems="stretch">
           <View p={8}>
-            <Body>{value ? `${value.lat}, ${value.lng}` : 'Select a location'}</Body>
+            <Body>{value ? `${value.lat.toFixed(5)}, ${value.lng.toFixed(5)}` : 'Select a location'}</Body>
           </View>
           <Center px={8} borderLeftWidth={2} borderColor={colorLookup('border.base')}>
             <FontAwesome name="map-marker" color={colorLookup('text')} size={bodySize} />


### PR DESCRIPTION
We're only rounding on display, so the accuracy is not really lost, but regardless, 5 decimals is a 1.1m resolution and certainly good enough.

Fixes https://github.com/NWACus/avy/issues/630

![File (42)](https://github.com/NWACus/avy/assets/7328370/5c7e35d1-5ff9-4792-af01-3474d8ea2cd4)
