### PR TITLE
Add clearing of obs location

### DIFF
--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -45,13 +45,13 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
 
   const toggleModal = useCallback(() => {
     setModalVisible(!modalVisible);
-     setCleared(false)
+    setCleared(false);
   }, [modalVisible, setModalVisible]);
 
-  const value: LocationPoint | undefined = !cleared ? field.value as LocationPoint | undefined : undefined;
+  const value: LocationPoint | undefined = !cleared ? (field.value as LocationPoint | undefined) : undefined;
 
   const toggleModalandClearLocation = useCallback(() => {
-    setCleared(true)
+    setCleared(true);
     setModalVisible(!modalVisible);
   }, [modalVisible, setModalVisible]);
 
@@ -83,7 +83,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   const onPress = useCallback(
     (event: GestureReponderEvent) => {
       void (async () => {
-        setCleared(false)
+        setCleared(false);
         const point = {x: event.nativeEvent.locationX, y: event.nativeEvent.locationY};
         const coordinate = await mapRef.current?.coordinateForPoint(point);
         if (coordinate) {

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -36,7 +36,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   const mapLayer = mapLayerResult.data;
   const [initialRegion, setInitialRegion] = useState<Region>(defaultMapRegionForZones([]));
   const [mapReady, setMapReady] = useState<boolean>(false);
-  const [cleared, setCleared] = useState<boolean>(null);
+  const [cleared, setCleared] = useState<boolean>(false);
   const mapRef = useRef<MapView>(null);
 
   const toggleModalMain = useCallback(() => {

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -47,7 +47,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   const toggleModalandClearLocation = useCallback(() => {
     field.onChange(null);
     setModalVisible(!modalVisible);
-  }, [modalVisible, setModalVisible]);
+  }, [modalVisible, setModalVisible, field]);
 
   useEffect(() => {
     if (mapLayer && !mapReady) {

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -36,22 +36,16 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   const mapLayer = mapLayerResult.data;
   const [initialRegion, setInitialRegion] = useState<Region>(defaultMapRegionForZones([]));
   const [mapReady, setMapReady] = useState<boolean>(false);
-  const [cleared, setCleared] = useState<boolean>(false);
   const mapRef = useRef<MapView>(null);
-
-  const toggleModalMain = useCallback(() => {
-    setModalVisible(!modalVisible);
-  }, [modalVisible, setModalVisible]);
 
   const toggleModal = useCallback(() => {
     setModalVisible(!modalVisible);
-    setCleared(false);
   }, [modalVisible, setModalVisible]);
 
-  const value: LocationPoint | undefined = !cleared ? (field.value as LocationPoint | undefined) : undefined;
+  const value: LocationPoint | undefined = field.value as LocationPoint | undefined;
 
   const toggleModalandClearLocation = useCallback(() => {
-    setCleared(true);
+    field.onChange(null);
     setModalVisible(!modalVisible);
   }, [modalVisible, setModalVisible]);
 
@@ -83,7 +77,6 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   const onPress = useCallback(
     (event: GestureReponderEvent) => {
       void (async () => {
-        setCleared(false);
         const point = {x: event.nativeEvent.locationX, y: event.nativeEvent.locationY};
         const coordinate = await mapRef.current?.coordinateForPoint(point);
         if (coordinate) {
@@ -98,7 +91,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   return (
     <VStack width="100%" space={4} ref={ref}>
       <BodySmBlack>{label}</BodySmBlack>
-      <TouchableOpacity onPress={toggleModalMain} disabled={disabled}>
+      <TouchableOpacity onPress={toggleModal} disabled={disabled}>
         <HStack borderWidth={2} borderColor={colorLookup('border.base')} borderRadius={4} justifyContent="space-between" alignItems="stretch">
           <View p={8}>
             <Body>{value ? `${value.lat}, ${value.lng}` : 'Select a location'}</Body>
@@ -150,7 +143,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
                         initialRegion={initialRegion}
                         onPressPolygon={emptyHandler}
                         renderFillColor={false}>
-                        {field.value != null && !cleared && <MapMarker coordinate={locationPointToLatLng(field.value as LocationPoint)} />}
+                        {field.value != null && <MapMarker coordinate={locationPointToLatLng(field.value as LocationPoint)} />}
                       </ZoneMap>
                     </Pressable>
                   )}


### PR DESCRIPTION
attempt to solve https://github.com/NWACus/avy/issues/656. This changes the behavior a bit, where to select a location you now push a "check" location and "x" to clear it. The part that is not perfect is clearing the coordinates fully, you can spot that if you clear and then come back to set it again - the point will briefly be visible at the previous location if there was one. 

https://nwactechcommittee.slack.com/archives/C051KR96B2L/p1711086267002079?thread_ts=1711086244.167219&cid=C051KR96B2L