### PR TITLE
VSCode prettier config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "eslint.useESLintClass": true
+  "eslint.useESLintClass": true,
+  "prettier.configPath": "./.prettierrc.js",
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
With this change VSCode is now respecting the project's prettier configuration.

Before this prettier was using a system default _or_ some global configuration I might have which has a different `import` statement code style among other things.