### PR TITLE
Stop using safe area for keyboard vertical offset

### DIFF
--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {FieldErrors, FormProvider, useForm, useWatch} from 'react-hook-form';
 import {ColorValue, KeyboardAvoidingView, Platform, View as RNView, ScrollView, findNodeHandle} from 'react-native';
-import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {ClientContext, ClientProps} from 'clientContext';
 import {Button} from 'components/content/Button';
@@ -59,7 +59,7 @@ const ImageListOverlay: React.FC<{index: number; onPress: (index: number) => voi
 };
 
 const useKeyboardVerticalOffset = () => {
-  return useHeaderHeight() + useSafeAreaInsets().top;
+  return useHeaderHeight();
 };
 
 export const SimpleForm: React.FC<{


### PR DESCRIPTION
Not sure what happened between #712 an now but the safe area is no longer needed.

Before:

<img width="411" alt="Pasted_Image_3_29_24__2_03 PM" src="https://github.com/NWACus/avy/assets/19795/687c4345-b78b-4de2-9d8a-883f2a7d911c">

After 

<img width="403" alt="image" src="https://github.com/NWACus/avy/assets/19795/34758a5a-9281-4c00-a150-1e2f9043d342">
