### PR TITLE
Add generics to TextField to fit with react-hook-form

### DIFF
--- a/components/form/TextField.tsx
+++ b/components/form/TextField.tsx
@@ -1,14 +1,22 @@
 import {HStack, View, ViewProps, VStack} from 'components/core';
 import {BodySm, BodySmBlack, BodyXSm} from 'components/text';
-import React, {useCallback, useLayoutEffect, useRef, useState} from 'react';
-import {useController} from 'react-hook-form';
+import React, {Ref, useCallback, useLayoutEffect, useRef, useState} from 'react';
+import {FieldPathByValue, FieldValues, useController} from 'react-hook-form';
 import {Pressable, View as RNView, StyleSheet, TextInput, TextInputProps} from 'react-native';
 import {colorLookup} from 'theme';
 
 export type KeysMatching<T, V> = {[K in keyof T]-?: T[K] extends V ? K : never}[keyof T];
 
-interface TextFieldProps extends ViewProps {
-  name: string;
+/**
+ * TFieldValues and TFieldName match the generics of useController's with one additional constraint:
+ *
+ *  - TFieldName _must_ extends a key whose value is a `string | null | undefined` type because TextField at this time
+ *    only works with string values.
+ *
+ * FieldPathByValue is a utility type provided by react-hook-form that computes the keys whose values are constrained to that type.
+ */
+interface TextFieldProps<TFieldValues extends FieldValues, TFieldName extends FieldPathByValue<TFieldValues, StringFieldValue>> extends ViewProps {
+  name: TFieldName;
   label: string;
   comment?: string;
   textTransform?: (text: string) => string;
@@ -23,8 +31,19 @@ const textInputDefaultStyle = {
   fontFamily: 'Lato_400Regular',
 };
 
-export const TextField = React.forwardRef<RNView, TextFieldProps>(({name, label, comment, textTransform, textInputProps = {}, disabled, hideLabel = false, ...props}, ref) => {
-  const {field, fieldState} = useController({name});
+/**
+ * TextField can work with any form key with a value of this type.
+ */
+type StringFieldValue = string | null | undefined;
+
+/**
+ * To be used with forwardRef to create a generic component.
+ */
+const _TextField = <TFieldValues extends FieldValues, TFieldName extends FieldPathByValue<TFieldValues, StringFieldValue>>(
+  {name, label, comment, textTransform, textInputProps = {}, disabled, hideLabel = false, ...props}: TextFieldProps<TFieldValues, TFieldName>,
+  ref: Ref<RNView>,
+) => {
+  const {field, fieldState} = useController<TFieldValues, TFieldName>({name});
 
   const onChangeText = useCallback(
     (text: string): void => {
@@ -80,7 +99,7 @@ export const TextField = React.forwardRef<RNView, TextFieldProps>(({name, label,
             onBlur={onBlur}
             onFocus={onFocus}
             onChangeText={onChangeText}
-            value={field.value as string} // TODO(skuznets): determine why the generics here don't collapse to string itself ...
+            value={field.value}
             style={textInputDefaultStyle}
             placeholderTextColor={colorLookup('text.tertiary')}
             editable={!disabled}
@@ -92,7 +111,35 @@ export const TextField = React.forwardRef<RNView, TextFieldProps>(({name, label,
       {fieldState.error && <BodyXSm color={colorLookup('error.900')}>{fieldState.error.message}</BodyXSm>}
     </VStack>
   );
-});
+};
+
+/**
+ * The type of TFieldValues cannot be inferred by the use of <TextField />, it has to be supplied as a generic.
+ *
+ * It's usually nicer to have generic types inferred. This type allows alias TextField types to provide the TFieldValues
+ * and let the name prop be inferred based off of that.
+ *
+ * Example, the use of name="age" will be a compiler failure because the value of age is a number.
+ *
+ *    const MyCoolTextField = TextField as TextFieldComponent<{ firstName: string, age: number }>;
+ *
+ *    const Component = () => {
+ *      return (
+ *         <>
+ *          <MyCoolTextField name="firstName" .../>
+ *          <MyCoolTextField name="age" .../>
+ *         </>
+ *      );
+ *    };
+ */
+export type TextFieldComponent<TFieldValues extends FieldValues> = <TFieldName extends FieldPathByValue<TFieldValues, StringFieldValue>>(
+  props: React.PropsWithRef<TextFieldProps<TFieldValues, TFieldName>> & {ref?: Ref<RNView>},
+) => JSX.Element;
+
+export const TextField = React.forwardRef(_TextField) as (<TFieldValues extends FieldValues, TFieldName extends FieldPathByValue<TFieldValues, StringFieldValue>>(
+  props: React.PropsWithoutRef<TextFieldProps<TFieldValues, TFieldName>> & {ref?: Ref<RNView>},
+) => JSX.Element) & {displayName?: string};
+
 TextField.displayName = 'TextField';
 
 const styles = StyleSheet.create({

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -25,7 +25,7 @@ import {DateField} from 'components/form/DateField';
 import {LocationField} from 'components/form/LocationField';
 import {SelectField} from 'components/form/SelectField';
 import {SwitchField} from 'components/form/SwitchField';
-import {TextField} from 'components/form/TextField';
+import {TextField, TextFieldComponent} from 'components/form/TextField';
 import {ImageAndCaption, ObservationFormData, defaultObservationFormData, simpleObservationFormSchema} from 'components/observations/ObservationFormData';
 import {UploaderState, getUploader} from 'components/observations/uploader/ObservationsUploader';
 import {TaskStatus} from 'components/observations/uploader/Task';
@@ -57,6 +57,11 @@ const ImageListOverlay: React.FC<{index: number; onPress: (index: number) => voi
     </View>
   );
 };
+
+/**
+ * ObservationTextField can only have a name prop that is a key of a string value.
+ */
+const ObservationTextField = TextField as TextFieldComponent<ObservationFormData>;
 
 const useKeyboardVerticalOffset = () => {
   return useHeaderHeight() + useSafeAreaInsets().top;
@@ -383,7 +388,7 @@ export const SimpleForm: React.FC<{
                         ]}
                         disabled={disableFormControls}
                       />
-                      <TextField
+                      <ObservationTextField
                         name="email"
                         label="Email address"
                         comment="(never shared with the public)"
@@ -397,7 +402,7 @@ export const SimpleForm: React.FC<{
                         }}
                         disabled={disableFormControls}
                       />
-                      <TextField
+                      <ObservationTextField
                         name="phone"
                         label="Phone number"
                         comment="(optional, never shared with the public)"
@@ -450,7 +455,7 @@ export const SimpleForm: React.FC<{
                         ]}
                         disabled={disableFormControls}
                       />
-                      <TextField
+                      <ObservationTextField
                         name="location_name"
                         label="Location"
                         ref={fieldRefs.location_name}
@@ -556,7 +561,7 @@ export const SimpleForm: React.FC<{
                   <Conditional name="instability.avalanches_observed" value={true}>
                     <Card borderRadius={0} borderColor="white" header={<Title3Semibold>Avalanches</Title3Semibold>}>
                       <VStack space={formFieldSpacing} mt={8}>
-                        <TextField
+                        <ObservationTextField
                           name="avalanches_summary"
                           label="Observed avalanches"
                           ref={fieldRefs.avalanches_summary}
@@ -576,7 +581,7 @@ export const SimpleForm: React.FC<{
                   </Conditional>
                   <Card borderRadius={0} borderColor="white" header={<Title3Semibold>Field Notes</Title3Semibold>}>
                     <VStack space={formFieldSpacing} mt={8}>
-                      <TextField
+                      <ObservationTextField
                         name="observation_summary"
                         label="What did you observe?"
                         ref={fieldRefs.observation_summary}


### PR DESCRIPTION
I saw the `todo:` and knew how to solve it. It's a bit of a doozy though.

The end result is that you can have stricter typing for the form fields. It _could_ be simplified if we only want `TextField` to ever work with `ObservationFormData`.

The end result is:

 - You can't use a `name` prop for a form field that is not a string:
    <img width="181" alt="image" src="https://github.com/NWACus/avy/assets/19795/e7ec1b90-4cd6-4b11-9d75-34da770e8124">
 - It infers the names you _can_ use:
   <img width="547" alt="image" src="https://github.com/NWACus/avy/assets/19795/84cbb274-4711-4f5a-9a85-0b616e36cb63">
