### PR TITLE
Constrain keys of fieldRefs

### DIFF
--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -10,7 +10,7 @@ import {AxiosError} from 'axios';
 import * as ImagePicker from 'expo-image-picker';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {FieldErrors, FormProvider, useForm, useWatch} from 'react-hook-form';
+import {FieldErrors, FieldPath, FormProvider, useForm, useWatch} from 'react-hook-form';
 import {ColorValue, KeyboardAvoidingView, Platform, View as RNView, ScrollView, findNodeHandle} from 'react-native';
 import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -122,9 +122,10 @@ export const SimpleForm: React.FC<{
         'instability.collapsing_description': React.createRef<RNView>(),
         avalanches_summary: React.createRef<RNView>(),
         observation_summary: React.createRef<RNView>(),
-      } as const),
+      } satisfies Partial<Record<FieldPath<ObservationFormData>, React.Ref<unknown>>>),
     [],
   );
+
   const scrollViewRef = useRef<ScrollView>(null);
 
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);


### PR DESCRIPTION
The keys only work if they're valid `useForm` keys from `ObservationFormData`

<img width="510" alt="Pasted_Image_3_29_24__11_11 PM" src="https://github.com/NWACus/avy/assets/19795/357f59b7-bf8f-4e8c-add8-f6b406fa041d">
