### PR TITLE
Return sha of pull instead of ref when doing pull request get lookup for expo update GAH

### DIFF
--- a/.github/workflows/expo_preview.yaml
+++ b/.github/workflows/expo_preview.yaml
@@ -59,7 +59,7 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             })
-            return response.data.head.ref
+            return response.data.head.sha
 
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master


### PR DESCRIPTION
issue_comment trigger doesnt really provide us with much data about the branch/commit/etc, but we need a sha to get the expo_preview task to success at the end