### PR TITLE
Switch the sha used to mark expo_preview task as success

### DIFF
--- a/.github/workflows/expo_preview.yaml
+++ b/.github/workflows/expo_preview.yaml
@@ -59,7 +59,7 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             })
-            return response.data.head.sha
+            return response.data.merge_commit_sha
 
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master


### PR DESCRIPTION
head.sha provided an : Error: No commit found for SHA: "c828abe8555ebf1516696f16a1cf5af45a74860c". Going to try the other sha that is returned from pulls.get. 