### PR TITLE
Remove marking task as success, comment on PR is enough

### DIFF
--- a/.github/workflows/expo_preview.yaml
+++ b/.github/workflows/expo_preview.yaml
@@ -47,24 +47,3 @@ jobs:
               repo: context.repo.repo,
               body: body
             })
-
-      - name: Lookup Branch
-        uses: actions/github-script@v3
-        id: pr-branch
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const response = await github.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            })
-            return response.data.merge_commit_sha
-
-      - name: Set latest commit status as ${{ job.status }}
-        uses: myrotvorets/set-commit-status-action@master
-        if: always()
-        with:
-          sha: ${{ steps.pr-branch.outputs.result }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}


### PR DESCRIPTION
This will simply add a comment with task status vs setting latest commit status on the PR based on github action results. The reason to take out the the setting of latest commit status is due to it not working for PRs from forked repos - it only works for PRs from repos inside of avy. 