### PR TITLE
Error caused by an unexpected enum 'static' in NWACWeatherStationStatus

### DIFF
--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -1287,6 +1287,7 @@ export type WeatherStationSource = (typeof WeatherStationSource)[keyof typeof We
 export const NWACWeatherStationStatus = {
   Active: 'active',
   Inactive: 'inactive',
+  Static: 'static',
 } as const;
 export type NWACWeatherStationStatus = (typeof NWACWeatherStationStatus)[keyof typeof NWACWeatherStationStatus];
 


### PR DESCRIPTION
Weather tab currently is not loading in the prod app due to this error. Doesnt look like we actually use status anywhere from a quick glance but adding the value fixes the hang on the weather tab

error in sentry: 
 {
    "received": "static",
    "code": "invalid_enum_value",
    "options": [
      "active",
      "inactive"
    ],
    "path": [
      "features",
      100,
      "properties",
      "station_note",
      0,
      "status"
    ],
    "message": "Invalid enum value. Expected 'active' | 'inactive', received 'static'"
  },
https://nwac.sentry.io/issues/5080771829/events/67263066baec40f487ed0a32527c5c67/