### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/components/content/NavigationHeader.tsx
+++ b/components/content/NavigationHeader.tsx
@@ -41,7 +41,7 @@ export const NavigationHeader: React.FunctionComponent<
         <TextComponent textAlign="center" style={{flex: 1, borderColor: 'transparent', borderWidth: 1}}>
           {title}
         </TextComponent>
-        <AvalancheCenterLogo style={{height: 32, width: 32, resizeMode: 'contain', flex: 0, flexGrow: 0}} avalancheCenterId={center_id} />
+        <AvalancheCenterLogo style={{height: 32, width: 32, resizeMode: 'cover', flex: 0, flexGrow: 0}} avalancheCenterId={center_id} />
       </HStack>
     </View>
   );

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -333,7 +333,7 @@ export const ObservationCard: React.FunctionComponent<{
                 </VStack>
               </Card>
               {images(observation.media).length > 0 && (
-                <Card borderRadius={0} borderColor="white" header={<BodyBlack>Media</BodyBlack>} noDivider>
+                <Card borderRadius={0} borderColor="white" header={<BodyBlack>Media</BodyBlack>}>
                   <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={images(observation.media)} displayCaptions={false} />
                 </Card>
               )}

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -45,7 +45,7 @@ const useKeyboardVerticalOffset = () => {
   return useHeaderHeight();
 };
 
-export const SimpleForm: React.FC<{
+export const ObservationForm: React.FC<{
   center_id: AvalancheCenterID;
   onClose?: () => void;
 }> = ({center_id, onClose}) => {

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -539,21 +539,27 @@ export const ObservationForm: React.FC<{
                     header={
                       <HStack justifyContent="space-between">
                         <Title3Semibold>Photos</Title3Semibold>
-                        <ObservationAddImageButton maxImageCount={maxImageCount} disable={disableFormControls} space={2} py={2} pl={4} pr={8} />
+                        <ObservationAddImageButton maxImageCount={maxImageCount} disable={disableFormControls} space={4} py={4} pl={4} pr={8} />
                       </HStack>
                     }>
                     <VStack space={formFieldSpacing} mt={8}>
-                      <ObservationImagePicker maxImageCount={maxImageCount} disable={disableFormControls} onModalDisplayed={setModalDisplayed} />
+                      <ObservationImagePicker maxImageCount={maxImageCount} onModalDisplayed={setModalDisplayed} />
                     </VStack>
                   </Card>
 
                   <Button mx={16} mt={8} buttonStyle="primary" disabled={mutation.isSuccess || mutation.isLoading} busy={mutation.isLoading} onPress={onSubmitPress}>
                     <BodySemibold>{mutation.isLoading ? 'Uploading observation' : 'Submit your observation'}</BodySemibold>
                   </Button>
-                  <VStack mx={16} mt={16} mb={32}>
-                    {mutation.isSuccess && <Body>Thanks for your observation!</Body>}
-                    {mutation.isError && <Body color={colorLookup('error.900')}>There was an error submitting your observation.</Body>}
-                  </VStack>
+                  {mutation.isSuccess && (
+                    <VStack mx={16} mt={16} mb={32}>
+                      <Body>Thanks for your observation!</Body>
+                    </VStack>
+                  )}
+                  {mutation.isError && (
+                    <VStack mx={16} mt={16} mb={32}>
+                      <Body color={colorLookup('error.900')}>There was an error submitting your observation.</Body>
+                    </VStack>
+                  )}
                 </VStack>
               </ScrollView>
             </VStack>

--- a/components/observations/ObservationImagePicker.tsx
+++ b/components/observations/ObservationImagePicker.tsx
@@ -133,9 +133,8 @@ export const ObservationAddImageButton: React.FC<ObservationAddImageButtonProps>
 
 export const ObservationImagePicker: React.FC<{
   maxImageCount: number;
-  disable: boolean;
   onModalDisplayed: (isOpen: boolean) => void;
-}> = ({maxImageCount, disable, onModalDisplayed}) => {
+}> = ({maxImageCount, onModalDisplayed}) => {
   const {field} = useController<ObservationFormData, 'images'>({name: 'images', defaultValue: []});
   const images = field.value;
 
@@ -182,7 +181,6 @@ export const ObservationImagePicker: React.FC<{
 
   return (
     <>
-      <Body>You can add up to {maxImageCount} images.</Body>
       <HStack flexWrap="wrap">
         {images?.map(({image, caption}, i) => {
           return (
@@ -231,10 +229,12 @@ export const ObservationImagePicker: React.FC<{
           );
         })}
       </HStack>
-      <VStack space={4}>
-        <ObservationAddImageButton disable={disable} maxImageCount={maxImageCount} />
-        {missingImagePermissions && <BodySm color={colorLookup('error.900')}>We need permission to access your photos to upload images. Please check your system settings.</BodySm>}
-      </VStack>
+      {missingImagePermissions && (
+        <VStack space={4}>
+          <BodySm color={colorLookup('error.900')}>We need permission to access your photos to upload images. Please check your system settings.</BodySm>
+        </VStack>
+      )}
+      {images?.length === 0 && <Body>You can add up to {maxImageCount} images.</Body>}
       <ImageCaptionField image={editingImage} onUpdateImage={onUpdateImageCaption} onDismiss={onDismiss} onModalDisplayed={onModalDisplayed} />
     </>
   );

--- a/components/screens/ObservationsScreen.tsx
+++ b/components/screens/ObservationsScreen.tsx
@@ -1,9 +1,9 @@
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
 import {NavigationHeader} from 'components/content/NavigationHeader';
 import {NWACObservationDetailView, ObservationDetailView} from 'components/observations/ObservationDetailView';
+import {ObservationForm} from 'components/observations/ObservationForm';
 import {ObservationsListView} from 'components/observations/ObservationsListView';
 import {ObservationsPortal} from 'components/observations/ObservationsPortal';
-import {SimpleForm} from 'components/observations/SimpleForm';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {ObservationsStackParamList, TabNavigatorParamList} from 'routes';
@@ -34,7 +34,7 @@ const ObservationsPortalScreen = ({route}: NativeStackScreenProps<ObservationsSt
 
 const ObservationSubmitScreen = ({route}: NativeStackScreenProps<ObservationsStackParamList, 'observationSubmit'>) => {
   const {center_id} = route.params;
-  return <SimpleForm center_id={center_id} />;
+  return <ObservationForm center_id={center_id} />;
 };
 
 const ObservationsListScreen = ({route}: NativeStackScreenProps<ObservationsStackParamList, 'observationsList'>) => {

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import {ScrollView} from 'react-native';
 
 import * as Sentry from '@sentry/react-native';
 
@@ -10,11 +9,11 @@ import {InfoTooltip} from 'components/content/InfoTooltip';
 import {incompleteQueryState, NotFound, QueryState} from 'components/content/QueryState';
 import {Center, Divider, HStack, View, VStack} from 'components/core';
 import {BodyBlack, bodySize, BodyXSm, BodyXSmBlack} from 'components/text';
-import {Column, formatDateTime} from 'components/weather_data/WeatherStationsDetail';
+import {formatDateTime} from 'components/weather_data/WeatherStationsDetail';
 import {compareDesc} from 'date-fns';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useWeatherStationTimeseries} from 'hooks/useWeatherStationTimeseries';
-import {useFeatureFlag, usePostHog} from 'posthog-react-native';
+import {usePostHog} from 'posthog-react-native';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, StationNote, Variable, WeatherStationSource, WeatherStationTimeseries} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
@@ -32,7 +31,6 @@ interface columnData {
   data: (number | string | null)[];
 }
 export const WeatherStationDetail: React.FC<Props> = ({center_id, stationId, source, requestedTime}) => {
-  const useNewTable = !!useFeatureFlag(`new-weather-table`) || process.env.EXPO_PUBLIC_NEW_WEATHER_TABLE === 'true';
   const [days, setDays] = useState(1);
   const avalancheCenterMetadataResult = useAvalancheCenterMetadata(center_id);
   const metadata = avalancheCenterMetadataResult.data;
@@ -126,7 +124,7 @@ export const WeatherStationDetail: React.FC<Props> = ({center_id, stationId, sou
           size="small"
           paddingTop={6}
         />
-        {useNewTable ? <NewWeatherDataTable columns={columns} timeseries={timeseries} /> : <WeatherDataTable columns={columns} timeseries={timeseries} />}
+        <WeatherDataTable columns={columns} timeseries={timeseries} />
         <View height={16} />
       </VStack>
     </VStack>
@@ -268,7 +266,7 @@ export const orderStationVariables = (stationVariables: Variable[]): Variable[] 
 const columnPadding = 3;
 const rowPadding = 2;
 
-function NewWeatherDataTable({columns: columnsWithTime, timeseries}: {columns: columnData[]; timeseries: WeatherStationTimeseries}) {
+function WeatherDataTable({columns: columnsWithTime, timeseries}: {columns: columnData[]; timeseries: WeatherStationTimeseries}) {
   // DataGrid expects data in row-major order, so we need to transpose our data
   const [times, ...columns] = columnsWithTime;
   const data: string[][] = useMemo(() => {
@@ -362,26 +360,6 @@ function NewWeatherDataTable({columns: columnsWithTime, timeseries}: {columns: c
       renderColumnHeader={renderColumnHeader}
       renderCornerHeader={renderCornerHeader}
     />
-  );
-}
-
-function WeatherDataTable({columns, timeseries}: {columns: columnData[]; timeseries: WeatherStationTimeseries}) {
-  return (
-    <ScrollView style={{width: '100%', height: '100%'}}>
-      <ScrollView horizontal style={{width: '100%', height: '100%'}}>
-        <HStack py={8} justifyContent="space-between" alignItems="center" bg="white">
-          {columns.map(({variable, data}, columnIndex) => (
-            <Column
-              key={columnIndex}
-              borderRightWidth={columnIndex == 0 ? 1 : 0}
-              name={formatVariable(variable)}
-              units={formatUnits(variable, timeseries.UNITS)}
-              data={formatData(variable, data)}
-            />
-          ))}
-        </HStack>
-      </ScrollView>
-    </ScrollView>
   );
 }
 


### PR DESCRIPTION
weather_data: remove the concept of old weather table

We've used the 'new' weather table for the entire season and are happy
with it. No need to feature-flag this any longer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

observations: show divider for media

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

navigation header: resize mode to fit better

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

observations: rename 'simple' form

The 'simple' form was a name in reference to something else which we
don't support or even have in the code-base any longer, so let's name it
in a descriptive way instead.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

observations: remove duplicate button to add photos

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


Fixes https://github.com/NWACus/avy/issues/767
Fixes https://github.com/NWACus/avy/issues/765
Fixes https://github.com/NWACus/avy/issues/766
Fixes https://github.com/NWACus/avy/issues/763
Fixes https://github.com/NWACus/avy/issues/762
Fixes https://github.com/NWACus/avy/issues/761