### PR TITLE
ObservationDetailView: fix date parsing, estimation logic

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -28,7 +28,6 @@ import {
   AvalancheBedSurface,
   AvalancheCause,
   AvalancheCenterID,
-  AvalancheDateUncertainty,
   AvalancheTrigger,
   AvalancheType,
   CloudCover,
@@ -37,7 +36,6 @@ import {
   FormatAvalancheAspect,
   FormatAvalancheBedSurface,
   FormatAvalancheCause,
-  FormatAvalancheDateUncertainty,
   FormatAvalancheTrigger,
   FormatAvalancheType,
   FormatCloudCover,
@@ -50,7 +48,7 @@ import {
   SnowAvailableForTransport,
   WindLoading,
 } from 'types/nationalAvalancheCenter';
-import {pacificDateToLocalShortDateString, utcDateToLocalShortDateString, utcDateToLocalTimeString} from 'utils/date';
+import {pacificDateToLocalShortDateString, utcDateToLocalShortDateString} from 'utils/date';
 
 export const NWACObservationDetailView: React.FunctionComponent<{
   id: string;
@@ -348,10 +346,7 @@ export const ObservationCard: React.FunctionComponent<{
                       <VStack space={8} style={{flex: 1}} key={`avalanche-${index}`}>
                         <BodyBlack>{`#${index + 1}${item.location ? `: ${item.location}` : ''}`}</BodyBlack>
                         {item.comments && <HTML source={{html: item.comments}} />}
-                        <TableRow
-                          label={`Date${item.dateAccuracy ? ` (${FormatAvalancheDateUncertainty(item.dateAccuracy as AvalancheDateUncertainty)})` : ''}`}
-                          value={`${utcDateToLocalTimeString(item.date)}`}
-                        />
+                        <TableRow label={`Date (${item.date_known ? 'Exact' : 'Estimated'})`} value={`${pacificDateToLocalShortDateString(item.date)}`} />
                         {item.dSize && item.rSize && <TableRow label={'Size'} value={`D${item.dSize}-R${item.rSize}`} />}
                         {item.trigger && item.cause && (
                           <TableRow

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -826,18 +826,6 @@ export type WindLoading = (typeof WindLoading)[keyof typeof WindLoading];
 export const FormatWindLoading = (value: WindLoading): string => {
   return reverseLookup(WindLoading, value);
 };
-export const AvalancheDateUncertainty = {
-  Exact: '0',
-  '+/- 1 day': '1',
-  '+/- 3 days': '3',
-  '+/- 1 week': '7',
-  '+/- 1 month': '30',
-  Estimated: 'estimated',
-} as const;
-export type AvalancheDateUncertainty = (typeof AvalancheDateUncertainty)[keyof typeof AvalancheDateUncertainty];
-export const FormatAvalancheDateUncertainty = (value: AvalancheDateUncertainty): string => {
-  return reverseLookup(AvalancheDateUncertainty, value);
-};
 export const AvalancheAspect = {
   N: 'N',
   NE: 'NE',
@@ -1021,7 +1009,9 @@ export const observationSchema = z.object({
     .array(
       z.object({
         date: z.string().nullable().optional(/* only because of NWAC */),
-        dateAccuracy: z.nativeEnum(AvalancheDateUncertainty).or(z.string().length(0)).optional(),
+        date_known: z.boolean().nullable().optional(/* only because of NWAC */),
+        time: z.string().nullable().optional(/* only because of NWAC */),
+        time_known: z.boolean().nullable().optional(/* only because of NWAC */),
         location: z.string().nullable().optional(/* only because of NWAC */),
         number: z.number().nullable().optional(/* only because of NWAC */),
         avalancheType: z.nativeEnum(AvalancheType).or(z.string().length(0)).optional(),


### PR DESCRIPTION
The date field is yet another time-less entity, so for now assume PST and fix this in the future to use the time zone of the center we're looking at, although that might break down in western Idaho ...

Also, fix the schema for avalanche observations that changed last year so we correctly detect inexact dates.

Fixes #772 

![File (48)](https://github.com/user-attachments/assets/cd458691-f3f7-46a2-992f-94bfb56c5289)
