### PR TITLE
Issue 747: Stop pin from moving on map pans

### DIFF
--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -43,7 +43,6 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
       onMoveShouldSetPanResponder: () => true,
       onPanResponderRelease: (event, gestureState) => {
         if (gestureState.dx != 0 && gestureState.dy != 0) {
-          console.log('Gesture ignored because the user moved the map');
           return;
         }
 

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -8,7 +8,7 @@ import {Body, BodySmBlack, BodyXSm, Title3Black, bodySize} from 'components/text
 import {useMapLayer} from 'hooks/useMapLayer';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useController} from 'react-hook-form';
-import {GestureResponderEvent, Modal, Pressable, View as RNView, TouchableOpacity} from 'react-native';
+import {Modal, PanResponder, View as RNView, TouchableOpacity} from 'react-native';
 import MapView, {LatLng, MapMarker, Region} from 'react-native-maps';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
@@ -36,6 +36,27 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   const [initialRegion, setInitialRegion] = useState<Region>(defaultMapRegionForZones([]));
   const [mapReady, setMapReady] = useState<boolean>(false);
   const mapRef = useRef<MapView>(null);
+
+  const mapPanResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderRelease: (event, gestureState) => {
+        if (gestureState.dx != 0 && gestureState.dy != 0) {
+          console.log('Gesture ignored because the user moved the map');
+          return;
+        }
+
+        void (async () => {
+          const point = {x: event.nativeEvent.locationX, y: event.nativeEvent.locationY};
+          const coordinate = await mapRef.current?.coordinateForPoint(point);
+          if (coordinate) {
+            field.onChange(latLngToLocationPoint(coordinate));
+          }
+        })();
+      },
+    }),
+  ).current;
 
   const toggleModal = useCallback(() => {
     setModalVisible(!modalVisible);
@@ -73,35 +94,25 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
       fillOpacity: feature.properties.fillOpacity,
     })) ?? [];
 
-  const onPress = useCallback(
-    (event: GestureResponderEvent) => {
-      void (async () => {
-        const point = {x: event.nativeEvent.locationX, y: event.nativeEvent.locationY};
-        const coordinate = await mapRef.current?.coordinateForPoint(point);
-        if (coordinate) {
-          field.onChange(latLngToLocationPoint(coordinate));
-        }
-      })();
-    },
-    [field],
-  );
   const emptyHandler = useCallback(() => undefined, []);
 
   return (
-    <VStack width="100%" space={4} ref={ref}>
-      <BodySmBlack>{label}</BodySmBlack>
-      <TouchableOpacity onPress={toggleModal} disabled={disabled}>
-        <HStack borderWidth={2} borderColor={colorLookup('border.base')} borderRadius={4} justifyContent="space-between" alignItems="stretch">
-          <View p={8}>
-            <Body>{value ? `${value.lat.toFixed(5)}, ${value.lng.toFixed(5)}` : 'Select a location'}</Body>
-          </View>
-          <Center px={8} borderLeftWidth={2} borderColor={colorLookup('border.base')}>
-            <FontAwesome name="map-marker" color={colorLookup('text')} size={bodySize} />
-          </Center>
-        </HStack>
-      </TouchableOpacity>
-      {/* TODO: animate the appearance/disappearance of the error string */}
-      {error && <BodyXSm color={colorLookup('error.900')}>{error.message}</BodyXSm>}
+    <>
+      <VStack width="100%" space={4} ref={ref}>
+        <BodySmBlack>{label}</BodySmBlack>
+        <TouchableOpacity onPress={toggleModal} disabled={disabled}>
+          <HStack borderWidth={2} borderColor={colorLookup('border.base')} borderRadius={4} justifyContent="space-between" alignItems="stretch">
+            <View p={8}>
+              <Body>{value ? `${value.lat.toFixed(5)}, ${value.lng.toFixed(5)}` : 'Select a location'}</Body>
+            </View>
+            <Center px={8} borderLeftWidth={2} borderColor={colorLookup('border.base')}>
+              <FontAwesome name="map-marker" color={colorLookup('text')} size={bodySize} />
+            </Center>
+          </HStack>
+        </TouchableOpacity>
+        {/* TODO: animate the appearance/disappearance of the error string */}
+        {error && <BodyXSm color={colorLookup('error.900')}>{error.message}</BodyXSm>}
+      </VStack>
 
       {modalVisible && (
         <Modal visible={modalVisible} onRequestClose={toggleModalandClearLocation} animationType="slide">
@@ -133,7 +144,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
                 <Center width="100%" height="100%">
                   {incompleteQueryState(mapLayerResult) && <QueryState results={[mapLayerResult]} />}
                   {mapReady && (
-                    <Pressable onPress={onPress}>
+                    <View {...mapPanResponder.panHandlers}>
                       <ZoneMap
                         ref={mapRef}
                         animated={false}
@@ -144,7 +155,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
                         renderFillColor={false}>
                         {field.value != null && <MapMarker coordinate={locationPointToLatLng(field.value as LocationPoint)} />}
                       </ZoneMap>
-                    </Pressable>
+                    </View>
                   )}
                 </Center>
               </VStack>
@@ -152,7 +163,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
           </SafeAreaProvider>
         </Modal>
       )}
-    </VStack>
+    </>
   );
 });
 LocationField.displayName = 'LocationField';


### PR DESCRIPTION
This fixes the issue in #747 where the pin moved every time a user panned or zoomed in on the map. This was because no matter what the user did while interacting with the map, it would file an `onPress` that would then update the pin location. 

This fix replaces `<Pressable>` and the `onPress` with a `<View>` and `PanResponder`. The `PanResponder` keeps tracks of movements the user does on the `View` which are then used to determine if the user tapped the view or did a different gesture.

![PanFix](https://github.com/user-attachments/assets/f7feb829-4bcc-4334-9d6c-4284a28d9861)
