### PR TITLE
*: remove observations feed date limits

### DIFF
--- a/components/form/DateField.tsx
+++ b/components/form/DateField.tsx
@@ -11,7 +11,7 @@ import {utcDateToLocalDateString} from 'utils/date';
 interface DateFieldProps extends ViewProps {
   name: string;
   label?: string;
-  minimumDate: Date;
+  minimumDate?: Date;
   maximumDate: Date;
   disabled?: boolean;
 }
@@ -43,7 +43,6 @@ export const DateField: React.FC<DateFieldProps> = ({name, label, minimumDate, m
     }
   }, [datePickerVisible, setDatePickerVisible, onDateSelected, value, minimumDate, maximumDate]);
 
-  // TODO: maximum/minimum date
   return (
     <VStack width="100%" space={4} {...props}>
       {label && <BodySmBlack>{label}</BodySmBlack>}

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -34,7 +34,6 @@ import Toast from 'react-native-toast-message';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, InstabilityDistribution, userFacingCenterId} from 'types/nationalAvalancheCenter';
-import {startOfSeasonLocalDate} from 'utils/date';
 
 /**
  * ObservationTextField can only have a name prop that is a key of a string value.
@@ -352,7 +351,7 @@ export const ObservationForm: React.FC<{
                         }}
                         disabled={disableFormControls}
                       />
-                      <DateField name="start_date" label="Observation date" minimumDate={startOfSeasonLocalDate(today)} maximumDate={today} disabled={disableFormControls} />
+                      <DateField name="start_date" label="Observation date" maximumDate={today} disabled={disableFormControls} />
                       <SelectField
                         name="activity"
                         label="Activity"

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -67,7 +67,7 @@ interface ObservationFragmentWithPageIndexAndZoneAndSource extends ObservationFr
 export const ObservationsListView: React.FunctionComponent<ObservationsListViewProps> = ({center_id, requestedTime, additionalFilters}) => {
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const endDate = requestedTimeToUTCDate(requestedTime);
-  const originalFilterConfig: ObservationFilterConfig = useMemo(() => createDefaultFilterConfig(requestedTime, additionalFilters), [requestedTime, additionalFilters]);
+  const originalFilterConfig: ObservationFilterConfig = useMemo(() => createDefaultFilterConfig(additionalFilters), [additionalFilters]);
   const [filterConfig, setFilterConfig] = useState<ObservationFilterConfig>(originalFilterConfig);
   const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal}] = useToggle(false);
   const mapResult = useMapLayer(center_id);
@@ -158,8 +158,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
     })();
   }, [observationsResult]);
 
-  const {from: filterStartDate} = filterConfig.dates;
-  const moreDataAvailable = observationsResult.hasNextPage && (observations.length === 0 || new Date(observations[observations.length - 1].startDate) > filterStartDate);
+  const moreDataAvailable = observationsResult.hasNextPage;
 
   // the displayed observations need to match all filters - for instance, if a user chooses a zone *and*
   // an observer type, we only show observations that match both of those at the same time
@@ -251,11 +250,11 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         <Center height={OBSERVATION_SUMMARY_CARD_HEIGHT} paddingBottom={48}>
           <Body>
             <FormattedMessage
-              description="How many observations were found"
+              description="How many observations were found."
               defaultMessage="{count, plural,
-  =0 {No matching observations in this time period}
-  one {One matching observation in this time period}
-  other {# matching observations in this time period}}"
+  =0 {No observations match the filters.}
+  one {One observation matches the filters.}
+  other {# observations match the filters.}}"
               values={{
                 count: observationsSection.data.length,
               }}

--- a/utils/date.test.ts
+++ b/utils/date.test.ts
@@ -1,14 +1,5 @@
-import {toDate} from 'date-fns-tz';
 import * as TimezoneMock from 'timezone-mock';
-import {
-  apiDateString,
-  nominalForecastDateString,
-  nominalNWACWeatherForecastDate,
-  normalizeTimeZone,
-  startOfSeasonLocalDate,
-  utcDateToLocalDateString,
-  utcDateToLocalTimeString,
-} from 'utils/date';
+import {apiDateString, nominalForecastDateString, nominalNWACWeatherForecastDate, normalizeTimeZone, utcDateToLocalDateString, utcDateToLocalTimeString} from 'utils/date';
 
 describe('Dates', () => {
   describe('apiDateString', () => {
@@ -112,24 +103,6 @@ describe('Dates', () => {
     });
     it('returns the current day afternoon when requesting after the expiry time using UTC', () => {
       expect(nominalNWACWeatherForecastDate(new Date('2023-01-25T03:44:27-00:00'))).toBe('2023-01-24 afternoon');
-    });
-  });
-
-  describe('startOfSeasonLocalDate', () => {
-    const localDate = (dateString: string): Date => {
-      return toDate(dateString, {timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone});
-    };
-    it('returns September 1 of the current year when date is after september 1', () => {
-      expect(startOfSeasonLocalDate(localDate('2023-10-01'))).toEqual(localDate('2023-09-01'));
-    });
-    it('returns September 1 of the previous year when date is before august 31', () => {
-      expect(startOfSeasonLocalDate(localDate('2023-01-01'))).toEqual(localDate('2022-09-01'));
-    });
-    it('returns September 1 of the previous year when date is august 31', () => {
-      expect(startOfSeasonLocalDate(localDate('2023-08-31'))).toEqual(localDate('2022-09-01'));
-    });
-    it('returns September 1 of the current year when date is september 31', () => {
-      expect(startOfSeasonLocalDate(localDate('2023-09-01'))).toEqual(localDate('2023-09-01'));
     });
   });
 

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -164,24 +164,3 @@ export const parseRequestedTimeString = (requestedTime: RequestedTimeString): Re
 
   return 'latest';
 };
-
-export const startOfSeasonLocalDate = (requestedTime: RequestedTime): Date => {
-  // NWAC defines the season as 9/1 -> 8/31 of the next year. We'll apply this globally for now,
-  // maybe change based on center in the future.
-
-  // Given the requestedTime value, let's jump through some hoops to get the date at midnight local time
-  // Midnight on September 1 in UTC is 6pm on August 31 in Seattle, and we don't want to get 8/31 back from this method - we want to get 9/1.
-  const utcDate: Date = requestedTimeToUTCDate(requestedTime);
-  const localTimeZone = normalizeTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
-  const localDateString = formatInTimeZone(utcDate, localTimeZone.ianaName, 'yyyy-MM-dd');
-  // can't do new Date(localDateString) or that'll interpret the date as UTC
-  const date = toDate(localDateString, {timeZone: localTimeZone.ianaName});
-
-  // Months are zero-based, so September is 8
-  return new Date(date.getMonth() >= 8 ? date.getFullYear() : date.getFullYear() - 1, 8, 1, 0, 0, 0, 0);
-};
-
-export const endOfSeasonLocalDate = (requestedTime: RequestedTime): Date => {
-  const startOfSeason = startOfSeasonLocalDate(requestedTime);
-  return new Date(startOfSeason.getFullYear() + 1, 8, 1, 0, 0, 0);
-};


### PR DESCRIPTION
The observations feed doesn't have any good reason to enforce a bound on how far back in time you can scroll. This paradigm was ported from the website where choosing "last season" will shoot off a request that fetches all observations for the entire season. Since we're not asking for all observations at once and doing a progressive load, there's no real reason to have this behavior in the app.

Fixes #811 