### PR TITLE
*: use capabilities API for display ID

### DIFF
--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -58,7 +58,7 @@ export const AvalancheCenterSelector: React.FunctionComponent<{
       <AvalancheCenterList
         selectedCenter={currentCenterId}
         setSelectedCenter={setAvalancheCenterWrapper}
-        data={avalancheCenterList(metadata)}
+        data={avalancheCenterList(metadata, capabilities)}
         width="100%"
         height="100%"
         bg="white"

--- a/components/avalancheCenterList.ts
+++ b/components/avalancheCenterList.ts
@@ -1,9 +1,10 @@
 import * as Updates from 'expo-updates';
-import {AvalancheCenter, AvalancheCenterID, avalancheCenterIDSchema} from 'types/nationalAvalancheCenter';
+import {AllAvalancheCenterCapabilities, AvalancheCenter, AvalancheCenterID, avalancheCenterIDSchema, userFacingCenterId} from 'types/nationalAvalancheCenter';
 
 export interface AvalancheCenterListData {
   center: AvalancheCenter;
   description?: string;
+  display_id: string;
 }
 
 const supportedAvalancheCenters = (): {center: AvalancheCenterID; description: string}[] => {
@@ -63,12 +64,13 @@ export const filterToSupportedCenters = (ids: AvalancheCenterID[]): AvalancheCen
   return ids.filter(id => supportedCenters.includes(id));
 };
 
-export const avalancheCenterList = (metadata: AvalancheCenter[]): AvalancheCenterListData[] => {
+export const avalancheCenterList = (metadata: AvalancheCenter[], capabilities: AllAvalancheCenterCapabilities): AvalancheCenterListData[] => {
   const centers = supportedAvalancheCenters();
   return metadata
     .map(center => ({
       center: center,
       description: centers.find(supported => supported.center === center.id)?.description,
+      display_id: userFacingCenterId(center.id as AvalancheCenterID, capabilities),
     }))
     .sort((a, b) => {
       // Centers with descriptions are "blessed" and should sort above the rest

--- a/components/content/AvalancheCenterList.tsx
+++ b/components/content/AvalancheCenterList.tsx
@@ -6,7 +6,7 @@ import {HStack, VStack, VStackProps} from 'components/core';
 import {Body, BodySemibold} from 'components/text';
 import {TouchableOpacity} from 'react-native';
 import {colorLookup} from 'theme';
-import {AvalancheCenterID, userFacingCenterId} from 'types/nationalAvalancheCenter';
+import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
 
 interface AvalancheCenterListItemProps {
   data: AvalancheCenterListData;
@@ -32,7 +32,7 @@ const AvalancheCenterListItem: React.FC<AvalancheCenterListItemProps> = ({data, 
         <AvalancheCenterLogo style={{height: 32, width: 32, resizeMode: 'contain', flex: 0, flexGrow: 0, marginTop: 4}} avalancheCenterId={center_id} />
         <VStack space={2} flexShrink={1} flexGrow={1}>
           <BodySemibold>
-            {data.center.name} ({userFacingCenterId(center_id)})
+            {data.center.name} ({data.display_id})
           </BodySemibold>
           <Body>{data.description}</Body>
         </VStack>

--- a/components/modals/AvalancheCenterSelectionModal.tsx
+++ b/components/modals/AvalancheCenterSelectionModal.tsx
@@ -5,7 +5,7 @@ import Topo from 'assets/illustrations/topo.svg';
 import {avalancheCenterList, AvalancheCenters} from 'components/avalancheCenterList';
 import {AvalancheCenterList} from 'components/content/AvalancheCenterList';
 import {Button} from 'components/content/Button';
-import {incompleteQueryState} from 'components/content/QueryState';
+import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {Center, Divider, View, VStack} from 'components/core';
 import {Body, BodyBlack, Title3Black} from 'components/text';
 import {useAllAvalancheCenterMetadata} from 'hooks/useAllAvalancheCenterMetadata';
@@ -40,6 +40,10 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
   }
   const safeAreaInsets = useSafeAreaInsets();
 
+  if (incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities) {
+    return <QueryState results={[capabilitiesResult, ...metadataResults]} />;
+  }
+
   return (
     <Modal transparent visible={visible && !loading} animationType="slide" onRequestClose={closeHandler}>
       <SafeAreaProvider>
@@ -61,7 +65,7 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
                   <Body textAlign="center">You can change this anytime in settings.</Body>
                 </Center>
                 <ScrollView>
-                  <AvalancheCenterList selectedCenter={selectedCenter} setSelectedCenter={setSelectedCenter} data={avalancheCenterList(metadata)} />
+                  <AvalancheCenterList selectedCenter={selectedCenter} setSelectedCenter={setSelectedCenter} data={avalancheCenterList(metadata, capabilities)} />
                 </ScrollView>
               </VStack>
               <Divider />

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -17,6 +17,7 @@ import {GenerateObservationShareLink} from 'components/observations/ObservationU
 import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, bodySize} from 'components/text';
 import {HTML} from 'components/text/HTML';
+import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservation} from 'hooks/useNACObservation';
 import {useNWACObservation} from 'hooks/useNWACObservation';
@@ -27,6 +28,7 @@ import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {
   Activity,
+  AllAvalancheCenterCapabilities,
   AvalancheAspect,
   AvalancheBedSurface,
   AvalancheCause,
@@ -62,12 +64,14 @@ export const NWACObservationDetailView: React.FunctionComponent<{
   const observation = observationResult.data;
   const mapResult = useMapLayer(observation?.center_id);
   const mapLayer = mapResult.data;
+  const capabilitiesResult = useAvalancheCenterCapabilities();
+  const capabilities = capabilitiesResult.data;
 
-  if (incompleteQueryState(observationResult, mapResult) || !observation || !mapLayer) {
-    return <QueryState results={[observationResult, mapResult]} />;
+  if (incompleteQueryState(observationResult, mapResult, capabilitiesResult) || !observation || !mapLayer || !capabilities) {
+    return <QueryState results={[observationResult, mapResult, capabilitiesResult]} />;
   }
 
-  return <ObservationCard observation={observation} mapLayer={mapLayer} />;
+  return <ObservationCard observation={observation} mapLayer={mapLayer} capabilities={capabilities} />;
 };
 
 export const ObservationDetailView: React.FunctionComponent<{
@@ -77,12 +81,14 @@ export const ObservationDetailView: React.FunctionComponent<{
   const observation = observationResult.data;
   const mapResult = useMapLayer(observation?.center_id?.toUpperCase() as AvalancheCenterID);
   const mapLayer = mapResult.data;
+  const capabilitiesResult = useAvalancheCenterCapabilities();
+  const capabilities = capabilitiesResult.data;
 
-  if (incompleteQueryState(observationResult, mapResult) || !observation || !mapLayer) {
-    return <QueryState results={[observationResult, mapResult]} />;
+  if (incompleteQueryState(observationResult, mapResult, capabilitiesResult) || !observation || !mapLayer || !capabilities || !capabilities) {
+    return <QueryState results={[observationResult, mapResult, capabilitiesResult]} />;
   }
 
-  return <ObservationCard observation={observation} mapLayer={mapLayer} />;
+  return <ObservationCard observation={observation} mapLayer={mapLayer} capabilities={capabilities} />;
 };
 
 const dataTableFlex = [1, 1];
@@ -199,7 +205,8 @@ export const withUnits = (value: string | number | null | undefined, units: stri
 export const ObservationCard: React.FunctionComponent<{
   observation: Observation;
   mapLayer: MapLayer;
-}> = ({observation, mapLayer}) => {
+  capabilities: AllAvalancheCenterCapabilities;
+}> = ({observation, mapLayer, capabilities}) => {
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const {avalanches_observed, avalanches_triggered, avalanches_caught} = observation.instability;
   const zone_name = observation.location_point?.lat && observation.location_point?.lng && matchesZone(mapLayer, observation.location_point?.lat, observation.location_point?.lng);
@@ -308,7 +315,7 @@ export const ObservationCard: React.FunctionComponent<{
                       </Marker>
                     </ZoneMap>
                   )}
-                  <TableRow label="Avalanche Center" value={userFacingCenterId(observation.center_id)} />
+                  <TableRow label="Avalanche Center" value={userFacingCenterId(observation.center_id, capabilities)} />
                   {observation.location_name && <TableRow label="Location" value={observation.location_name} />}
                   <TableRow label="Route" value={observation.route || 'Not specified'} />
                   <TableRow label="Activity" value={activityDisplayName(observation.activity)} />

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -27,6 +27,7 @@ import {ObservationAddImageButton, ObservationImagePicker} from 'components/obse
 import {UploaderState, getUploader} from 'components/observations/uploader/ObservationsUploader';
 import {TaskStatus} from 'components/observations/uploader/Task';
 import {Body, BodySemibold, Title3Semibold} from 'components/text';
+import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {usePostHog} from 'posthog-react-native';
@@ -50,6 +51,8 @@ export const ObservationForm: React.FC<{
 }> = ({center_id, onClose}) => {
   const metadataResult = useAvalancheCenterMetadata(center_id);
   const metadata = metadataResult.data;
+  const capabilitiesResult = useAvalancheCenterCapabilities();
+  const capabilities = capabilitiesResult.data;
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const formContext = useForm<ObservationFormData>({
@@ -258,10 +261,10 @@ export const ObservationForm: React.FC<{
     }
   }, []);
 
-  if (incompleteQueryState(metadataResult) || !metadata) {
+  if (incompleteQueryState(metadataResult, capabilitiesResult) || !metadata || !capabilities) {
     return (
       <SafeAreaView edges={['top', 'left', 'right']}>
-        <QueryState results={[metadataResult]} />;
+        <QueryState results={[metadataResult, capabilitiesResult]} />;
       </SafeAreaView>
     );
   }
@@ -284,7 +287,7 @@ export const ObservationForm: React.FC<{
                 ref={scrollViewRef}>
                 <VStack width="100%" justifyContent="flex-start" alignItems="stretch" pt={8} pb={8}>
                   <View px={16} pb={formFieldSpacing}>
-                    <Body>Help keep the {userFacingCenterId(center_id)} community informed by submitting your observation.</Body>
+                    <Body>Help keep the {userFacingCenterId(center_id, capabilities)} community informed by submitting your observation.</Body>
                   </View>
                   <Card borderRadius={0} borderColor="white" header={<Title3Semibold>Privacy</Title3Semibold>}>
                     <VStack space={formFieldSpacing} mt={8}>

--- a/components/observations/ObservationsPortal.tsx
+++ b/components/observations/ObservationsPortal.tsx
@@ -1,8 +1,10 @@
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import Topo from 'assets/illustrations/topo.svg';
 import {Button} from 'components/content/Button';
+import {QueryState, incompleteQueryState} from 'components/content/QueryState';
 import {VStack, View} from 'components/core';
 import {Body, BodyBlack, Title3Black} from 'components/text';
+import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {usePostHog} from 'posthog-react-native';
 import React, {useCallback} from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -29,6 +31,13 @@ export const ObservationsPortal: React.FC<{
   }, [postHog, center_id]);
   useFocusEffect(recordAnalytics);
 
+  const capabilitiesResult = useAvalancheCenterCapabilities();
+  const capabilities = capabilitiesResult.data;
+
+  if (incompleteQueryState(capabilitiesResult) || !capabilities) {
+    return <QueryState results={[capabilitiesResult]} />;
+  }
+
   return (
     <View width="100%" height="100%" bg="#F6F8FC">
       {/* SafeAreaView shouldn't inset from bottom edge because TabNavigator is sitting there */}
@@ -37,7 +46,7 @@ export const ObservationsPortal: React.FC<{
         <Topo width={887.0152587890625} height={456.3430480957031} style={{position: 'absolute', left: -306.15625, bottom: -60}} />
         <VStack height="100%" width="100%" justifyContent="center" alignItems="stretch" space={16} px={32} pb={200}>
           <Title3Black textAlign="center">You haven&apos;t submitted any observations in the App yet</Title3Black>
-          <Body textAlign="center">Help keep the {userFacingCenterId(center_id)} community informed by submitting your observation.</Body>
+          <Body textAlign="center">Help keep the {userFacingCenterId(center_id, capabilities)} community informed by submitting your observation.</Body>
           <Button buttonStyle="primary" onPress={onSubmit}>
             <BodyBlack>Submit an observation</BodyBlack>
           </Button>

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -21,6 +21,7 @@ import {AvalancheCenters} from 'components/avalancheCenterList';
 import {ActionList} from 'components/content/ActionList';
 import {Button} from 'components/content/Button';
 import {Card} from 'components/content/Card';
+import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {FeatureFlagsDebuggerScreen} from 'components/FeatureFlagsDebugger';
 import {ForecastScreen} from 'components/screens/ForecastScreen';
 import {MapScreen} from 'components/screens/MapScreen';
@@ -39,6 +40,7 @@ import {getVersionInfoFull} from 'components/screens/menu/Version';
 import {NWACObservationScreen, ObservationScreen} from 'components/screens/ObservationsScreen';
 import {Body, BodyBlack, Title3Black} from 'components/text';
 import {settingsMenuItems} from 'data/settingsMenuItems';
+import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {LoggerContext, LoggerProps} from 'loggerContext';
@@ -95,6 +97,8 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
   const navigation = useNavigation<MenuStackNavigationProps>();
   const {data} = useAvalancheCenterMetadata(avalancheCenterId);
   const menuItems = settingsMenuItems[avalancheCenterId];
+  const capabilitiesResult = useAvalancheCenterCapabilities();
+  const capabilities = capabilitiesResult.data;
 
   const {
     preferences: {mixpanelUserId},
@@ -120,6 +124,10 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
       [],
     );
 
+    if (incompleteQueryState(capabilitiesResult) || !capabilities) {
+      return <QueryState results={[capabilitiesResult]} />;
+    }
+
     return (
       <View style={{...StyleSheet.absoluteFillObject}} bg="white">
         {/* SafeAreaView shouldn't inset from bottom edge because TabNavigator is sitting there */}
@@ -128,7 +136,7 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
             <VStack width="100%" height="100%" justifyContent="flex-start" alignItems="stretch" bg={colorLookup('primary.background')} space={10}>
               <Card borderRadius={0} borderColor="white" header={<Title3Black>More</Title3Black>} noDivider>
                 <Body>
-                  {data?.name && `${data.name} `}({userFacingCenterId(avalancheCenterId)})
+                  {data?.name && `${data.name} `}({userFacingCenterId(avalancheCenterId, capabilities)})
                 </Body>
               </Card>
               <View py={12} px={32}>

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -23,8 +23,9 @@ export const avalancheCenterIDSchema = z.enum([
 
 export type AvalancheCenterID = z.infer<typeof avalancheCenterIDSchema>;
 
-export function userFacingCenterId(input: AvalancheCenterID): string {
-  return input === 'SNFAC' ? 'SAC' : input;
+export function userFacingCenterId(input: AvalancheCenterID, capabilities: AllAvalancheCenterCapabilities): string {
+  const capability = capabilities.centers.find(center => center.id === input);
+  return capability !== undefined ? capability.display_id : input;
 }
 
 export const AvalancheCenterWebsites: Record<AvalancheCenterID, string> = {
@@ -1442,6 +1443,7 @@ export type AvalancheCenterPlatforms = z.infer<typeof avalancheCenterPlatformsSc
 
 export const avalancheCenterCapabilitiesSchema = z.object({
   id: z.string(),
+  display_id: z.string(),
   platforms: avalancheCenterPlatformsSchema,
 });
 export type AvalancheCenterCapabilities = z.infer<typeof avalancheCenterCapabilitiesSchema>;


### PR DESCRIPTION
We previously hard-coded one display ID instead of reaching out to the source of truth and doing the more robust approach. Now we can handle any display ID for any center, correctly.