### PR TITLE
AvalancheForecast: work around tab library bug for headers

### DIFF
--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -134,6 +134,10 @@ export const AvalancheForecast: React.FunctionComponent<{
 };
 
 const TabLabel: React.FC<{title: string; focused: boolean; color: string}> = ({title, focused, color}) => {
+  // the tab view library has a long-standing bug where they don't re-render tabs during focus,
+  // so we resort to always rendering the focused (larger) text in order to ensure it does not
+  // get cut off, ref:
+  // https://github.com/satya164/react-native-tab-view/issues/992
   return (
     <View>
       {focused ? (
@@ -145,6 +149,11 @@ const TabLabel: React.FC<{title: string; focused: boolean; color: string}> = ({t
           {title}
         </Body>
       )}
+      <View style={{height: 0}}>
+        <BodySemibold color={'transparent'} textAlign={'center'}>
+          {title}
+        </BodySemibold>
+      </View>
     </View>
   );
 };


### PR DESCRIPTION
The react-navigation tab library doesn't seem to correctly re-render the view holding the tab label, so rendering a wider label when focused leads to the text getting cut off. We can always render the larger label in an invibisble way to force the correct behavior.