### PR TITLE
DeveloperMenu: don't use a collapsible card

### DIFF
--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -93,26 +93,25 @@ export const MenuStackScreen = (
 };
 
 export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheCenterID, staging: boolean, setStaging: React.Dispatch<React.SetStateAction<boolean>>) => {
-  const {logger} = React.useContext<LoggerProps>(LoggerContext);
-  const navigation = useNavigation<MenuStackNavigationProps>();
-  const {data} = useAvalancheCenterMetadata(avalancheCenterId);
-  const menuItems = settingsMenuItems[avalancheCenterId];
-  const capabilitiesResult = useAvalancheCenterCapabilities();
-  const capabilities = capabilitiesResult.data;
-
-  const {
-    preferences: {mixpanelUserId},
-  } = usePreferences();
-  const [updateGroupId] = getUpdateGroupId();
-
-  const postHog = usePostHog();
-
-  const recordAnalytics = useCallback(() => {
-    postHog?.screen('menu');
-  }, [postHog]);
-  useFocusEffect(recordAnalytics);
-
   const MenuScreen = function (_: NativeStackScreenProps<MenuStackParamList, 'menu'>) {
+    const {logger} = React.useContext<LoggerProps>(LoggerContext);
+    const navigation = useNavigation<MenuStackNavigationProps>();
+    const {data} = useAvalancheCenterMetadata(avalancheCenterId);
+    const menuItems = settingsMenuItems[avalancheCenterId];
+    const capabilitiesResult = useAvalancheCenterCapabilities();
+    const capabilities = capabilitiesResult.data;
+
+    const {
+      preferences: {mixpanelUserId},
+    } = usePreferences();
+    const [updateGroupId] = getUpdateGroupId();
+
+    const postHog = usePostHog();
+
+    const recordAnalytics = useCallback(() => {
+      postHog?.screen('menu');
+    }, [postHog]);
+    useFocusEffect(recordAnalytics);
     const sendMailHandler = useCallback(
       () =>
         void sendMail({
@@ -121,7 +120,7 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
           footer: `Please do not delete, info below helps with debugging.\n\n ${getVersionInfoFull(mixpanelUserId, updateGroupId)}`,
           logger,
         }),
-      [],
+      [logger, mixpanelUserId, updateGroupId],
     );
 
     if (incompleteQueryState(capabilitiesResult) || !capabilities) {

--- a/components/screens/menu/DeveloperMenu.tsx
+++ b/components/screens/menu/DeveloperMenu.tsx
@@ -25,7 +25,7 @@ import {ClientContext} from 'clientContext';
 import {AvalancheProblemSizeLine} from 'components/AvalancheProblemSizeLine';
 import {ActionList} from 'components/content/ActionList';
 import {Button} from 'components/content/Button';
-import {Card, CollapsibleCard} from 'components/content/Card';
+import {Card} from 'components/content/Card';
 import {ConnectionLost, InternalError, NotFound} from 'components/content/QueryState';
 import {ActionToast, ErrorToast, InfoToast, SuccessToast, WarningToast} from 'components/content/Toast';
 import {getUploader} from 'components/observations/uploader/ObservationsUploader';
@@ -76,15 +76,10 @@ export const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging
 
     logger.info({environment: staging ? 'production' : 'staging'}, 'switching environment');
   }, [staging, setStaging]);
-  const {preferences, setPreferences, clearPreferences} = usePreferences();
+  const {preferences, clearPreferences} = usePreferences();
   const [updateGroupId] = useState(getUpdateGroupId());
   return (
-    <CollapsibleCard
-      identifier={'developerMenu'}
-      startsCollapsed={preferences.developerMenuCollapsed}
-      collapsedStateChanged={collapsed => setPreferences({developerMenuCollapsed: collapsed})}
-      borderColor="white"
-      header={<BodyBlack>Developer Menu</BodyBlack>}>
+    <Card borderColor="white" header={<BodyBlack>Developer Menu</BodyBlack>}>
       <VStack space={4}>
         <Card borderRadius={0} borderColor="white" header={<BodyBlack>Debug Settings</BodyBlack>}>
           <VStack space={12}>
@@ -523,7 +518,7 @@ export const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging
           ]}
         />
       </VStack>
-    </CollapsibleCard>
+    </Card>
   );
 };
 


### PR DESCRIPTION
Something with the Expo SDK 52 bump was causing this particular collapsible to not collapse and un-collapse, and I don't have the time to figure it out right now. Collapsing the Developer Menu is an edge case usability thing that is OK to lose for now.