### PR TITLE
app.json: disable new architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",


### PR DESCRIPTION
The react-native-maps viewer is broken on Android with the new architecture, so we need to revert this for now.

xref https://github.com/react-native-maps/react-native-maps/issues/5236