### PR TITLE
observations: fix form values

### DIFF
--- a/components/form/SelectField.tsx
+++ b/components/form/SelectField.tsx
@@ -20,6 +20,7 @@ interface SelectFieldProps {
   prompt?: string;
   radio?: boolean; // If true, will default to selecting first item and always enforce selection
   disabled?: boolean;
+  invisible?: boolean;
 }
 
 const borderColor = colorLookup('border.base');
@@ -70,7 +71,7 @@ const selectStyles: SelectStyles = {
   },
 };
 
-export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, label, items, prompt, radio, disabled}, ref) => {
+export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, label, items, prompt, radio, disabled, invisible}, ref) => {
   const {setValue} = useFormContext();
   const {field, fieldState} = useController({name});
   const menuItems =
@@ -108,7 +109,7 @@ export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, la
   );
 
   return (
-    <VStack width="100%" space={4} ref={ref}>
+    <VStack width="100%" space={4} ref={ref} style={invisible && {display: 'none'}}>
       <BodySmBlack>{label}</BodySmBlack>
       <Select
         key={JSON.stringify(defaultOption)} // force a re-render when the default changes

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -311,6 +311,18 @@ export const ObservationForm: React.FC<{
                         ]}
                         disabled={disableFormControls}
                       />
+                      <SelectField name="observer_type" label="Observer Type" radio items={[{value: 'public', label: 'Public'}]} disabled={true} invisible={true} />
+                      <SelectField
+                        name="status"
+                        label="Observation status"
+                        radio
+                        items={[
+                          {value: 'draft', label: 'Request review'},
+                          {value: 'published', label: 'Publish immediately'},
+                        ]}
+                        disabled={true}
+                        invisible={true}
+                      />
                     </VStack>
                   </Card>
                   <Card borderRadius={0} borderColor="white" header={<Title3Semibold>General information</Title3Semibold>}>

--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -10,8 +10,8 @@ const FAKE_OBSERVATION_DATA: Partial<ObservationFormData> = {
     lat: 47.6062,
     lng: -122.3321,
   },
-  email: 'brian@nwac.us',
-  name: 'Brian',
+  email: 'developer@nwac.us',
+  name: 'NWAC Developer',
   phone: `(012) 345 - 6789`,
   observation_summary: '[TEST] This is a test observation.',
   location_name: '[TEST] Snoqualmie Pass',
@@ -28,7 +28,6 @@ export const defaultObservationFormData = (initialValues: Partial<ObservationFor
         cracking: false,
         collapsing: false,
       },
-      media: [],
       observer_type: PartnerType.Public,
       photoUsage: MediaUsage.Credit,
       private: false,
@@ -109,12 +108,13 @@ export const simpleObservationFormSchema = z
     location_name: z.string({required_error: required}).max(256, tooLong),
     location_point: locationPointSchema,
     name: z.string({required_error: required}).max(50, tooLong),
-    status: z.literal('draft').or(z.literal('published')),
+    status: z.enum(['draft', 'published']),
     phone: z
       .string()
       .regex(/\(\d{3}\) \d{3} - \d{4}/, "That doesn't look like a phone number.")
       .optional(),
     show_name: z.boolean().optional(),
+    observer_type: z.literal(PartnerType.Public),
     observation_summary: z.string({required_error: required}).max(1024, tooLong),
     photoUsage: z.nativeEnum(MediaUsage, {required_error: required}),
     private: z.boolean(),

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -494,6 +494,7 @@ const fakeObservation: {apiPrefix: string; center_id: AvalancheCenterID; observa
     status: 'published',
     name: 'Brian',
     phone: '(012) 345 - 6789',
+    observer_type: 'public',
     observation_summary: 'This is a test observation.',
     photoUsage: MediaUsage.Credit,
     private: false,


### PR DESCRIPTION
It looks like bumping the react-hook-form library changed the semantics of data in default values for a form that was never bound to a controller. In the past, this data remained in the values of the form, but now it does not. We were failing to validate the observation state before submitting it as we were losing the `status` field. Binding invisible and unchanging values to controllers that are disabled and not shown to the user is a simple if inelegant workaround.

Fixes https://github.com/NWACus/avy/issues/844