### PR TITLE
Fix collapsible card on initial render

### DIFF
--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -63,24 +63,14 @@ export interface CollapsibleCardProps extends CardProps {
   identifier: string;
   noDivider?: boolean;
   startsCollapsed: boolean;
-  collapsedStateChanged?: (collapsed: boolean) => void;
 }
 
-export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<CollapsibleCardProps>> = ({
-  identifier,
-  startsCollapsed,
-  collapsedStateChanged,
-  header,
-  children,
-  noDivider,
-  ...props
-}) => {
+export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<CollapsibleCardProps>> = ({identifier, startsCollapsed, header, children, noDivider, ...props}) => {
   const [isCollapsed, setIsCollapsed] = useState(startsCollapsed);
   const textColor = colorLookup('text');
   const pressHandler = useCallback(() => {
     setIsCollapsed(!isCollapsed);
-    collapsedStateChanged?.(!isCollapsed);
-  }, [isCollapsed, collapsedStateChanged]);
+  }, [isCollapsed]);
   const postHog = usePostHog();
   useEffect(() => {
     postHog?.capture('card', {identifier: identifier, isCollapsed: isCollapsed});

--- a/patches/react-native-collapsible+1.6.2.patch
+++ b/patches/react-native-collapsible+1.6.2.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-collapsible/Collapsible.js b/node_modules/react-native-collapsible/Collapsible.js
+index dc4d3b8..d878252 100644
+--- a/node_modules/react-native-collapsible/Collapsible.js
++++ b/node_modules/react-native-collapsible/Collapsible.js
+@@ -51,6 +51,12 @@ export default class Collapsible extends Component {
+     }
+   }
+ 
++  componentDidMount() {
++    if (!this.props.collapsed) {
++      this._measureContent((height) => height != null && this.state.height.setValue(height));
++    }
++  }
++
+   contentHandle = null;
+ 
+   _handleRef = (ref) => {


### PR DESCRIPTION
components/content/Card: remove collapsed handler

We don't have any users for this feature, so we should not keep it in
the codebase.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

patches: patch react-native-collapsible

The current version of this library is broken on initial render.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

Fixes #https://github.com/NWACus/avy/issues/841

RCA https://github.com/oblador/react-native-collapsible/issues/479