### PR TITLE
types: add a 'certain' likelihood

### DIFF
--- a/components/AvalancheProblemLikelihoodLine.tsx
+++ b/components/AvalancheProblemLikelihoodLine.tsx
@@ -18,6 +18,7 @@ export const likelihoodText = (input: AvalancheProblemLikelihood): string => {
 const likelihoodToRange = (likelihood: AvalancheProblemLikelihood): SeverityNumberLineRange => {
   const index =
     {
+      [AvalancheProblemLikelihood.Certain]: 0,
       [AvalancheProblemLikelihood.AlmostCertain]: 0,
       [AvalancheProblemLikelihood.VeryLikely]: 1,
       [AvalancheProblemLikelihood.Likely]: 2,
@@ -31,7 +32,7 @@ export const AvalancheProblemLikelihoodLine: React.FunctionComponent<AvalanchePr
   return (
     <SeverityNumberLine
       labels={[
-        likelihoodText(AvalancheProblemLikelihood.AlmostCertain),
+        likelihoodText(AvalancheProblemLikelihood.Certain),
         likelihoodText(AvalancheProblemLikelihood.VeryLikely),
         likelihoodText(AvalancheProblemLikelihood.Likely),
         likelihoodText(AvalancheProblemLikelihood.Possible),

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -106,6 +106,7 @@ export enum AvalancheProblemLikelihood {
   Likely = 'likely',
   VeryLikely = 'very likely',
   AlmostCertain = 'almost certain',
+  Certain = 'certain',
 }
 
 export enum AvalancheProblemLocation {


### PR DESCRIPTION
Avalanche problems may now be rated 'certain', and we would like to display that terminology on the number line.