### PR TITLE
components: handle expired forecasts more correctly

### DIFF
--- a/components/AvalancheDangerTriangle.tsx
+++ b/components/AvalancheDangerTriangle.tsx
@@ -21,8 +21,9 @@ export const colorFor = (danger: DangerLevel | null | undefined): Color => {
       return Color('rgb(255, 242, 0)');
     case DangerLevel.Low:
       return Color('rgb(80, 184, 72)');
-    case DangerLevel.None:
     case DangerLevel.GeneralInformation:
+      return Color('rgb(110, 164, 219)');
+    case DangerLevel.None:
     default:
       return Color('rgb(147, 149, 152)');
   }


### PR DESCRIPTION
We were not showing the correct light-blue color for zones with information but no active forecast, nor were we capturing expired forecasts correctly on the map layer.

Map layer shows light blue for current information:
| Before | After |
| - | - |
| ![File (59)](https://github.com/user-attachments/assets/959e4ed9-1cea-44cf-87a4-cde0db2cdeb5) | ![File (52)](https://github.com/user-attachments/assets/5fe4ec3c-f6d9-4cd3-b28d-b496d23bb5ab) |

Map layer shows grey for expired forecasts instead of their previous danger:
| Before | After |
| - | - |
| ![File (56)](https://github.com/user-attachments/assets/0c6a31b4-60d8-452f-8464-7dbfda02a90a) | ![File (53)](https://github.com/user-attachments/assets/59bcabde-51f7-49eb-a643-de3ac6853c36) |

Card hides expired danger rating, travel advice, and publication/expiry times for expired forecasts:
| Before | After |
| - | - |
| ![File (57)](https://github.com/user-attachments/assets/eeb81cb2-960c-4a00-b0a5-274d4d9a1673) | ![File (55)](https://github.com/user-attachments/assets/595d093e-bb44-4341-8d7d-93ac4664529e) |

Card still shows information for currently valid informative posts:
| Before | After |
| - | - |
| ![File (58)](https://github.com/user-attachments/assets/d7ad01d8-5fd2-4275-bdbb-f4110fa779ab) | ![File (54)](https://github.com/user-attachments/assets/95612b47-cb36-4ee3-9e5b-f4d243bf0610) |



