### PR TITLE
components/map: use GeoJSON map marker

### DIFF
--- a/components/content/ZoneMap.tsx
+++ b/components/content/ZoneMap.tsx
@@ -16,7 +16,7 @@ const defaultAvalancheCenterMapRegionBounds: RegionBounds = {
 export const mapViewZoneFor = (center: AvalancheCenterID, feature: MapLayerFeature): MapViewZone => {
   return {
     zone_id: feature.id,
-    geometry: feature.geometry,
+    feature: feature,
     hasWarning: feature.properties.warning.product !== null,
     center_id: center,
     name: feature.properties.name,
@@ -34,7 +34,7 @@ export type MapViewZone = {
   danger_level?: DangerLevel;
   start_date: string | null;
   end_date: string | null;
-  geometry?: Geometry;
+  feature: MapLayerFeature;
   fillOpacity: number;
   hasWarning: boolean;
 };
@@ -66,7 +66,7 @@ export const ZoneMap = React.forwardRef<MapView, ZoneMapProps>(({animated, zones
 ZoneMap.displayName = 'ZoneMap';
 
 export function defaultMapRegionForZones(zones: MapViewZone[]) {
-  return defaultMapRegionForGeometries(zones.map(zone => zone.geometry));
+  return defaultMapRegionForGeometries(zones.map(zone => zone.feature.geometry));
 }
 
 export function defaultMapRegionForGeometries(geometries: (Geometry | undefined)[] | undefined) {

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -22,7 +22,10 @@ interface LocationFieldProps {
 }
 
 const latLngToLocationPoint = (latLng: LatLng) => ({lat: latLng.latitude, lng: latLng.longitude});
-const locationPointToLatLng = (locationPoint: LocationPoint) => ({latitude: locationPoint.lat, longitude: locationPoint.lng});
+const locationPointToLatLng = (locationPoint: LocationPoint) => ({
+  latitude: locationPoint.lat,
+  longitude: locationPoint.lng,
+});
 
 export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name, label, center, disabled}, ref) => {
   const {
@@ -82,16 +85,18 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
   }, [mapLayer, setInitialRegion, value, mapReady, setMapReady]);
 
   const zones: MapViewZone[] =
-    mapLayer?.features.map(feature => ({
-      zone_id: feature.id,
-      name: feature.properties.name,
-      center_id: center,
-      geometry: feature.geometry,
-      hasWarning: feature.properties.warning?.product !== null,
-      start_date: feature.properties.start_date,
-      end_date: feature.properties.end_date,
-      fillOpacity: feature.properties.fillOpacity,
-    })) ?? [];
+    mapLayer?.features.map(
+      (feature): MapViewZone => ({
+        zone_id: feature.id,
+        name: feature.properties.name,
+        center_id: center,
+        feature: feature,
+        hasWarning: feature.properties.warning?.product !== null,
+        start_date: feature.properties.start_date,
+        end_date: feature.properties.end_date,
+        fillOpacity: feature.properties.fillOpacity,
+      }),
+    ) ?? [];
 
   const emptyHandler = useCallback(() => undefined, []);
 


### PR DESCRIPTION
Originally it must not have been clear that we could just shove the Feature for a zone into the GeoJSON marker and support all the varied types of geometries.

Fixes https://github.com/NWACus/avy/issues/141