### PR TITLE
components/map: use many Polygons over Geojson

### DIFF
--- a/components/content/ZoneMap.tsx
+++ b/components/content/ZoneMap.tsx
@@ -71,7 +71,7 @@ export function defaultMapRegionForZones(zones: MapViewZone[]) {
 
 export function defaultMapRegionForGeometries(geometries: (Geometry | undefined)[] | undefined) {
   const avalancheCenterMapRegionBounds: RegionBounds = geometries
-    ? geometries.reduce((accumulator, currentValue) => updateBoundsToContain(accumulator, toLatLngList(currentValue)), defaultAvalancheCenterMapRegionBounds)
+    ? geometries.reduce((accumulator, currentValue) => updateBoundsToContain(accumulator, toLatLngList(currentValue).flat()), defaultAvalancheCenterMapRegionBounds)
     : defaultAvalancheCenterMapRegionBounds;
   const avalancheCenterMapRegion: Region = regionFromBounds(avalancheCenterMapRegionBounds);
   // give the polygons a little buffer in the region so we don't render them at the outskirts of the screen


### PR DESCRIPTION
For whatver reason the `onPress` events on iOS are all sorts of messed up when we use `Geojson` markers, the events do not get a `coordinates` object passed in, which we need.