### PR TITLE
*: only send PostHog data when we have it

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -50,9 +50,11 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('avalancheForecastMap', {
-      center: center,
-    });
+    if (postHog && center) {
+      postHog.screen('avalancheForecastMap', {
+        center: center,
+      });
+    }
   }, [postHog, center]);
   useFocusEffect(recordAnalytics);
 

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -114,8 +114,8 @@ export const AvalancheTab: React.FunctionComponent<{
   );
 
   const recordAnalytics = useCallback(() => {
-    if (zoneName) {
-      postHog?.screen('avalancheForecastTab', {
+    if (postHog && center_id && zoneName) {
+      postHog.screen('avalancheForecastTab', {
         center: center_id,
         zone: zoneName,
       });

--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -143,10 +143,12 @@ export const NACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, reque
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('weatherForecastTab', {
-      center: center_id,
-      zone: zone.name,
-    });
+    if (postHog && center_id && zone.name) {
+      postHog.screen('weatherForecastTab', {
+        center: center_id,
+        zone: zone.name,
+      });
+    }
   }, [postHog, center_id, zone.name]);
   useFocusEffect(recordAnalytics);
 
@@ -528,7 +530,10 @@ const InlineWeatherForecast: React.FunctionComponent<{forecast: InlineWeatherDat
   return <ForecastPeriod periods={periods} />;
 };
 
-const RowColumnWeatherForecast: React.FunctionComponent<{forecast: RowColumnWeatherData; center_id: AvalancheCenterID}> = ({forecast, center_id}) => {
+const RowColumnWeatherForecast: React.FunctionComponent<{
+  forecast: RowColumnWeatherData;
+  center_id: AvalancheCenterID;
+}> = ({forecast, center_id}) => {
   if (center_id === 'BTAC') {
     return <BTACWeatherForecast forecast={forecast} />;
   }

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -219,10 +219,12 @@ export const ObservationCard: React.FunctionComponent<{
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('observation', {
-      center: observation.center_id,
-      id: observation.id,
-    });
+    if (postHog && observation.center_id && observation.id) {
+      postHog.screen('observation', {
+        center: observation.center_id,
+        id: observation.id,
+      });
+    }
   }, [postHog, observation.center_id, observation.id]);
   useFocusEffect(recordAnalytics);
 

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -68,9 +68,11 @@ export const ObservationForm: React.FC<{
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('observationForm', {
-      center: center_id,
-    });
+    if (postHog && center_id) {
+      postHog.screen('observationForm', {
+        center: center_id,
+      });
+    }
   }, [postHog, center_id]);
   useFocusEffect(recordAnalytics);
 
@@ -121,7 +123,11 @@ export const ObservationForm: React.FC<{
   const mutation = useMutation<void, AxiosError, ObservationFormData>({
     mutationFn: async (observationFormData: ObservationFormData) => {
       logger.info({formValues: observationFormData}, 'submitting observation');
-      const observationId = await getUploader().submitObservation({center_id, apiPrefix: nationalAvalancheCenterHost, observationFormData});
+      const observationId = await getUploader().submitObservation({
+        center_id,
+        apiPrefix: nationalAvalancheCenterHost,
+        observationFormData,
+      });
       const promise: Promise<void> = new Promise((resolve, reject) => {
         let lastObsStatus: TaskStatus | null = null;
         const listener = (uploaderState: UploaderState) => {

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -59,6 +59,7 @@ interface ObservationFragmentWithPageIndex extends ObservationFragment {
 }
 
 type SourceType = 'nac' | 'nwac';
+
 interface ObservationFragmentWithPageIndexAndZoneAndSource extends ObservationFragmentWithPageIndex {
   zone: string;
   source: SourceType;
@@ -76,10 +77,12 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('observations', {
-      center: center_id,
-      zone: additionalFilters && additionalFilters.zones && additionalFilters.zones.length > 0 ? additionalFilters.zones[0] : 'global',
-    });
+    if (postHog && center_id) {
+      postHog.screen('observations', {
+        center: center_id,
+        zone: additionalFilters && additionalFilters.zones && additionalFilters.zones.length > 0 ? additionalFilters.zones[0] : 'global',
+      });
+    }
   }, [postHog, additionalFilters, center_id]);
   useFocusEffect(recordAnalytics);
 
@@ -103,7 +106,13 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const observationsResult = displayNWACObservations ? nwacObservationsResult : nacObservationsResult;
 
   const flatObservationList: ObservationFragmentWithPageIndex[] = useMemo(
-    () => (observationsResult.data?.pages ?? []).flatMap((page, index) => page.data.map(o => ({...o, pageIndex: index}))),
+    () =>
+      (observationsResult.data?.pages ?? []).flatMap((page, index) =>
+        page.data.map(o => ({
+          ...o,
+          pageIndex: index,
+        })),
+      ),
     [observationsResult],
   );
   const observations: ObservationFragmentWithPageIndexAndZoneAndSource[] = useMemo(
@@ -405,7 +414,10 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
 };
 
 const colorsFor = (partnerType: PartnerType) => {
-  return {primary: colorLookup(`observer.${partnerType}.primary`).toString(), secondary: colorLookup(`observer.${partnerType}.secondary`).toString()};
+  return {
+    primary: colorLookup(`observer.${partnerType}.primary`).toString(),
+    secondary: colorLookup(`observer.${partnerType}.secondary`).toString(),
+  };
 };
 
 export interface FilterPillButtonProps {
@@ -416,6 +428,7 @@ export interface FilterPillButtonProps {
   textColor: ColorValue;
   backgroundColor: ColorValue;
 }
+
 export const FilterPillButton: React.FC<FilterPillButtonProps> = ({label, headIcon, tailIcon, onPress, textColor, backgroundColor}) => (
   <TouchableOpacity onPress={onPress}>
     <HStack

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -30,6 +30,7 @@ interface columnData {
   variable: Variable;
   data: (number | string | null)[];
 }
+
 export const WeatherStationDetail: React.FC<Props> = ({center_id, stationId, source, requestedTime}) => {
   const [days, setDays] = useState(1);
   const avalancheCenterMetadataResult = useAvalancheCenterMetadata(center_id);
@@ -42,10 +43,12 @@ export const WeatherStationDetail: React.FC<Props> = ({center_id, stationId, sou
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('weatherStation', {
-      center: center_id,
-      stationId: stationId,
-    });
+    if (postHog && center_id && stationId) {
+      postHog.screen('weatherStation', {
+        center: center_id,
+        stationId: stationId,
+      });
+    }
   }, [postHog, center_id, stationId]);
   useFocusEffect(recordAnalytics);
 

--- a/components/weather_data/WeatherStationList.tsx
+++ b/components/weather_data/WeatherStationList.tsx
@@ -34,9 +34,11 @@ export const WeatherStationList: React.FunctionComponent<{
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('weatherStations', {
-      center: center_id,
-    });
+    if (postHog && center_id) {
+      postHog.screen('weatherStations', {
+        center: center_id,
+      });
+    }
   }, [postHog, center_id]);
   useFocusEffect(recordAnalytics);
 

--- a/components/weather_data/WeatherStationMap.tsx
+++ b/components/weather_data/WeatherStationMap.tsx
@@ -80,9 +80,11 @@ export const WeatherStationMap: React.FunctionComponent<{
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('weatherStationsMap', {
-      center: center_id,
-    });
+    if (postHog && center_id) {
+      postHog.screen('weatherStationsMap', {
+        center: center_id,
+      });
+    }
   }, [postHog, center_id]);
   useFocusEffect(recordAnalytics);
 

--- a/components/weather_data/WeatherStationPage.tsx
+++ b/components/weather_data/WeatherStationPage.tsx
@@ -24,9 +24,11 @@ export const WeatherStationPage: React.FC<Props> = ({center_id, requestedTime}) 
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('weatherTab', {
-      center: center_id,
-    });
+    if (postHog && center_id) {
+      postHog.screen('weatherTab', {
+        center: center_id,
+      });
+    }
   }, [postHog, center_id]);
   useFocusEffect(recordAnalytics);
 

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -83,7 +83,11 @@ const shortUnitsMap: Record<string, string> = {
 const shortUnits = (units: string): string => shortUnitsMap[units] || units;
 
 const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({timeSeries}) => {
-  type Column = {elevation: number | undefined | null; field: string; dataByTime: Record<string, number | string | null>};
+  type Column = {
+    elevation: number | undefined | null;
+    field: string;
+    dataByTime: Record<string, number | string | null>;
+  };
   const tableColumns: Column[] = useMemo(() => {
     const columns: Column[] = [];
     for (const station of timeSeries.STATION) {
@@ -269,10 +273,13 @@ export const WeatherStationsDetail: React.FC<Props> = ({center_id, name, station
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
-    postHog?.screen('weatherStations', {
-      center: center_id,
-    });
-  }, [postHog, center_id]);
+    if (postHog && center_id && name) {
+      postHog.screen('weatherStations', {
+        center: center_id,
+        name: name,
+      });
+    }
+  }, [postHog, center_id, name]);
   useFocusEffect(recordAnalytics);
 
   React.useEffect(() => {


### PR DESCRIPTION
We have lots of events with `""` as the center ID, which leads me to believe that there are component renders where we somehow don't have props or something? Wild.