### PR TITLE
data: make key type center ID

### DIFF
--- a/data/settingsMenuItems.ts
+++ b/data/settingsMenuItems.ts
@@ -1,4 +1,6 @@
-export const settingsMenuItems: Record<string, {title: string; url: string}[]> = {
+import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
+
+export const settingsMenuItems: Record<AvalancheCenterID, {title: string; url: string}[]> = {
   NWAC: [
     {
       title: 'About NWAC',
@@ -97,7 +99,7 @@ export const settingsMenuItems: Record<string, {title: string; url: string}[]> =
       url: 'https://www.sierraavalanchecenter.org/events',
     },
   ],
-  COAC: [
+  COAA: [
     {
       title: 'About COAC',
       url: 'https://www.coavalanche.org/about/',
@@ -111,4 +113,17 @@ export const settingsMenuItems: Record<string, {title: string; url: string}[]> =
       url: 'https://www.coavalanche.org/events/',
     },
   ],
+  BAC: [],
+  CNFAIC: [],
+  ESAC: [],
+  FAC: [],
+  HPAC: [],
+  IPAC: [],
+  KPAC: [],
+  MSAC: [],
+  MWAC: [],
+  PAC: [],
+  TAC: [],
+  WAC: [],
+  WCMAC: [],
 };


### PR DESCRIPTION
I made a mistake with COAC (display name), not COAA (id) in the last commit. No reason for this `Record` to have `string` as the key, and while making every entry explicit is annoying, at least it isn't incorrect!