### PR TITLE
App.tsx: tune PostHog auto-capture

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -535,7 +535,13 @@ const BaseApp: React.FunctionComponent<{
       <HTMLRendererConfig>
         <SafeAreaProvider>
           <NavigationContainer linking={linking} ref={navigationRef} onReady={trackNavigationChange} onStateChange={trackNavigationChange}>
-            <PostHogProvider client={postHog}>
+            <PostHogProvider
+              client={postHog}
+              autocapture={{
+                captureScreens: false, // we need to translate screen parameters to human-readable info, which requires HTTP request data, so we can't use the built-in screen capture with route property mapping feature
+                captureTouches: true,
+                captureLifecycleEvents: true,
+              }}>
               <FeatureFlagsProvider>
                 <KillSwitchMonitor>
                   <SelectProvider>


### PR DESCRIPTION
The PostHog documentation states that auto-capture should be off-by-default and entirely opt-in, but the behavior we're seeing is that it seems to be on for us even though we do not turn it on. We do *not* want their automated screen captures, so this commit tries to make that explicit.