### PR TITLE
App.tsx: stop tracking touches in PostHog

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -539,7 +539,6 @@ const BaseApp: React.FunctionComponent<{
               client={postHog}
               autocapture={{
                 captureScreens: false, // we need to translate screen parameters to human-readable info, which requires HTTP request data, so we can't use the built-in screen capture with route property mapping feature
-                captureTouches: true,
                 captureLifecycleEvents: true,
               }}>
               <FeatureFlagsProvider>


### PR DESCRIPTION
These are cool in theory but will generate a large volume of useless events unless we have something specific we are trying to do with them.