### PR TITLE
Fix Modal Back Gestures

### DIFF
--- a/components/content/Dropdown.tsx
+++ b/components/content/Dropdown.tsx
@@ -57,7 +57,7 @@ export const Dropdown: React.FC<DropdownProps> = ({items, selectedItem, onSelect
           </HStack>
         </View>
       </TouchableOpacity>
-      <Modal visible={dropdownVisible} transparent animationType="none">
+      <Modal visible={dropdownVisible} transparent animationType="none" onRequestClose={hideDropdown}>
         <TouchableWithoutFeedback disabled={!dropdownVisible} onPress={hideDropdown}>
           <View style={{...StyleSheet.absoluteFillObject}}>
             <VStack

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -70,7 +70,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const endDate = requestedTimeToUTCDate(requestedTime);
   const originalFilterConfig: ObservationFilterConfig = useMemo(() => createDefaultFilterConfig(additionalFilters), [additionalFilters]);
   const [filterConfig, setFilterConfig] = useState<ObservationFilterConfig>(originalFilterConfig);
-  const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal}] = useToggle(false);
+  const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal, off: hideFilterModal}] = useToggle(false);
   const mapResult = useMapLayer(center_id);
   const mapLayer = mapResult.data;
 
@@ -311,7 +311,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
 
   return (
     <VStack width="100%" height="100%" space={0}>
-      <Modal visible={filterModalVisible}>
+      <Modal visible={filterModalVisible} onRequestClose={hideFilterModal}>
         <ObservationsFilterForm
           requestedTime={requestedTime}
           mapLayer={mapLayer}

--- a/components/weather_data/WeatherStationList.tsx
+++ b/components/weather_data/WeatherStationList.tsx
@@ -30,7 +30,7 @@ export const WeatherStationList: React.FunctionComponent<{
   const parsedTime = parseRequestedTimeString(requestedTime);
   const currentTime = requestedTimeToUTCDate(parsedTime);
   const [filterConfig, setFilterConfig] = React.useState<WeatherStationFilterConfig>({...initialFilterConfig});
-  const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal}] = useToggle(false);
+  const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal, off: hideFilterModal}] = useToggle(false);
   const postHog = usePostHog();
 
   const recordAnalytics = useCallback(() => {
@@ -86,7 +86,7 @@ export const WeatherStationList: React.FunctionComponent<{
   return (
     <>
       <VStack width="100%" height="100%" space={0}>
-        <Modal visible={filterModalVisible}>
+        <Modal visible={filterModalVisible} onRequestClose={hideFilterModal}>
           <WeatherStationFilterForm
             mapLayer={mapLayer}
             initialFilterConfig={{...initialFilterConfig}}


### PR DESCRIPTION
### Description

Adds `onRequestClose` handlers to modals where it is missing

Closes #640


### Testing Steps
1. Open the Observations list and open the filter modal. You should be able to exit back to the list by swiping from the right edge of the screen
2. Open any forecast page and open the forecast zone dropdown. You should be able to close the dropdown by swiping from the right edge of the screen

