### PR TITLE
Observation Map Controls

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -298,8 +298,8 @@ export const ObservationCard: React.FunctionComponent<{
                       onPressPolygon={emptyHandler}
                       pitchEnabled={false}
                       rotateEnabled={false}
-                      scrollEnabled={false}
-                      zoomEnabled={false}
+                      scrollEnabled={true}
+                      zoomEnabled={true}
                       initialRegion={{
                         latitude: observation.location_point.lat,
                         longitude: observation.location_point.lng,


### PR DESCRIPTION
### Description

Enable scroll and zoom on observation maps

Closes #893

### Testing Steps
1. Open any observation. You should be able to move around in the map as well as pinch to zoom in/out

