### PR TITLE
FeatureFlags: wait for registration before fetching flags

### DIFF
--- a/FeatureFlags.tsx
+++ b/FeatureFlags.tsx
@@ -45,7 +45,10 @@ interface FeatureFlagsProviderProps {
 
 const tryReloadFeatureFlags = (posthog: PostHog) => {
   logger.debug('fetching feature flags');
-  void posthog.reloadFeatureFlagsAsync();
+  void (async () => {
+    const featureFlags = await posthog.reloadFeatureFlagsAsync();
+    logger.debug(`reloaded feature flags: ${JSON.stringify(featureFlags)}`);
+  })();
 };
 
 // In release and preview mode, When returning to foreground, don't fetch feature flags more frequently than every 30 minutes
@@ -55,8 +58,9 @@ const tryReloadFeatureFlagsWithDebounce = _.debounce(tryReloadFeatureFlags, FEAT
 
 export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({children}) => {
   const postHog = usePostHog();
+  const [registered, setRegistered] = React.useState(false);
   useEffect(() => {
-    if (postHog) {
+    if (postHog && !registered) {
       postHog.register({
         // Posthog automatically captures `Application.nativeBuildVersion` as `App Build`, but stores it as a string.
         // We additionally capture it as a number here, so that we can use < and > in feature flag rules.
@@ -65,37 +69,39 @@ export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({child
         updateBuildTime: process.env.EXPO_PUBLIC_GIT_REVISION as string,
         channel: Updates.channel || 'development',
       });
+      logger.debug('registered user');
+      setRegistered(true);
     }
-  }, [postHog]);
+  }, [postHog, registered, setRegistered]);
   // We use the mixpanel user id (a unique UUID generated for each install of the app) as the posthog distinct id as well.
   const {
     preferences: {mixpanelUserId: distinctUserId},
   } = usePreferences();
   const [userIdentified, setUserIdentified] = useState(false);
   useEffect(() => {
-    if (postHog && distinctUserId && !userIdentified) {
+    if (postHog && distinctUserId && !userIdentified && registered) {
       postHog.identify(distinctUserId);
       setUserIdentified(true);
       logger.debug('identified user, reloading feature flags', {distinctUserId});
       tryReloadFeatureFlagsWithDebounce(postHog);
     }
-  }, [postHog, distinctUserId, userIdentified]);
+  }, [postHog, distinctUserId, userIdentified, registered]);
 
   const appState = useAppState();
   useEffect(() => {
-    if (postHog && appState === 'active') {
+    if (postHog && appState === 'active' && registered && userIdentified) {
       logger.debug('appState changed to active, reloading feature flags');
       tryReloadFeatureFlagsWithDebounce(postHog);
     }
-  }, [appState, postHog]);
+  }, [appState, postHog, registered, userIdentified]);
 
   const netInfo = useNetInfo();
   useEffect(() => {
-    if (postHog && netInfo.isConnected && netInfo.isInternetReachable) {
+    if (postHog && netInfo.isConnected && netInfo.isInternetReachable && registered && userIdentified) {
       logger.debug('network online, reloading feature flags');
       tryReloadFeatureFlagsWithDebounce(postHog);
     }
-  }, [netInfo, postHog]);
+  }, [netInfo, postHog, registered, userIdentified]);
 
   // TODO: why does TS thing useFeatureFlags() returns an any? it has a concrete return type ...
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
We don't want to race between registration and feature flag resolution, as information from registration is necessary for resolving the flags.