### PR TITLE
App: bootstrap feature flags.

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -268,6 +268,12 @@ let postHog: PostHog | undefined = undefined;
 const postHogAsync: Promise<PostHog | undefined> = process.env.EXPO_PUBLIC_POSTHOG_API_KEY
   ? PostHog.initAsync(process.env.EXPO_PUBLIC_POSTHOG_API_KEY as string, {
       host: 'https://app.posthog.com',
+      bootstrap: {
+        featureFlags: {
+          'down-for-maintenance': false,
+          'update-required': false,
+        },
+      },
     })
   : new Promise<undefined>(resolve => {
       resolve(undefined);


### PR DESCRIPTION
It may not always be quick or even possible to load feature flags at startup time. To ensure the most important flags are present, we can pre-compute them and use the values to bootstrap the client.