### PR TITLE
App.tsx: don't send Sentry events in dev unless configured

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -178,6 +178,7 @@ if (Sentry?.init) {
       // Example: 1.0.0.54
       dist: `${Application.nativeApplicationVersion || '0.0.0'}.${Application.nativeBuildVersion || '0'}`,
       release: process.env.EXPO_PUBLIC_GIT_REVISION as string,
+      enabled: !!Updates.channel || Boolean(process.env.EXPO_PUBLIC_SENTRY_IN_DEV),
       enableWatchdogTerminationTracking: true,
       integrations: [routingInstrumentation],
       beforeSend: async (event, hint) => {


### PR DESCRIPTION
We regressed this functionality in d0bf3a11981e4120a9f9753dfc2af611c6a9745f. Following the migration guide to update:

https://docs.sentry.io/platforms/react-native/migration/sentry-expo/#review-sentryinit-options