### PR TITLE
Fix Typescript Errors

### DIFF
--- a/components/AvalancheCenterLogo.tsx
+++ b/components/AvalancheCenterLogo.tsx
@@ -37,7 +37,7 @@ export const AvalancheCenterLogo: React.FunctionComponent<AvalancheCenterLogoPro
 
   const {data: uri} = useCachedImageURI(source[avalancheCenterId].uri);
   if (!uri) {
-    return <ActivityIndicator style={style} />;
+    return <ActivityIndicator />;
   }
 
   const images: Record<AvalancheCenterID, {(s: ImageStyle): ReactElement}> = {

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -168,11 +168,11 @@ export class ObservationUploader {
 
       // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in,
       // but returns string otherwise. hence the use of `as string`.
-      const observationTaskId = uuid.v4();
+      const observationTaskId = uuid.v4() as string;
 
       observationFormData.images?.forEach(({image, caption}) => {
         tasks.push({
-          id: uuid.v4(),
+          id: uuid.v4() as string,
           parentId: observationTaskId,
           attemptCount: 0,
           type: 'image',


### PR DESCRIPTION
This PR fixes Typescript errors that resulted in a build error in #936 

What's weird about these errors is that Typescript check in the CI has only failed in the above PR, but these changes have been in the codebase for months/years now. What's even weirder is that when I run the Typescript compiler script locally on `main` it fails, but in Github it's passing. We're going to investigate why the compiler is unreliable on Github.