### PR TITLE
Add gesture Support to ImageView.tsx

### DIFF
--- a/components/content/carousel/carouselV2/MediaCarousel.tsx
+++ b/components/content/carousel/carouselV2/MediaCarousel.tsx
@@ -11,7 +11,7 @@ export interface MediaCarouselProps extends ViewProps {
   displayCaptions?: boolean;
 }
 
-export const MediaCoursel: React.FunctionComponent<PropsWithChildren<MediaCarouselProps>> = ({
+export const MediaCarousel: React.FunctionComponent<PropsWithChildren<MediaCarouselProps>> = ({
   thumbnailHeight,
   thumbnailAspectRatio = 1.3,
   mediaItems,

--- a/components/content/carousel/carouselV2/MediaViewerModal/ImageView.tsx
+++ b/components/content/carousel/carouselV2/MediaViewerModal/ImageView.tsx
@@ -1,15 +1,113 @@
 import {View} from 'components/core';
 import {Image, useImage} from 'expo-image';
-import React from 'react';
+import React, {useState} from 'react';
 import {ActivityIndicator} from 'react-native';
+import {
+  Gesture,
+  GestureDetector,
+  GestureStateChangeEvent,
+  GestureUpdateEvent,
+  NativeGesture,
+  PanGestureHandlerEventPayload,
+  PinchGestureHandlerEventPayload,
+} from 'react-native-gesture-handler';
+import Animated, {runOnJS, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import {ImageMediaItem} from 'types/nationalAvalancheCenter';
 
 interface ImageViewProps {
   item: ImageMediaItem;
+  nativeGesture: NativeGesture | null;
+  fullScreenWidth: number | null;
 }
 
-export const ImageView: React.FunctionComponent<ImageViewProps> = ({item}: ImageViewProps) => {
+const MAX_SCALE = 8.0;
+const MIN_SCALE = 1.0;
+const DOUBLE_TAP_SCALE = 1.5;
+const RESET_TRANSLATION_VALUE = 0.0;
+
+export const ImageView: React.FunctionComponent<ImageViewProps> = ({item, nativeGesture, fullScreenWidth}) => {
   const image = useImage(item.url.original);
+
+  const scale = useSharedValue(1);
+  const startScale = useSharedValue(0);
+
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const prevTranslateX = useSharedValue(0);
+  const prevTranslateY = useSharedValue(0);
+
+  const [panEnabled, setPanEnabled] = useState(false);
+
+  const setPanOnJS = (value: boolean) => {
+    setPanEnabled(value);
+  };
+
+  const pinchGesture = Gesture.Pinch()
+    .onStart(() => {
+      startScale.value = scale.value;
+    })
+    .onUpdate((event: GestureUpdateEvent<PinchGestureHandlerEventPayload>) => {
+      scale.value = startScale.value * event.scale;
+    })
+    .onEnd(() => {
+      if (scale.value < MIN_SCALE) {
+        scale.value = withTiming(MIN_SCALE);
+        translateX.value = withTiming(RESET_TRANSLATION_VALUE);
+        translateY.value = withTiming(RESET_TRANSLATION_VALUE);
+        runOnJS(setPanOnJS)(false);
+        return;
+      }
+
+      if (scale.value > MAX_SCALE) {
+        scale.value = withTiming(MAX_SCALE);
+      }
+
+      runOnJS(setPanOnJS)(true);
+    });
+
+  const panGesture = Gesture.Pan()
+    .onStart((_: GestureStateChangeEvent<PanGestureHandlerEventPayload>) => {
+      prevTranslateX.value = translateX.value;
+      prevTranslateY.value = translateY.value;
+    })
+    .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
+      translateX.value = prevTranslateX.value + event.translationX / (1.5 * scale.value);
+      translateY.value = prevTranslateY.value + event.translationY / (1.5 * scale.value);
+    })
+    .onEnd(() => {
+      if (fullScreenWidth != null) {
+        const maxXTranslate = 0.5 * fullScreenWidth - (0.5 * fullScreenWidth) / scale.value;
+
+        if (maxXTranslate > 0 && Math.abs(translateX.value) > maxXTranslate) {
+          translateX.value = translateX.value > 0 ? withTiming(maxXTranslate) : withTiming(-1 * maxXTranslate);
+        }
+      }
+    });
+
+  if (nativeGesture != null) {
+    panGesture.enabled(panEnabled);
+    panGesture.blocksExternalGesture(nativeGesture);
+  }
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onEnd(() => {
+      if (scale.value > MIN_SCALE) {
+        scale.value = withTiming(MIN_SCALE);
+        translateX.value = withTiming(RESET_TRANSLATION_VALUE);
+        translateY.value = withTiming(RESET_TRANSLATION_VALUE);
+        runOnJS(setPanOnJS)(false);
+      } else {
+        scale.value = withTiming(DOUBLE_TAP_SCALE);
+        runOnJS(setPanOnJS)(true);
+      }
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{scale: scale.value}, {translateX: translateX.value}, {translateY: translateY.value}],
+  }));
+
+  const composedGesture = Gesture.Simultaneous(pinchGesture, panGesture, doubleTap);
 
   if (!image) {
     return (
@@ -19,5 +117,11 @@ export const ImageView: React.FunctionComponent<ImageViewProps> = ({item}: Image
     );
   }
 
-  return <Image style={{flex: 1}} contentFit="contain" contentPosition={'center'} source={item.url.original} />;
+  return (
+    <GestureDetector gesture={composedGesture}>
+      <Animated.View style={[{flex: 1}, animatedStyle]}>
+        <Image style={[{flex: 1}, animatedStyle]} contentFit="contain" contentPosition={'center'} source={item.url.original} />
+      </Animated.View>
+    </GestureDetector>
+  );
 };

--- a/components/content/carousel/carouselV2/MediaViewerModal/ImageView.tsx
+++ b/components/content/carousel/carouselV2/MediaViewerModal/ImageView.tsx
@@ -42,6 +42,14 @@ export const ImageView: React.FunctionComponent<ImageViewProps> = ({item, native
     setPanEnabled(value);
   };
 
+  const resetTransforms = () => {
+    'worklet';
+    scale.value = withTiming(MIN_SCALE);
+    translateX.value = withTiming(RESET_TRANSLATION_VALUE);
+    translateY.value = withTiming(RESET_TRANSLATION_VALUE);
+    runOnJS(setPanOnJS)(false);
+  };
+
   const pinchGesture = Gesture.Pinch()
     .onStart(() => {
       startScale.value = scale.value;
@@ -51,10 +59,7 @@ export const ImageView: React.FunctionComponent<ImageViewProps> = ({item, native
     })
     .onEnd(() => {
       if (scale.value < MIN_SCALE) {
-        scale.value = withTiming(MIN_SCALE);
-        translateX.value = withTiming(RESET_TRANSLATION_VALUE);
-        translateY.value = withTiming(RESET_TRANSLATION_VALUE);
-        runOnJS(setPanOnJS)(false);
+        resetTransforms();
         return;
       }
 
@@ -93,10 +98,7 @@ export const ImageView: React.FunctionComponent<ImageViewProps> = ({item, native
     .numberOfTaps(2)
     .onEnd(() => {
       if (scale.value > MIN_SCALE) {
-        scale.value = withTiming(MIN_SCALE);
-        translateX.value = withTiming(RESET_TRANSLATION_VALUE);
-        translateY.value = withTiming(RESET_TRANSLATION_VALUE);
-        runOnJS(setPanOnJS)(false);
+        resetTransforms();
       } else {
         scale.value = withTiming(DOUBLE_TAP_SCALE);
         runOnJS(setPanOnJS)(true);

--- a/components/content/carousel/carouselV2/MediaViewerModal/MediaContentView.tsx
+++ b/components/content/carousel/carouselV2/MediaViewerModal/MediaContentView.tsx
@@ -5,6 +5,7 @@ import {BodySm} from 'components/text';
 import {usePostHog} from 'posthog-react-native';
 import React, {useEffect} from 'react';
 import {Dimensions} from 'react-native';
+import {NativeGesture} from 'react-native-gesture-handler';
 import {MediaItem, MediaType} from 'types/nationalAvalancheCenter';
 
 const SCREEN = Dimensions.get('screen');
@@ -14,16 +15,17 @@ const SCREEN_HEIGHT = SCREEN.height;
 interface MediaContentProps {
   item: MediaItem;
   isVisible: boolean;
+  nativeGesture: NativeGesture;
 }
 
-export const MediaContentView: React.FunctionComponent<MediaContentProps> = ({item, isVisible}: MediaContentProps) => {
+export const MediaContentView: React.FunctionComponent<MediaContentProps> = ({item, isVisible, nativeGesture}) => {
   const postHog = usePostHog();
 
   let content: React.JSX.Element;
   let isMediaSupported = true;
 
   if (item.type === MediaType.Image) {
-    content = <ImageView item={item} />;
+    content = <ImageView item={item} nativeGesture={nativeGesture} fullScreenWidth={SCREEN_WIDTH} />;
   } else if (item.type === MediaType.Video) {
     content = <WebVideoView item={item} isVisible={isVisible} />;
   } else {

--- a/components/content/carousel/carouselV2/MediaViewerModal/MediaViewerModal.tsx
+++ b/components/content/carousel/carouselV2/MediaViewerModal/MediaViewerModal.tsx
@@ -4,6 +4,7 @@ import {MediaViewerModalHeader} from 'components/content/carousel/carouselV2/Med
 import {View} from 'components/core';
 import React, {useCallback, useState} from 'react';
 import {Dimensions, FlatList, Modal, ViewToken} from 'react-native';
+import {Gesture, GestureDetector, GestureHandlerRootView} from 'react-native-gesture-handler';
 import {colorLookup} from 'theme';
 import {MediaItem, MediaType} from 'types/nationalAvalancheCenter';
 
@@ -28,14 +29,16 @@ const getItemId = (item: MediaItem) => {
 export const MediaViewerModal: React.FunctionComponent<MediaViewerModalProps> = ({visible, startIndex, mediaItems, onClose}: MediaViewerModalProps) => {
   const [currentItemIndex, setCurrentItemIndex] = useState(startIndex);
 
+  const nativeGesture = Gesture.Native();
+
   const renderItem = useCallback(
     ({item}: {item: MediaItem}) => {
       const visibleItemId = getItemId(mediaItems[currentItemIndex]);
       const renderItemId = getItemId(item);
 
-      return <MediaContentView item={item} isVisible={visibleItemId === renderItemId} />;
+      return <MediaContentView item={item} isVisible={visibleItemId === renderItemId} nativeGesture={nativeGesture} />;
     },
-    [mediaItems, currentItemIndex],
+    [mediaItems, currentItemIndex, nativeGesture],
   );
 
   const getItemLayout = useCallback(
@@ -66,17 +69,21 @@ export const MediaViewerModal: React.FunctionComponent<MediaViewerModalProps> = 
     <Modal visible={visible} onRequestClose={onClose} animationType="fade">
       <View flex={1} style={{backgroundColor: colorLookup('modal.background')}}>
         <MediaViewerModalHeader index={currentItemIndex} mediaCount={mediaItems.length} onClose={onClose} />
-        <FlatList
-          data={mediaItems}
-          renderItem={renderItem}
-          getItemLayout={getItemLayout}
-          horizontal
-          pagingEnabled
-          showsHorizontalScrollIndicator={false}
-          onViewableItemsChanged={onViewableItemsChanged}
-          viewabilityConfig={{itemVisiblePercentThreshold: 90}}
-          initialScrollIndex={startIndex}
-        />
+        <GestureHandlerRootView>
+          <GestureDetector gesture={nativeGesture}>
+            <FlatList
+              data={mediaItems}
+              renderItem={renderItem}
+              getItemLayout={getItemLayout}
+              horizontal
+              pagingEnabled
+              showsHorizontalScrollIndicator={false}
+              onViewableItemsChanged={onViewableItemsChanged}
+              viewabilityConfig={{itemVisiblePercentThreshold: 90}}
+              initialScrollIndex={startIndex}
+            />
+          </GestureDetector>
+        </GestureHandlerRootView>
         <MediaViewerModalFooter item={mediaItems[currentItemIndex]} />
       </View>
     </Modal>

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -10,7 +10,7 @@ import {Card, CardProps} from 'components/content/Card';
 import {QueryState, incompleteQueryState} from 'components/content/QueryState';
 import {ZoneMap} from 'components/content/ZoneMap';
 import {Carousel, images} from 'components/content/carousel';
-import {MediaCoursel} from 'components/content/carousel/carouselV2/MediaCarousel';
+import {MediaCarousel} from 'components/content/carousel/carouselV2/MediaCarousel';
 import {HStack, VStack, View} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {matchesZone} from 'components/observations/ObservationsFilterForm';
@@ -344,7 +344,7 @@ export const ObservationCard: React.FunctionComponent<{
               </Card>
               {(observation.media ?? []).length > 0 && (
                 <Card borderRadius={0} borderColor="white" header={<BodyBlack>Media</BodyBlack>}>
-                  <MediaCoursel thumbnailHeight={160} thumbnailAspectRatio={1.3} mediaItems={observation.media ?? []} displayCaptions={false} />
+                  <MediaCarousel thumbnailHeight={160} thumbnailAspectRatio={1.3} mediaItems={observation.media ?? []} displayCaptions={false} />
                 </Card>
               )}
               {((observation.avalanches && observation.avalanches.length > 0) || observation.avalanches_summary) && (


### PR DESCRIPTION
### Overview

This adds gesture support to `ImageView.tsx` to bring the custom MediaViewer functionality back to what it was with the old  image viewer. Three gestures are added to the view: pinch, pan, and double tap.

These gestures use the `react-native-gesture-handler` package while the animations use `react-native-reanimated`. These packages are built to work together, and they were packages that are already being included in the repo.

The design decisions I made with passing in an optional native gesture and an option fullScreenWidth into the `ImageView` was to hopefully make it as reusable as possible.

### Overview of `react-native-gesture-handler`

I decided to go with this package over the built in `GestureResponder` that's provided by React Native because `react-native-gesture-handler` has better performance and platform support. It's built to use the iOS/Android native touches and runs the gesture/animation code at the native level, instead of `GestureResponder` which runs at the Javascript level. This leads to less frame dropping, and code that works on both platforms with little to no need to write platform specific code to handle the gestures.

#### Explanation of Edge Calculation

The equation in `ImageView.tsx` on line 80 pulls the image back to the edge of the screen after the gesture completes. This is based on the observation that no matter what the scale of the image is if the `translationX.value` is equal to half of the screen width, then the edge of the image will be in the middle of the screen. This seems to be true for both iOS and Android. Using this I calculate the edge of the screen as follows:

`screen_edge = 0.5 * screen_width - ((0.5 * screen_width) / scale.value)`

By setting the `translateX.value` to this, the image goes back to the edge of the screen

### Where to Start
- `ImageView.tsx`

### Testing

Tested on both the iOS simulator and Android emulator. Since we still support Expo 52 I wasn't able to try it on Expo Go on device. 

![GestureSupport](https://github.com/user-attachments/assets/49e4b38e-6274-4bd0-993c-b95d600db7b7)




