### PR TITLE
fonts: Bring back font loading in App.tsx

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -64,6 +64,20 @@ import {PostHogProvider} from 'posthog-react-native';
 import {startupUpdateCheck, UpdateStatus} from 'Updates';
 import {ZodError} from 'zod';
 
+import {
+  Lato_100Thin,
+  Lato_100Thin_Italic,
+  Lato_300Light,
+  Lato_300Light_Italic,
+  Lato_400Regular,
+  Lato_400Regular_Italic,
+  Lato_700Bold,
+  Lato_700Bold_Italic,
+  Lato_900Black,
+  Lato_900Black_Italic,
+  useFonts,
+} from '@expo-google-fonts/lato';
+
 logger.info('App starting.');
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -332,6 +346,23 @@ const BaseApp: React.FunctionComponent<{
     })();
   }, [logger, queryClient, avalancheCenterId, nationalAvalancheCenterHost, nationalAvalancheCenterWordpressHost, nwacHost, snowboundHost]);
 
+  const [fontsLoaded, error] = useFonts({
+    Lato_100Thin,
+    Lato_100Thin_Italic,
+    Lato_300Light,
+    Lato_300Light_Italic,
+    Lato_400Regular_Italic,
+    Lato_400Regular,
+    Lato_700Bold,
+    Lato_700Bold_Italic,
+    Lato_900Black,
+    Lato_900Black_Italic,
+  });
+
+  if (error) {
+    logger.error({error: error}, 'error loading fonts');
+  }
+
   const navigationRef = useNavigationContainerRef();
   const trackNavigationChange = useCallback(() => {
     if (routingInstrumentation && navigationRef) {
@@ -395,7 +426,7 @@ const BaseApp: React.FunctionComponent<{
 
   const [startupPaused, {off: unpauseStartup}] = useToggle(process.env.EXPO_PUBLIC_PAUSE_ON_STARTUP === 'true');
 
-  if (updateStatus !== 'ready' || preferences.mixpanelUserId == '') {
+  if (!fontsLoaded || updateStatus !== 'ready' || preferences.mixpanelUserId == '') {
     // Here, we render a view that looks exactly like the splash screen but now has an activity indicator
     return (
       <View


### PR DESCRIPTION
After looking at what fonts should look like, it appears that at least on the Android emulator they do not look right unless we load them inside App.tsx. Need to dig into this more but wanted to leave this breadcrumb here for now...

not loading:
<img width="453" height="976" alt="image" src="https://github.com/user-attachments/assets/a462d2fe-f355-430e-abf3-d357f52aba70" />

with loading: 
<img width="537" height="1041" alt="image" src="https://github.com/user-attachments/assets/ac2a9123-9983-4c29-92a9-d4931aed33fc" />
