### PR TITLE
.github: bump node version

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: 🏗 Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
         cache: yarn
     - name: 🏗 Setup Expo
       uses: expo/expo-github-action@v7


### PR DESCRIPTION
eas-cli is complaining about node version, this was fixed in the expo bump but got reverted as part of that. bringing it back. 