### PR TITLE
app.json: Update android minSdkVersion from 26 to 35

### DIFF
--- a/app.json
+++ b/app.json
@@ -69,7 +69,7 @@
         "expo-build-properties",
         {
           "android": {
-            "minSdkVersion": 26
+            "minSdkVersion": 35
           }
         }
       ],


### PR DESCRIPTION
Google Play mandates that new apps and app updates target a recent Android API level. As of August 31, 2025, apps must target an API level within one year of the latest Android release. Currently, this means targeting Android 15 (API level 35) or higher for most apps