### PR TITLE
app.json: explicitly set targetSdkVersion to 35

### DIFF
--- a/app.json
+++ b/app.json
@@ -69,7 +69,9 @@
         "expo-build-properties",
         {
           "android": {
-            "minSdkVersion": 35
+            "minSdkVersion": 26,
+            "compileSdkVersion": 35,
+            "targetSdkVersion": 35
           }
         }
       ],


### PR DESCRIPTION
bringing the minSdkVersion back to the value it was before. went back and forth on if we should or shouldn't set the compileSdkVersion, but after reading [this ](https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd#.fo6h6k65r)decided it might as well be the same as target. In theory [expo ](https://docs.expo.dev/versions/latest/#support-for-android-and-ios-versions) sets all these for us but it's a bit confusing since it would mean that our app should have been able to be pushed vs getting an error that our target sdk is too low 🤷 