### PR TITLE
app.json: bump to 1.0.14

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Avy",
     "slug": "avalanche-forecast",
     "owner": "nwac",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",


### PR DESCRIPTION
Publishing a new build (not an OTA) for both ios and android, so need to bump app version (cant submit a new build on IOs without a new version)