### PR TITLE
menu: fix empty space in FAC link

### DIFF
--- a/data/settingsMenuItems.ts
+++ b/data/settingsMenuItems.ts
@@ -138,7 +138,7 @@ export const settingsMenuItems: Record<AvalancheCenterID, {title: string; url: s
   FAC: [
     {
       title: 'Avalanche Education',
-      url: ' https://www.flatheadavalanche.org/education',
+      url: 'https://www.flatheadavalanche.org/education',
     },
     {
       title: 'FlatheadAvalanche.org',


### PR DESCRIPTION
whoops