### PR TITLE
Fix timestamp mismatch

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -201,6 +201,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
             // product-specific queries can give us results that are expired or older than the map layer, in which case we don't
             // want to use them
             if (
+              (forecast.product_type === ProductType.Forecast || forecast.product_type === ProductType.Summary) &&
               forecast.expires_time &&
               zonesById[id].end_date &&
               (isAfter(toDate(new Date(forecast.expires_time), {timeZone: 'UTC'}), requestedTimeToUTCDate(requestedTime)) /* product is not expired */ ||


### PR DESCRIPTION
#1007 

Rusty caught an issue where the timestamp on the forecast card was different than the time on the actual forecast.

What's happening is that the map layer API timestamp for forecasts contains no time zone information. For example, it was 2025-11-20T02:00:00. The forecast API returns the timestamp as 2025-11-20T02:00:00+00:00 where the extra +00:00 lets the date converter know that it's a UTC timestamp.

This normally isn't a problem because we check the map layer data against the forecast data and replace the timestamps with the correct ones. However, we were only doing that when the product type coming from the forecast API was "forecast" and not "summary".

This change always replaces the map layer timestamp with the forecast timestamp, if the forecast timestamp is still relevant.

A better fix would be to change it in the API.