### PR TITLE
ObservationDetailView: parse all dates as UTC

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -51,7 +51,7 @@ import {
   WindLoading,
   userFacingCenterId,
 } from 'types/nationalAvalancheCenter';
-import {pacificDateToLocalShortDateString, utcDateToLocalShortDateString} from 'utils/date';
+import {utcDateToLocalShortDateString} from 'utils/date';
 
 export const NWACObservationDetailView: React.FunctionComponent<{
   id: string;
@@ -235,7 +235,7 @@ export const ObservationCard: React.FunctionComponent<{
                   <VStack space={8} style={{flex: 1}}>
                     <AllCapsSmBlack>Observed</AllCapsSmBlack>
                     <AllCapsSm style={{textTransform: 'none'}} color="text.secondary">
-                      {pacificDateToLocalShortDateString(observation.start_date)}
+                      {utcDateToLocalShortDateString(observation.start_date)}
                     </AllCapsSm>
                   </VStack>
                   <VStack space={8} style={{flex: 1}}>
@@ -357,7 +357,7 @@ export const ObservationCard: React.FunctionComponent<{
                       <VStack space={8} style={{flex: 1}} key={`avalanche-${index}`}>
                         <BodyBlack>{`#${index + 1}${item.location ? `: ${item.location}` : ''}`}</BodyBlack>
                         {item.comments && <HTML source={{html: item.comments}} />}
-                        <TableRow label={`Date (${item.date_known ? 'Exact' : 'Estimated'})`} value={`${pacificDateToLocalShortDateString(item.date)}`} />
+                        <TableRow label={`Date (${item.date_known ? 'Exact' : 'Estimated'})`} value={`${utcDateToLocalShortDateString(item.date)}`} />
                         {item.d_size && <TableRow label={'Size'} value={`D${item.d_size}${item.r_size ? '-R' + item.r_size : ''}`} />}
                         {item.trigger && (
                           <TableRow

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -39,7 +39,7 @@ import {
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MediaType, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
-import {RequestedTime, pacificDateToLocalDateString, requestedTimeToUTCDate} from 'utils/date';
+import {RequestedTime, requestedTimeToUTCDate, utcDateToLocalDateString} from 'utils/date';
 
 interface ObservationsListViewItem {
   id: ObservationFragment['id'];
@@ -523,7 +523,7 @@ export const ObservationSummaryCard: React.FunctionComponent<ObservationSummaryC
       style={{opacity: pending ? 0.5 : 1.0}}
       header={
         <HStack alignContent="flex-start" justifyContent="space-between" flexWrap="wrap" alignItems="center" space={8}>
-          <BodySmBlack>{pacificDateToLocalDateString(observation.startDate)}</BodySmBlack>
+          <BodySmBlack>{utcDateToLocalDateString(observation.startDate)}</BodySmBlack>
           <HStack space={8} alignItems="center">
             {redFlags && <MaterialCommunityIcons name="flag" size={bodySize} color={colorFor(DangerLevel.Considerable).string()} />}
             {avalanches && <NACAvalancheIcon size={bodySize} color={colorFor(DangerLevel.High).string()} />}

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -107,22 +107,6 @@ export const utcDateToLocalShortDateString = (date: Date | string | undefined | 
   return format(d, `MMM d, yyyy`);
 };
 
-export const pacificDateToLocalShortDateString = (date: Date | string | undefined | null): string => {
-  if (date == null) {
-    return 'Unknown';
-  }
-  const d = typeof date === 'string' ? toDate(date, {timeZone: 'America/Los_Angeles'}) : date;
-  return format(d, `MMM d, yyyy`);
-};
-
-export const pacificDateToLocalDateString = (date: Date | string | undefined | null): string => {
-  if (date == null) {
-    return 'Unknown';
-  }
-  const d = typeof date === 'string' ? toDate(date, {timeZone: 'America/Los_Angeles'}) : date;
-  return format(d, `EEEE, MMMM d, yyyy`);
-};
-
 export const pacificDateToDayOfWeekString = (date: Date | string | undefined | null): string => {
   if (date == null) {
     return 'Unknown';


### PR DESCRIPTION
It's not clear why we were explicitly parsing these observation dates as Pacfic time in the past, but it was likely due to support for the NWAC observation API. The NAC API always returns UTC, so we should parse as such.

fixes https://github.com/NWACus/avy/issues/1015