### PR TITLE
Update fetch more data window

### DIFF
--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -388,8 +388,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         onScroll={onScroll}
         onScrollEndDrag={onScroll}
         scrollEventThrottle={160}
-        // when within 5 page lengths of the end, start fetching the next set of data
-        onEndReachedThreshold={5}
+        onEndReachedThreshold={0.5}
         onEndReached={fetchMoreData}
         ListFooterComponent={renderListFooter}
         ListEmptyComponent={


### PR DESCRIPTION
This is a part of an ongoing issue where the app seems to be crashing because of running out of memory. A lot of these EXC_BAD_ACCESS memory crashes happen after numerous calls to fetch observation data. 

This change reduces the window size to only fetch new obs when a user gets close to the bottom of the list. On an iPhone 13 this change will start fetching more data when the user is 2 items away from the bottom instead of 20 as the list fits about 4 items at a time on the screen.

This will not solve the crash, but it will help reduce the number of calls made at one time especially in the early season months.