### PR TITLE
Fix import cycle

### DIFF
--- a/components/content/carousel/MediaViewerModal/MediaViewerModal.tsx
+++ b/components/content/carousel/MediaViewerModal/MediaViewerModal.tsx
@@ -1,10 +1,9 @@
-import {AntDesign} from '@expo/vector-icons';
 import {MediaContentView} from 'components/content/carousel/MediaViewerModal/MediaContentView';
 import {MediaViewerModalFooter} from 'components/content/carousel/MediaViewerModal/MediaViewerModalFooter';
 import {MediaViewerModalHeader} from 'components/content/carousel/MediaViewerModal/MediaViewerModalHeader';
-import {Center, View, ViewProps} from 'components/core';
+import {View} from 'components/core';
 import React, {useCallback, useState} from 'react';
-import {Dimensions, FlatList, GestureResponderEvent, Modal, TouchableOpacity, ViewToken} from 'react-native';
+import {Dimensions, FlatList, Modal, ViewToken} from 'react-native';
 import {Gesture, GestureDetector, GestureHandlerRootView} from 'react-native-gesture-handler';
 import {colorLookup} from 'theme';
 import {MediaItem, MediaType} from 'types/nationalAvalancheCenter';
@@ -18,14 +17,6 @@ export interface MediaViewerModalProps {
   mediaItems: MediaItem[];
   onClose: () => void;
 }
-
-export const RoundButton = ({onPress, ...props}: {onPress: ((event: GestureResponderEvent) => void) | undefined} & ViewProps) => (
-  <TouchableOpacity onPress={onPress}>
-    <Center height={32} width={32} backgroundColor={colorLookup('modal.background')} borderRadius={16} {...props}>
-      <AntDesign size={24} color="white" name="close" />
-    </Center>
-  </TouchableOpacity>
-);
 
 const getItemId = (item: MediaItem) => {
   if (item.type === '' || item.type === null || item.type === MediaType.PDF || item.type === MediaType.Unknown) {

--- a/components/content/carousel/MediaViewerModal/MediaViewerModalHeader.tsx
+++ b/components/content/carousel/MediaViewerModal/MediaViewerModalHeader.tsx
@@ -1,14 +1,24 @@
-import {RoundButton} from 'components/content/carousel/MediaViewerModal/MediaViewerModal';
-import {Center, HStack, View} from 'components/core';
+import {AntDesign} from '@expo/vector-icons';
+import {Center, HStack, View, ViewProps} from 'components/core';
 import {BodySm} from 'components/text';
 import React from 'react';
+import {GestureResponderEvent, TouchableOpacity} from 'react-native';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
+import {colorLookup} from 'theme';
 
 interface MediaViewerModalHeaderProps {
   index: number;
   mediaCount: number;
   onClose: () => void;
 }
+
+const RoundButton = ({onPress, ...props}: {onPress: ((event: GestureResponderEvent) => void) | undefined} & ViewProps) => (
+  <TouchableOpacity onPress={onPress}>
+    <Center height={32} width={32} backgroundColor={colorLookup('modal.background')} borderRadius={16} {...props}>
+      <AntDesign size={24} color="white" name="close" />
+    </Center>
+  </TouchableOpacity>
+);
 
 export const MediaViewerModalHeader: React.FunctionComponent<MediaViewerModalHeaderProps> = ({index, mediaCount, onClose}) => {
   return (


### PR DESCRIPTION
I moved the `RoundButton` component from `MediaViewerModal` to `MediaViewerModalHeader` since I accidentally created an import cycle where `MediaViewerModal` -> `MediaViewerModalHeader` -> `MediaViewerModal` when I removed the old code.