### PR TITLE
Fix Observation Observed Time Issue

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -51,7 +51,7 @@ import {
   WindLoading,
   userFacingCenterId,
 } from 'types/nationalAvalancheCenter';
-import {utcDateToLocalShortDateString} from 'utils/date';
+import {observationStartDateToLocalShortDateString, utcDateToLocalShortDateString} from 'utils/date';
 
 export const NWACObservationDetailView: React.FunctionComponent<{
   id: string;
@@ -235,7 +235,7 @@ export const ObservationCard: React.FunctionComponent<{
                   <VStack space={8} style={{flex: 1}}>
                     <AllCapsSmBlack>Observed</AllCapsSmBlack>
                     <AllCapsSm style={{textTransform: 'none'}} color="text.secondary">
-                      {utcDateToLocalShortDateString(observation.start_date)}
+                      {observationStartDateToLocalShortDateString(observation.start_date)}
                     </AllCapsSm>
                   </VStack>
                   <VStack space={8} style={{flex: 1}}>

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -39,7 +39,7 @@ import {
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MediaType, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
-import {RequestedTime, requestedTimeToUTCDate, utcDateToLocalDateString} from 'utils/date';
+import {RequestedTime, observationStartDateToLocalDateString, requestedTimeToUTCDate} from 'utils/date';
 
 interface ObservationsListViewItem {
   id: ObservationFragment['id'];
@@ -522,7 +522,7 @@ export const ObservationSummaryCard: React.FunctionComponent<ObservationSummaryC
       style={{opacity: pending ? 0.5 : 1.0}}
       header={
         <HStack alignContent="flex-start" justifyContent="space-between" flexWrap="wrap" alignItems="center" space={8}>
-          <BodySmBlack>{utcDateToLocalDateString(observation.startDate)}</BodySmBlack>
+          <BodySmBlack>{observationStartDateToLocalDateString(observation.startDate)}</BodySmBlack>
           <HStack space={8} alignItems="center">
             {redFlags && <MaterialCommunityIcons name="flag" size={bodySize} color={colorFor(DangerLevel.Considerable).string()} />}
             {avalanches && <NACAvalancheIcon size={bodySize} color={colorFor(DangerLevel.High).string()} />}

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -107,6 +107,28 @@ export const utcDateToLocalShortDateString = (date: Date | string | undefined | 
   return format(d, `MMM d, yyyy`);
 };
 
+// This is used when dealing with observation start dates. These dates are given to us with no time zone or timestamp.
+// By giving it a timezone and setting it to miday, the date can be accurately represented in local time regardless of time zone shifts.
+export const observationStartDateToLocalShortDateString = (date: Date | string | undefined | null): string => {
+  if (date == null) {
+    return 'Unknown';
+  }
+  const d = typeof date === 'string' ? toDate(date, {timeZone: 'America/Los_Angeles'}) : date;
+  d.setHours(12);
+  return format(d, `MMM d, yyyy`);
+};
+
+// This is used when dealing with observation start dates. These dates are given to us with no time zone or timestamp.
+// By giving it a timezone and setting it to miday, the date can be accurately represented in local time regardless of time zone shifts.
+export const observationStartDateToLocalDateString = (date: Date | string | undefined | null): string => {
+  if (date == null) {
+    return 'Unknown';
+  }
+  const d = typeof date === 'string' ? toDate(date, {timeZone: 'America/Los_Angeles'}) : date;
+  d.setHours(12);
+  return format(d, `EEEE, MMMM d, yyyy`);
+};
+
 export const pacificDateToDayOfWeekString = (date: Date | string | undefined | null): string => {
   if (date == null) {
     return 'Unknown';


### PR DESCRIPTION
In an effort to fix the time discrepancy issues in the Observation Observed Date first noticed here #1015 we changed how we handled showing `start_date` to use UTC time in favor of Pacific Time because the field comes in from the backend as just the date with no timestamp information. Ex '2025-12-6'.

According to Chris, this assumption isn't correct and this field corresponds to "the date the user selected when creating the observation". 

In an effort to make the smallest change to fix the issue, I brought back the old `pacificDateToLocalShortDateString`, renamed it so that it's more clear why we're doing it, and set it so that it had a timestamp of 12:00 instead of it being midnight. This was it should render the correct date whether you're on the East coast or Alaska.