### PR TITLE
Add Avalanche Obs: Initial changes

### DIFF
--- a/components/content/Button.tsx
+++ b/components/content/Button.tsx
@@ -20,7 +20,7 @@ interface ButtonStyle {
   };
 }
 
-type PredefinedButtonStyle = 'normal' | 'primary' | 'destructive';
+type PredefinedButtonStyle = 'normal' | 'primary' | 'secondary' | 'destructive';
 
 const styles = {
   normal: {
@@ -50,6 +50,20 @@ const styles = {
       borderColor: colorLookup('blue2'),
       backgroundColor: colorLookup('blue2'),
       textColor: colorLookup('white'),
+    },
+  },
+  secondary: {
+    borderColor: colorLookup('border.base'),
+    textColor: colorLookup('text.secondary'),
+    disabled: {
+      backgroundColor: colorLookup('disabled'),
+      borderColor: colorLookup('disabled'),
+      textColor: colorLookup('text.secondary'),
+    },
+    pressed: {
+      borderColor: colorLookup('blue2'),
+      backgroundColor: colorLookup('background.color-light'),
+      textColor: colorLookup('blue2'),
     },
   },
   destructive: {

--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -3,7 +3,7 @@ import React, {PropsWithChildren, ReactNode, useCallback, useEffect, useState} f
 import {ColorValue, TouchableOpacity, ViewStyle} from 'react-native';
 import Collapsible from 'react-native-collapsible';
 
-import {FontAwesome} from '@expo/vector-icons';
+import {AntDesign, FontAwesome} from '@expo/vector-icons';
 
 import {Divider, HStack, View, ViewProps, VStack} from 'components/core';
 import {usePostHog} from 'posthog-react-native';
@@ -55,6 +55,67 @@ export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({
           </VStack>
         </View>
       </TouchableOpacity>
+    </View>
+  );
+};
+
+export interface EditDeleteCardProps extends ViewProps {
+  header?: ReactNode;
+  onEditPress: () => void;
+  onDeletePress: () => void;
+  borderWidth?: number;
+  borderRadius?: number;
+  borderColor?: ColorValue;
+  noDivider?: boolean;
+  noInternalSpace?: boolean;
+}
+
+export const EditDeleteCard: React.FunctionComponent<PropsWithChildren<EditDeleteCardProps>> = ({
+  header,
+  onEditPress,
+  onDeletePress,
+  borderColor,
+  borderRadius,
+  borderWidth,
+  noDivider,
+  noInternalSpace,
+  children,
+  ...boxProps
+}) => {
+  const onEditHandler = useCallback(() => onEditPress(), [onEditPress]);
+  const onDeleteHandler = useCallback(() => onDeletePress(), [onDeletePress]);
+
+  return (
+    <View {...boxProps}>
+      <View bg="white" borderWidth={borderWidth ?? 2} borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.300'} p={16}>
+        <VStack space={noInternalSpace ? 0 : 8}>
+          <HStack justifyContent="space-between">
+            <>{header}</>
+            <HStack space={4}>
+              <AntDesign.Button
+                size={16}
+                name="edit"
+                color="white"
+                backgroundColor="rgba(0, 0, 0, 0.3)"
+                iconStyle={{marginRight: 0}}
+                style={{textAlign: 'center'}}
+                onPress={onEditHandler}
+              />
+              <AntDesign.Button
+                size={16}
+                name="delete"
+                color="white"
+                backgroundColor="rgba(0, 0, 0, 0.3)"
+                iconStyle={{marginRight: 0}}
+                style={{textAlign: 'center'}}
+                onPress={onDeleteHandler}
+              />
+            </HStack>
+          </HStack>
+          {noDivider || <Divider />}
+          <>{children}</>
+        </VStack>
+      </View>
     </View>
   );
 };

--- a/components/form/SelectField.tsx
+++ b/components/form/SelectField.tsx
@@ -21,6 +21,7 @@ interface SelectFieldProps {
   radio?: boolean; // If true, will default to selecting first item and always enforce selection
   disabled?: boolean;
   invisible?: boolean;
+  minItemsShown?: number;
 }
 
 const borderColor = colorLookup('border.base');
@@ -80,7 +81,7 @@ const selectStyles: SelectStyles = {
   },
 };
 
-export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, label, items, prompt, radio, disabled, invisible}, ref) => {
+export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, label, items, prompt, radio, disabled, invisible, minItemsShown}, ref) => {
   const {setValue} = useFormContext();
   const {field, fieldState} = useController({name});
   const menuItems =
@@ -128,7 +129,7 @@ export const SelectField = React.forwardRef<RNView, SelectFieldProps>(({name, la
         onRemove={onRemove}
         styles={_.merge({}, selectStyles, {
           optionsList: {
-            minHeight: Math.min(10, menuItems.length) * 40,
+            minHeight: Math.min(minItemsShown ?? 10, menuItems.length) * 40,
           },
         })}
         // Setting `scrollToSelectedOption` based on https://github.com/MobileReality/react-native-select-pro/issues/230

--- a/components/observations/AvalancheObservationSection.tsx
+++ b/components/observations/AvalancheObservationSection.tsx
@@ -1,0 +1,83 @@
+import {MaterialIcons} from '@expo/vector-icons';
+import {Button} from 'components/content/Button';
+import {EditDeleteCard} from 'components/content/Card';
+import {HStack, VStack} from 'components/core';
+import {AvalancheObservationForm} from 'components/observations/AvalancheObservationForm';
+import {AvalancheObservationFormData, ObservationFormData} from 'components/observations/ObservationFormData';
+import {Body, BodySemibold} from 'components/text';
+import React, {useCallback, useState} from 'react';
+import {useController} from 'react-hook-form';
+import {ColorValue} from 'react-native';
+import {colorLookup} from 'theme';
+import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
+
+export const AvalancheObservationSection: React.FC<{center_id: AvalancheCenterID; disabled: boolean; busy: boolean}> = ({center_id, disabled, busy}) => {
+  const [isAvyObsModalDislayed, setAvyObsModalDisplayed] = useState(false);
+  const {field} = useController<ObservationFormData, 'avalanches'>({name: 'avalanches', defaultValue: []});
+  const avalancheObs = field.value;
+
+  const onAvyObsModalClose = useCallback(() => setAvyObsModalDisplayed(false), [setAvyObsModalDisplayed]);
+  const onNewAvyObsSave = useCallback(
+    (avalancheData: AvalancheObservationFormData) => {
+      field.onChange([...avalancheObs, avalancheData]);
+      setAvyObsModalDisplayed(false);
+    },
+    [setAvyObsModalDisplayed, avalancheObs, field],
+  );
+  const onToggleAvyObsModal = useCallback(() => setAvyObsModalDisplayed(true), [setAvyObsModalDisplayed]);
+
+  const onDeleteItem = useCallback(
+    (index: number) => {
+      field.onChange(avalancheObs.filter((_, i) => i !== index));
+    },
+    [avalancheObs, field],
+  );
+
+  const onEditItem = useCallback((_: number) => {}, []);
+
+  const handleDeleteItem = (index: number) => () => onDeleteItem(index);
+  const handleEditItem = (index: number) => () => onEditItem(index);
+
+  return (
+    <>
+      {avalancheObs.length > 0 && (
+        <VStack space={4}>
+          {avalancheObs.map((avalanche, index) => (
+            <EditDeleteCard
+              key={index}
+              borderWidth={1}
+              borderColor={colorLookup('border.base')}
+              my={2}
+              py={1}
+              borderRadius={10}
+              onDeletePress={handleDeleteItem(index)}
+              onEditPress={handleEditItem(index)}
+              header={<BodySemibold>{avalanche.location}</BodySemibold>}>
+              <HStack space={8}>
+                <Body>{avalanche.date.toDateString()}</Body>
+                <Body>{avalanche.d_size}</Body>
+                <Body>{avalanche.elevation} ft</Body>
+              </HStack>
+            </EditDeleteCard>
+          ))}
+        </VStack>
+      )}
+      <AddAvalancheObsButton onPress={onToggleAvyObsModal} disabled={disabled} busy={busy} />
+      <AvalancheObservationForm visible={isAvyObsModalDislayed} onSave={onNewAvyObsSave} onClose={onAvyObsModalClose} center_id={center_id} />
+    </>
+  );
+};
+
+const AddAvalancheObsButton: React.FC<{onPress: () => void; disabled: boolean; busy: boolean}> = ({onPress, disabled, busy}) => {
+  const renderChildren = useCallback(
+    ({textColor}: {textColor: ColorValue}) => (
+      <HStack width={'100%'} justifyContent="space-between">
+        <BodySemibold color={textColor}>{'Add avalanche details'}</BodySemibold>
+        <MaterialIcons name="chevron-right" size={24} color={textColor} style={{marginTop: 1}} />
+      </HStack>
+    ),
+    [],
+  );
+
+  return <Button mt={8} buttonStyle="secondary" disabled={disabled} busy={busy} onPress={onPress} renderChildren={renderChildren} />;
+};

--- a/components/observations/uploader/ObservationsUploader.test.ts
+++ b/components/observations/uploader/ObservationsUploader.test.ts
@@ -499,6 +499,7 @@ const fakeObservation: {apiPrefix: string; center_id: AvalancheCenterID; observa
     photoUsage: MediaUsage.Credit,
     private: false,
     start_date: new Date('2023-10-17T14:38:32.620Z'),
+    avalanches: [],
     images: [
       {
         image: {

--- a/components/observations/uploader/ObservationsUploader.ts
+++ b/components/observations/uploader/ObservationsUploader.ts
@@ -166,8 +166,6 @@ export class ObservationUploader {
 
       const tasks: TaskQueueEntry[] = [];
 
-      // uuid.v4 has a goofy implementation that only returns a byte array if you pass a byte array in,
-      // but returns string otherwise. hence the use of `as string`.
       const observationTaskId = uuid.v4();
 
       observationFormData.images?.forEach(({image, caption}) => {

--- a/components/observations/uploader/uploadObservation.ts
+++ b/components/observations/uploader/uploadObservation.ts
@@ -8,6 +8,7 @@ import {Observation, ObservationSource} from 'types/nationalAvalancheCenter';
 export async function uploadObservation(id: string, data: ObservationTaskData): Promise<Observation> {
   const {formData, extraData} = data;
   const {url, ...params} = extraData;
+  const avalancheFormData = formData.avalanches || [];
   const payload: Partial<Observation> = {
     ...formData,
     ...params,
@@ -15,6 +16,14 @@ export async function uploadObservation(id: string, data: ObservationTaskData): 
     // Date has to be a plain-old YYYY-MM-DD string. This format is the same format used by
     // `apiDateString`, but that function also converts to UTC, which we don't want to do here (#584)
     start_date: format(formData.start_date, 'yyyy-MM-dd'),
+    avalanches: avalancheFormData.map(avalanche => ({
+      ...avalanche,
+      // Similarly, avalanche date has to be a YYYY-MM-DD string
+      date: format(avalanche.date, 'yyyy-MM-dd'),
+      elevation: Number(avalanche.elevation),
+      number: Number(avalanche.number),
+      media: [],
+    })),
   };
   try {
     const {data: responseData} = await axios.post<Observation>(url, payload, {

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -1007,6 +1007,32 @@ export const instabilitySchema = z.object({
   collapsing_description: z.nativeEnum(InstabilityDistribution).or(z.string().length(0)).nullable().optional(),
 });
 
+export const avalancheObservationSchema = z.object({
+  date: z.string().nullable().optional(/* only because of NWAC */),
+  date_known: z.boolean().nullable().optional(/* only because of NWAC */),
+  time: z.string().nullable().optional(/* only because of NWAC */),
+  time_known: z.boolean().nullable().optional(/* only because of NWAC */),
+  location: z.string().nullable().optional(/* only because of NWAC */),
+  number: z.number().nullable().optional(/* only because of NWAC */),
+  avalanche_type: z.nativeEnum(AvalancheType).or(z.string().length(0)).nullable().optional(),
+  cause: z.nativeEnum(AvalancheCause).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
+  terminus: z.nativeEnum(AvalancheTerminus).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
+  trigger: z.nativeEnum(AvalancheTrigger).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
+  avg_crown_depth: z.number().nullable().optional(),
+  d_size: z.string().nullable().optional(/* only because of NWAC */),
+  r_size: z.string().nullable().optional(/* only because of NWAC */),
+  bed_sfc: z.nativeEnum(AvalancheBedSurface).or(z.string().length(0)).nullable().optional(),
+  elevation: z.number().or(z.string()).nullable().optional(/* only because of NWAC */),
+  vertical_fall: z.number().or(z.string()).nullable().optional(),
+  width: z.number().nullable().optional(/* only because of NWAC */),
+  slope_angle: z.number().nullable().optional(),
+  aspect: z.nativeEnum(AvalancheAspect).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
+  weak_layer_type: z.string().nullable().optional(), // TODO: this is clearly an enum somewhere, it's not anywhere I can see..
+  weak_layer_date: z.string().nullable().optional(),
+  comments: z.string().nullable().optional(/* only because of NWAC */),
+  media: z.array(mediaItemSchema).optional(/* only because of NWAC */),
+});
+
 export const locationSchema = z.object({
   lng: z.number().nullable(/* TODO confirm why there are 2 obs like this, are they flukes? */).optional(/* only for NWAC obs */),
   lat: z.number().nullable(/* TODO confirm why there are 2 obs like this, are they flukes? */).optional(/* only for NWAC obs */),
@@ -1038,36 +1064,7 @@ export const observationSchema = z.object({
   media: z.array(mediaItemSchema).nullable().optional(/* only because of NWAC */),
   avalanches_summary: z.string().nullable().optional(/* only because of NWAC */),
   urls: z.array(z.string()).optional(/* only because of NWAC */),
-  avalanches: z
-    .array(
-      z.object({
-        date: z.string().nullable().optional(/* only because of NWAC */),
-        date_known: z.boolean().nullable().optional(/* only because of NWAC */),
-        time: z.string().nullable().optional(/* only because of NWAC */),
-        time_known: z.boolean().nullable().optional(/* only because of NWAC */),
-        location: z.string().nullable().optional(/* only because of NWAC */),
-        number: z.number().nullable().optional(/* only because of NWAC */),
-        avalanche_type: z.nativeEnum(AvalancheType).or(z.string().length(0)).nullable().optional(),
-        cause: z.nativeEnum(AvalancheCause).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
-        terminus: z.nativeEnum(AvalancheTerminus).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
-        trigger: z.nativeEnum(AvalancheTrigger).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
-        avg_crown_depth: z.number().nullable().optional(),
-        d_size: z.string().nullable().optional(/* only because of NWAC */),
-        r_size: z.string().nullable().optional(/* only because of NWAC */),
-        bed_sfc: z.nativeEnum(AvalancheBedSurface).or(z.string().length(0)).nullable().optional(),
-        elevation: z.number().or(z.string()).nullable().optional(/* only because of NWAC */),
-        vertical_fall: z.number().or(z.string()).nullable().optional(),
-        width: z.number().nullable().optional(/* only because of NWAC */),
-        slope_angle: z.number().nullable().optional(),
-        aspect: z.nativeEnum(AvalancheAspect).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
-        weak_layer_type: z.string().nullable().optional(), // TODO: this is clearly an enum somewhere, it's not anywhere I can see..
-        weak_layer_date: z.string().nullable().optional(),
-        comments: z.string().nullable().optional(/* only because of NWAC */),
-        media: z.array(mediaItemSchema).optional(/* only because of NWAC */),
-      }),
-    )
-    .nullable()
-    .optional(/* only because of NWAC */),
+  avalanches: z.array(avalancheObservationSchema).nullable().optional(/* only because of NWAC */),
   advanced_fields: z
     .object({
       observed_terrain: z.string().nullable().optional(/* only because of NWAC */),


### PR DESCRIPTION
Initial PR for adding Avalanche Observations to the app, #949. There were no designs from SlabLab for what the list of avalanches on the ObservationForm should look like, so I tried to follow web as best as I could here.

The following PR will add the ability to edit avalanche observations and hopefully adding images.

This PR:
- Adds a new "Add Avalanche Details" button to the ObservationForm
- Creates a new AvalancheObservationForm to fill in data for the avalanche
- Adds a new section to view high level avalanche information 
- Delete avalanches from the list
- Successfully adds new avalanches

Missing from this PR:
- Ability to edit avalanche information
- Missing optional comments, problem type, and images
- Polish

<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-12 at 09 58 21" src="https://github.com/user-attachments/assets/a90973e5-59a5-495b-865d-54ac3e28c3bd" />
