### PR TITLE
Fix captions not working

### DIFF
--- a/components/observations/AvalancheObservationForm.tsx
+++ b/components/observations/AvalancheObservationForm.tsx
@@ -119,7 +119,7 @@ export const AvalancheObservationForm: React.FC<{
           <SelectModalProvider>
             <View flex={1} style={{paddingTop: insets.top}}>
               <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{flex: 1, height: '100%'}}>
-                <ScrollView style={{flex: 1}} contentContainerStyle={{paddingBottom: insets.bottom}}>
+                <ScrollView style={{flex: 1}} contentContainerStyle={{paddingBottom: insets.bottom}} keyboardShouldPersistTaps="handled">
                   <AvalancheObservationFormHeader onClose={onCloseHandler} />
                   <VStack>
                     <VStack space={formFieldSpacing} paddingBottom={32} paddingHorizontal={16}>


### PR DESCRIPTION
It seems like displaying a modal from a scroll view creates a conflict on how taps can be handled with the keyboard. What seems to be happening is that with the default value set to `never` for `keyboardShouldPersistTaps` the scroll view underneath the `ObservationImageEdit` modal was registering any taps happening outside of the "focused input" as a tap to close the keyboard. This meant that tapping on "Save" when adding a caption wasn't actually registering the button tap but it was just registering as a tap to close the keyboard.

This fixes the issue as it passes of the responsibility of handling the taps to dismiss the keyboard to the child component.

I missed this in testing because I was typing in the inputs on the simulator, and the keyboard wasn't showing when I did that. I tested this with the soft keyboard on the iOS simulator and with the physical android device

#949 