### PR TITLE
Fix map zoom out issue on Android

### DIFF
--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -38,6 +38,11 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
     setModalVisible(!modalVisible);
   }, [modalVisible, setModalVisible]);
 
+  const toggleModalandClearLocation = useCallback(() => {
+    field.onChange(null);
+    setModalVisible(!modalVisible);
+  }, [modalVisible, setModalVisible, field]);
+
   const value: LocationPoint | undefined = field.value as LocationPoint | undefined;
 
   const onLocationSelect = useCallback(
@@ -65,7 +70,7 @@ export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name
         {/* TODO: animate the appearance/disappearance of the error string */}
         {error && <BodyXSm color={colorLookup('error.900')}>{error.message}</BodyXSm>}
       </VStack>
-      {modalVisible && <LocationMap center={center} modalVisible={modalVisible} initialLocation={value} onClose={toggleModal} onSelect={onLocationSelect} />}
+      {modalVisible && <LocationMap center={center} modalVisible={modalVisible} initialLocation={value} onClose={toggleModalandClearLocation} onSelect={onLocationSelect} />}
     </>
   );
 });


### PR DESCRIPTION
#1042

This fixes an issue that we've had on Android where the map in the observation location field was zoomed out on Android. I'm approaching this fix as more of a stopgap solution since, hopefully, we will be changing map packages soon.

This also makes 2 updates to the modal that I decided to go ahead and fix while making changes here.
- Move the close button to the left and the save button to the right to be aligned with the other modals in the app
- Change how the location saving work.
    - Before: hitting X clears out the location, map taps automatically save the location, the checkmark just closes the modal
    - Now: Hitting the X closes the modal, hitting the checkmark saves the location, map taps just update the value

This fix is based off this issue that was reported on `react-native-maps`. While we don't have the version that's impacted talked about here, the issue seems the same so I changed how the map is mounted so that it's only mounted and shown when the modal is displayed instead of behind the scenes like it was.
https://github.com/react-native-maps/react-native-maps/issues/5563

Caveats:
- On my device there's a slight flicker when showing the modal because the map is loading as the modal is being shown. I think
- Every once and awhile the map shows zoomed out still. On my device if I close and reopen the modal, it fixes the issue

Recording of testing from Pixel 6a:
https://github.com/user-attachments/assets/b4015dce-ca34-413a-8a5b-f93edac907cb
What's shown:
- Initial map opening
- Tapping and saving location
- Changing location but hitting the X showing it's not saved and not cleared out anymore
- Updating the location and hitting save
- Showing the change was saved