### PR TITLE
Refactor ZoneMap to use Mapbox

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,7 @@ import {PreferencesProvider, usePreferences} from 'Preferences';
 import {NotFoundError} from 'types/requests';
 import {formatRequestedTime, RequestedTime} from 'utils/date';
 
+import Mapbox from '@rnmapbox/maps';
 import {Integration} from '@sentry/types';
 import {TRACE} from 'browser-bunyan';
 import * as messages from 'compiled-lang/en.json';
@@ -65,6 +66,10 @@ import {startupUpdateCheck, UpdateStatus} from 'Updates';
 import {ZodError} from 'zod';
 
 logger.info('App starting.');
+
+Mapbox.setAccessToken(Constants.expoConfig?.extra?.mapboxAPIKey as string).catch((error: Error) => {
+  logger.error('Failed to initialize mapbox with error: ', error);
+});
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   logger.info('enabling android layout animations');

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useRef, useState} from 'react';
 
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {View as RNView, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
-import AnimatedMapView, {ClickEvent, PoiClickEvent, Region} from 'react-native-maps';
+import {Region} from 'react-native-maps';
 
 import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
@@ -12,7 +12,6 @@ import {defaultMapRegionForGeometries, MapViewZone, mapViewZoneFor, ZoneMap} fro
 import {Center, HStack, View, VStack} from 'components/core';
 import {FocusAwareStatusBar} from 'components/core/FocusAwareStatusBar';
 import {DangerScale} from 'components/DangerScale';
-import {pointInFeature} from 'components/helpers/geographicCoordinates';
 import {TravelAdvice} from 'components/helpers/travelAdvice';
 import {AnimatedCards, AnimatedDrawerState, AnimatedMapWithDrawerController, CARD_MARGIN, CARD_WIDTH} from 'components/map/AnimatedCards';
 import {AvalancheCenterSelectionModal} from 'components/modals/AvalancheCenterSelectionModal';
@@ -30,6 +29,9 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import {HomeStackNavigationProps, TabNavigationProps} from 'routes';
 import {AvalancheCenterID, DangerLevel, ForecastPeriod, MapLayerFeature, ProductType} from 'types/nationalAvalancheCenter';
 import {formatRequestedTime, RequestedTime, requestedTimeToUTCDate, utcDateToLocalTimeString} from 'utils/date';
+
+import {Camera, CameraBounds} from '@rnmapbox/maps';
+import {Position} from '@turf/helpers';
 
 export interface MapProps {
   center: AvalancheCenterID;
@@ -60,22 +62,16 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
 
   const navigation = useNavigation<HomeStackNavigationProps & TabNavigationProps>();
   const [selectedZoneId, setSelectedZoneId] = useState<number | null>(null);
-  const onPressMapView = useCallback(
-    (event: ClickEvent) => {
-      // we seem to now get this event even if we're *also* getting a polygon press
-      // event, so we simply ignore the map press if it's inside a region
-      if (event.nativeEvent.coordinate && mapLayer && mapLayer.features) {
-        for (const feature of mapLayer.features) {
-          if (pointInFeature(event.nativeEvent.coordinate, feature)) {
-            return;
-          }
-        }
-      }
+
+  const onMapPress = useCallback(
+    (_: GeoJSON.Feature) => {
+      // Since the polygons are layered on the map, this is only called when the map is tapped outside of a polygon
       setSelectedZoneId(null);
     },
-    [mapLayer],
+    [setSelectedZoneId],
   );
-  const onPressPolygon = useCallback(
+
+  const onPolygonPress = useCallback(
     (zone: MapViewZone) => {
       if (selectedZoneId === zone.zone_id) {
         navigation.navigate('forecast', {
@@ -89,27 +85,15 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     },
     [navigation, selectedZoneId, requestedTime, setSelectedZoneId],
   );
-  // On the Android version of the Google Map layer, when a user taps on a map label (a place name, etc),
-  // we get a POI click event; we don't get to see the specific point that they tapped on, only the centroid
-  // of the POI itself. It doesn't look like we can turn off interactivity with POIs without hiding them entirely,
-  // so it seems like the best UX we can provide is to act as if the user tapped in the center of the POI itself
-  // and open the forecast zone for that point. When POI labels span multiple zones, that doesn't work perfectly.
-  const onPressPOI = useCallback(
-    (event: PoiClickEvent) => {
-      const matchingZones = event.nativeEvent.coordinate ? mapLayer?.features.filter(feature => pointInFeature(event.nativeEvent.coordinate, feature)) : [];
-      if (matchingZones && matchingZones.length > 0) {
-        onPressPolygon(mapViewZoneFor(center, matchingZones[0]));
-      }
-    },
-    [mapLayer?.features, onPressPolygon, center],
-  );
 
   const avalancheCenterMapRegion: Region = defaultMapRegionForGeometries(mapLayer?.features.map(feature => feature.geometry));
 
   // useRef has to be used here. Animation and gesture handlers can't use props and state,
   // and aren't re-evaluated on render. Fun!
-  const mapView = useRef<AnimatedMapView>(null);
-  const controller = useRef<AnimatedMapWithDrawerController>(new AnimatedMapWithDrawerController(AnimatedDrawerState.Hidden, avalancheCenterMapRegion, mapView, logger)).current;
+  const mapCameraRef = useRef<Camera>(null);
+  const controller = useRef<AnimatedMapWithDrawerController>(
+    new AnimatedMapWithDrawerController(AnimatedDrawerState.Hidden, avalancheCenterMapRegion, mapCameraRef, logger),
+  ).current;
   React.useEffect(() => {
     controller.animateUsingUpdatedAvalancheCenterMapRegion(avalancheCenterMapRegion);
   }, [avalancheCenterMapRegion, controller]);
@@ -246,22 +230,27 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     });
   const zones = Object.keys(zonesById).map(k => zonesById[k]);
   const showAvalancheCenterSelectionModal = !preferences.hasSeenCenterPicker;
+  const nePosition: Position = [
+    avalancheCenterMapRegion.longitude + avalancheCenterMapRegion.longitudeDelta / 2,
+    avalancheCenterMapRegion.latitude + avalancheCenterMapRegion.latitudeDelta / 2,
+  ];
+  const swPosition: Position = [
+    avalancheCenterMapRegion.longitude - avalancheCenterMapRegion.longitudeDelta / 2,
+    avalancheCenterMapRegion.latitude - avalancheCenterMapRegion.latitudeDelta / 2,
+  ];
+  const initialCameraBounds: CameraBounds = {ne: nePosition, sw: swPosition};
 
   return (
     <>
       <FocusAwareStatusBar barStyle="light-content" translucent backgroundColor={'rgba(0, 0, 0, 0.35)'} />
       <ZoneMap
-        ref={mapView}
-        animated
+        ref={mapCameraRef}
         style={StyleSheet.absoluteFillObject}
-        zoomEnabled={true}
-        scrollEnabled={true}
-        initialRegion={avalancheCenterMapRegion}
-        onPress={onPressMapView}
+        initialCameraBounds={initialCameraBounds}
         zones={zones}
         selectedZoneId={selectedZoneId}
-        onPressPolygon={onPressPolygon}
-        onPoiClick={onPressPOI}
+        onPolygonPress={onPolygonPress}
+        onMapPress={onMapPress}
       />
       <SafeAreaView>
         <View>

--- a/components/map/AnimatedMapMarker.tsx
+++ b/components/map/AnimatedMapMarker.tsx
@@ -1,0 +1,39 @@
+import {MarkerView} from '@rnmapbox/maps';
+import {Position} from '@turf/helpers';
+import React from 'react';
+import {Image} from 'react-native';
+import Animated, {Easing, useAnimatedProps, useSharedValue, withTiming} from 'react-native-reanimated';
+
+// Create an animated version of the MarkerView component
+const AnimatedMarkerView = Animated.createAnimatedComponent(MarkerView);
+
+export const AnimatedMapMarker: React.FunctionComponent<{id: string; coordinate: Position}> = ({id, coordinate}) => {
+  const longitude = useSharedValue(coordinate[0]);
+  const latitude = useSharedValue(coordinate[1]);
+
+  React.useEffect(() => {
+    longitude.value = withTiming(coordinate[0], {duration: 250, easing: Easing.linear});
+    latitude.value = withTiming(coordinate[1], {duration: 250, easing: Easing.linear});
+  }, [longitude, latitude, coordinate]);
+
+  // Define animated props for the coordinate
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      coordinate: [longitude.value, latitude.value],
+    };
+  }, [longitude, latitude]);
+
+  return (
+    <AnimatedMarkerView
+      id={id}
+      animatedProps={animatedProps}
+      coordinate={[longitude.value, latitude.value]}
+      anchor={{x: 0.5, y: 0.5}}
+      isSelected={false}
+      allowOverlap={false}
+      allowOverlapWithPuck={false}>
+      {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
+      <Image source={require('assets/map-marker.png')} style={{width: 40, height: 40}} />
+    </AnimatedMarkerView>
+  );
+};

--- a/components/map/AvalancheForecastZonePolygon.tsx
+++ b/components/map/AvalancheForecastZonePolygon.tsx
@@ -1,7 +1,9 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import {Animated} from 'react-native';
-import {LatLng, MapPolygonProps, Polygon, PolygonPressEvent} from 'react-native-maps';
+import {LatLng} from 'react-native-maps';
 
+import {LineLayer, Animated as MBAnimated, ShapeSource} from '@rnmapbox/maps';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {colorFor} from 'components/AvalancheDangerTriangle';
 import {MapViewZone} from 'components/content/ZoneMap';
 import {colorLookup} from 'theme';
@@ -30,21 +32,12 @@ export const toLatLngList = (geometry: Geometry | undefined): LatLng[][] => {
 
 export interface AvalancheForecastZonePolygonProps {
   zone: MapViewZone;
-  selected: boolean;
   renderFillColor: boolean;
   onPress?: (zone: MapViewZone) => void;
 }
 
-const AnimatedPolygon = Animated.createAnimatedComponent(Polygon);
-
-export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheForecastZonePolygonProps> = ({
-  zone,
-  selected,
-  onPress,
-  renderFillColor,
-}: AvalancheForecastZonePolygonProps) => {
+export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheForecastZonePolygonProps> = ({zone, onPress, renderFillColor}: AvalancheForecastZonePolygonProps) => {
   const outline = colorLookup('gray.700');
-  const highlight = colorLookup('blue.100');
   const useAnimation = zone.hasWarning && renderFillColor;
   const animationProgress = useRef(new Animated.Value(0)).current;
   useEffect(() => {
@@ -59,28 +52,19 @@ export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheFore
     }
   }, [animationProgress, useAnimation]);
 
-  const polygonProps: MapPolygonProps[] = toLatLngList(zone.feature.geometry).map(
-    (polygon): MapPolygonProps => ({
-      coordinates: polygon,
-      strokeColor: selected ? highlight.toString() : outline.toString(),
-      strokeWidth: selected ? 4 : 2,
-      tappable: onPress !== undefined,
-      zIndex: selected ? 1 : 0,
-      onPress: (event: PolygonPressEvent) => {
-        if (onPress) {
-          onPress(zone);
-
-          // By calling stopPropagation, we prevent this event from getting passed to the MapView's onPress handler,
-          // which would then clear the selection
-          // https://github.com/react-native-maps/react-native-maps/issues/1132
-          event.stopPropagation();
-        }
-      },
-    }),
+  const onPolygonPress = useCallback(
+    (_: OnPressEvent) => {
+      if (onPress) {
+        onPress(zone);
+      }
+    },
+    [zone, onPress],
   );
 
+  const fillOpacity = renderFillColor ? zone.fillOpacity : 0;
+  let fillColor: string | Animated.AnimatedInterpolation<string | number>;
   if (useAnimation) {
-    const fillColor = animationProgress.interpolate({
+    fillColor = animationProgress.interpolate({
       inputRange: [0, 1, 2, 3, 4, 5],
       outputRange: [
         colorFor(zone.danger_level).alpha(zone.fillOpacity).string(),
@@ -91,22 +75,24 @@ export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheFore
         colorFor(zone.danger_level).alpha(zone.fillOpacity).string(),
       ],
     });
-    return (
-      <>
-        {polygonProps.map((prop, idx) => (
-          <AnimatedPolygon key={idx} fillColor={fillColor} {...prop} />
-        ))}
-      </>
-    );
   } else {
-    const fillOpacity = renderFillColor ? zone.fillOpacity : 0;
-    const fillColor = colorFor(zone.danger_level).alpha(fillOpacity).string();
-    return (
-      <>
-        {polygonProps.map((prop, idx) => (
-          <Polygon key={idx} fillColor={fillColor} {...prop} />
-        ))}
-      </>
-    );
+    fillColor = colorFor(zone.danger_level).alpha(fillOpacity).string();
   }
+
+  return (
+    <ShapeSource key={`${zone.zone_id}`} id={`${zone.zone_id}`} shape={zone.feature} onPress={onPolygonPress} hitbox={{width: 0, height: 0}}>
+      <MBAnimated.FillLayer id={`${zone.zone_id}-fillLayer`} style={{fillColor: fillColor, visibility: renderFillColor ? 'visible' : 'none'}} />
+      <LineLayer id={`${zone.zone_id}-lineLayer`} style={{lineColor: outline.toString(), lineWidth: 2}} />
+    </ShapeSource>
+  );
+};
+
+export const SelectedAvalancheForecastZonePolygon: React.FunctionComponent<{zone: MapViewZone}> = ({zone}) => {
+  const highlight = colorLookup('blue.100');
+
+  return (
+    <ShapeSource key={`${zone.zone_id}-selected`} id={`${zone.zone_id}-selected`} shape={zone.feature}>
+      <LineLayer id={`${zone.zone_id}-lineLayer-selected`} style={{lineColor: highlight.toString(), lineWidth: 4}} />
+    </ShapeSource>
+  );
 };


### PR DESCRIPTION
This refactors the map views that show the polygons for the zone to use Mapbox. 
- #1071 

### Where to start
- `ZoneMap.tsx` and `AvalancheForecastZonePolygon.tsx`
    - These two files contain the bulk of the changes that relate to Mapbox. The rest of the files that were changed are mainly a result of these two

### Differences between `@rnmapbox` and `react-native-maps`
- Mapbox has the idea of a `Camera` component that controls what the user is looking at. The `Camera` is used to programmatically change what the user is seeing on the map. In `react-native-maps` this is done directly on the `MapView`
- Mapbox uses layers to create the polygons that are shown on the map. They can directly receive GeoJSON data so a lot of the preprocessing that we were doing is not longer needed
- The `z-index` of the layers is determined by the order in which they are rendered in. The last layer has the highest `z-index`
    - This is why there's a conditional render for the `SelectedAvalancheForecastZonePolygon` component so that it's always the last one rendered
 - Mapbox does not have the concept of `Region` that is used heavily with `react-native-maps`. This code will need to be refactored more. For now, the `Region` is being used to translate in the Mapbox equivalent of `CameraBounds`
- A lot of the `onPresses` that were passed to the `MapView` to handle different events are no longer required

### What's next
- Refactor the `WeatherStationMap.tsx`
    - #1075
- Refactor `Region` calculations and remove `react-native-maps`
    - #1072 
- Switch to the New Architecture
    - #1073 
