### PR TITLE
Temporary work around for card collapse issue on Android

### DIFF
--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -21,7 +21,7 @@ import {isArray} from 'lodash';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {usePostHog} from 'posthog-react-native';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {RefreshControl, ScrollView} from 'react-native';
+import {Platform, RefreshControl, ScrollView} from 'react-native';
 import {HomeStackParamList, TabNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {
@@ -166,7 +166,7 @@ export const NACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, reque
   }
 
   const adaptedWeatherForecast = center_id === 'SAC' ? adaptSierraWeatherForecast(weatherForecast) : weatherForecast;
-
+  const shouldStartCollapsed = Platform.OS === 'android';
   return (
     <ScrollView refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}>
       <VStack space={8} backgroundColor={colorLookup('primary.background')}>
@@ -196,11 +196,10 @@ export const NACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, reque
         {adaptedWeatherForecast.weather_discussion && (
           <CollapsibleCard
             identifier={'weatherSynopsis'}
-            marginTop={1}
             borderRadius={0}
             borderColor="white"
             header={<BodyBlack>Weather Discussion</BodyBlack>}
-            startsCollapsed={false}>
+            startsCollapsed={shouldStartCollapsed}>
             <HTML source={{html: adaptedWeatherForecast.weather_discussion}} />
           </CollapsibleCard>
         )}
@@ -792,6 +791,8 @@ export const BTACWeatherForecast: React.FunctionComponent<{forecast: RowColumnWe
     data: snowData,
   };
 
+  const shouldStartCollapsed = Platform.OS === 'android';
+
   return (
     <>
       <CollapsibleCard
@@ -800,7 +801,7 @@ export const BTACWeatherForecast: React.FunctionComponent<{forecast: RowColumnWe
         borderRadius={0}
         borderColor="white"
         header={<BodyBlack>Weather Discussion</BodyBlack>}
-        startsCollapsed={false}>
+        startsCollapsed={shouldStartCollapsed}>
         <Body>{forecast.data[weatherSynopsisRow][0].value}</Body>
       </CollapsibleCard>
       <ForecastPeriod periods={periods} />


### PR DESCRIPTION
- #886

There's some weird stuff going on with the `Collapsible` component from `react-native-collapsible` and it not rendering correctly on Android. There was a patch fix that was applied, but, for some reason, it doesn't work when the view that has the `CollapsedCard` component is shown as a part of the  top tab navigator that's on the `ForecastScreen`.

Specifically, it fails to render correctly when the card is a part of a view that is not the initial screen for the tab navigator.

This work around makes it so that the cards are collapsed on Android by default for the cards that are in the `WeatherTab`. The `AvalancheTab` doesn't have this issue because it's the initial screen. This is not a permanent fix as the issue is fixed with the New Architecture enabled