### PR TITLE
Refactor to use mapbox and remove react-native-maps

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,10 +15,8 @@ SENTRY_AUTH_TOKEN=
 EXPO_PUBLIC_SENTRY_DSN=
 
 #
-# These are embedded in the app via app.config.ts. Must be present to use maps. Not required for Expo Go.
+# This is embedded in the app via app.config.ts. Must be present to use maps
 #
-ANDROID_GOOGLE_MAPS_API_KEY=
-IOS_GOOGLE_MAPS_API_KEY=
 MAPBOX_API_KEY=
 
 #

--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,7 @@ import {PreferencesProvider, usePreferences} from 'Preferences';
 import {NotFoundError} from 'types/requests';
 import {formatRequestedTime, RequestedTime} from 'utils/date';
 
+import Mapbox from '@rnmapbox/maps';
 import {Integration} from '@sentry/types';
 import {TRACE} from 'browser-bunyan';
 import * as messages from 'compiled-lang/en.json';
@@ -65,6 +66,10 @@ import {startupUpdateCheck, UpdateStatus} from 'Updates';
 import {ZodError} from 'zod';
 
 logger.info('App starting.');
+
+Mapbox.setAccessToken(Constants.expoConfig?.extra?.mapboxAPIKey as string).catch((error: Error) => {
+  logger.error('Failed to initialize mapbox with error: ', error);
+});
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   logger.info('enabling android layout animations');

--- a/app.config.ts
+++ b/app.config.ts
@@ -7,8 +7,6 @@ export default ({config}: ConfigContext): Partial<ExpoConfig> => {
   // secrets can be stored in a .env file and loaded via direnv.
 
   // we're overwriting fields that were previously defined in app.json, so we know they're non-null:
-  config.ios!.config!.googleMapsApiKey = process.env.IOS_GOOGLE_MAPS_API_KEY as string;
-  config.android!.config!.googleMaps!.apiKey = process.env.ANDROID_GOOGLE_MAPS_API_KEY as string;
   config.extra!.mapboxAPIKey = process.env.MAPBOX_API_KEY as string;
   config.extra!.log_level = process.env.LOG_LEVEL != null ? (process.env.LOG_LEVEL as string) : 'info';
 

--- a/app.json
+++ b/app.json
@@ -26,9 +26,6 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "us.nwac.forecast",
-      "config": {
-        "googleMapsApiKey": "LOADED_FROM_ENVIRONMENT"
-      },
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": "NO",
         "NSPhotoLibraryUsageDescription": "The app is requesting access to the photo library to enable submission of avalanche observations that can include photos and/or video to provide context of an avalanche that was observed."
@@ -37,11 +34,6 @@
     },
     "android": {
       "package": "us.nwac.forecast",
-      "config": {
-        "googleMaps": {
-          "apiKey": "LOADED_FROM_ENVIRONMENT"
-        }
-      },
       "icon": "./assets/icon.png",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -2,17 +2,15 @@ import React, {useCallback, useRef, useState} from 'react';
 
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {View as RNView, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
-import AnimatedMapView, {ClickEvent, PoiClickEvent, Region} from 'react-native-maps';
 
 import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
 import {colorFor} from 'components/AvalancheDangerTriangle';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
-import {defaultMapRegionForGeometries, MapViewZone, mapViewZoneFor, ZoneMap} from 'components/content/ZoneMap';
+import {MapViewZone, mapViewZoneFor, ZoneMap} from 'components/content/ZoneMap';
 import {Center, HStack, View, VStack} from 'components/core';
 import {FocusAwareStatusBar} from 'components/core/FocusAwareStatusBar';
 import {DangerScale} from 'components/DangerScale';
-import {pointInFeature} from 'components/helpers/geographicCoordinates';
 import {TravelAdvice} from 'components/helpers/travelAdvice';
 import {AnimatedCards, AnimatedDrawerState, AnimatedMapWithDrawerController, CARD_MARGIN, CARD_WIDTH} from 'components/map/AnimatedCards';
 import {AvalancheCenterSelectionModal} from 'components/modals/AvalancheCenterSelectionModal';
@@ -30,6 +28,9 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import {HomeStackNavigationProps, TabNavigationProps} from 'routes';
 import {AvalancheCenterID, DangerLevel, ForecastPeriod, MapLayerFeature, ProductType} from 'types/nationalAvalancheCenter';
 import {formatRequestedTime, RequestedTime, requestedTimeToUTCDate, utcDateToLocalTimeString} from 'utils/date';
+
+import {Camera} from '@rnmapbox/maps';
+import {defaultMapRegionForGeometries} from 'components/helpers/geographicCoordinates';
 
 export interface MapProps {
   center: AvalancheCenterID;
@@ -60,22 +61,16 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
 
   const navigation = useNavigation<HomeStackNavigationProps & TabNavigationProps>();
   const [selectedZoneId, setSelectedZoneId] = useState<number | null>(null);
-  const onPressMapView = useCallback(
-    (event: ClickEvent) => {
-      // we seem to now get this event even if we're *also* getting a polygon press
-      // event, so we simply ignore the map press if it's inside a region
-      if (event.nativeEvent.coordinate && mapLayer && mapLayer.features) {
-        for (const feature of mapLayer.features) {
-          if (pointInFeature(event.nativeEvent.coordinate, feature)) {
-            return;
-          }
-        }
-      }
+
+  const onMapPress = useCallback(
+    (_: GeoJSON.Feature) => {
+      // Since the polygons are layered on the map, this is only called when the map is tapped outside of a polygon
       setSelectedZoneId(null);
     },
-    [mapLayer],
+    [setSelectedZoneId],
   );
-  const onPressPolygon = useCallback(
+
+  const onPolygonPress = useCallback(
     (zone: MapViewZone) => {
       if (selectedZoneId === zone.zone_id) {
         navigation.navigate('forecast', {
@@ -89,27 +84,15 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     },
     [navigation, selectedZoneId, requestedTime, setSelectedZoneId],
   );
-  // On the Android version of the Google Map layer, when a user taps on a map label (a place name, etc),
-  // we get a POI click event; we don't get to see the specific point that they tapped on, only the centroid
-  // of the POI itself. It doesn't look like we can turn off interactivity with POIs without hiding them entirely,
-  // so it seems like the best UX we can provide is to act as if the user tapped in the center of the POI itself
-  // and open the forecast zone for that point. When POI labels span multiple zones, that doesn't work perfectly.
-  const onPressPOI = useCallback(
-    (event: PoiClickEvent) => {
-      const matchingZones = event.nativeEvent.coordinate ? mapLayer?.features.filter(feature => pointInFeature(event.nativeEvent.coordinate, feature)) : [];
-      if (matchingZones && matchingZones.length > 0) {
-        onPressPolygon(mapViewZoneFor(center, matchingZones[0]));
-      }
-    },
-    [mapLayer?.features, onPressPolygon, center],
-  );
 
-  const avalancheCenterMapRegion: Region = defaultMapRegionForGeometries(mapLayer?.features.map(feature => feature.geometry));
+  const avalancheCenterMapRegion = defaultMapRegionForGeometries(mapLayer?.features.map(feature => feature.geometry));
 
   // useRef has to be used here. Animation and gesture handlers can't use props and state,
   // and aren't re-evaluated on render. Fun!
-  const mapView = useRef<AnimatedMapView>(null);
-  const controller = useRef<AnimatedMapWithDrawerController>(new AnimatedMapWithDrawerController(AnimatedDrawerState.Hidden, avalancheCenterMapRegion, mapView, logger)).current;
+  const mapCameraRef = useRef<Camera>(null);
+  const controller = useRef<AnimatedMapWithDrawerController>(
+    new AnimatedMapWithDrawerController(AnimatedDrawerState.Hidden, avalancheCenterMapRegion, mapCameraRef, logger),
+  ).current;
   React.useEffect(() => {
     controller.animateUsingUpdatedAvalancheCenterMapRegion(avalancheCenterMapRegion);
   }, [avalancheCenterMapRegion, controller]);
@@ -251,17 +234,13 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     <>
       <FocusAwareStatusBar barStyle="light-content" translucent backgroundColor={'rgba(0, 0, 0, 0.35)'} />
       <ZoneMap
-        ref={mapView}
-        animated
+        ref={mapCameraRef}
         style={StyleSheet.absoluteFillObject}
-        zoomEnabled={true}
-        scrollEnabled={true}
-        initialRegion={avalancheCenterMapRegion}
-        onPress={onPressMapView}
+        initialCameraBounds={avalancheCenterMapRegion.cameraBounds}
         zones={zones}
         selectedZoneId={selectedZoneId}
-        onPressPolygon={onPressPolygon}
-        onPoiClick={onPressPOI}
+        onPolygonPress={onPolygonPress}
+        onMapPress={onMapPress}
       />
       <SafeAreaView>
         <View>

--- a/components/content/ZoneMap.tsx
+++ b/components/content/ZoneMap.tsx
@@ -1,17 +1,9 @@
+import {AvalancheForecastZonePolygon, SelectedAvalancheForecastZonePolygon} from 'components/map/AvalancheForecastZonePolygon';
 import React from 'react';
+import {AvalancheCenterID, DangerLevel, MapLayerFeature} from 'types/nationalAvalancheCenter';
 
-import Constants, {AppOwnership} from 'expo-constants';
-import MapView, {MAP_TYPES, MapViewProps, PoiClickEvent, Region} from 'react-native-maps';
-
-import {RegionBounds, regionFromBounds, updateBoundsToContain} from 'components/helpers/geographicCoordinates';
-import {AvalancheForecastZonePolygon, toLatLngList} from 'components/map/AvalancheForecastZonePolygon';
-import {useToggle} from 'hooks/useToggle';
-import {AvalancheCenterID, DangerLevel, Geometry, MapLayerFeature} from 'types/nationalAvalancheCenter';
-
-const defaultAvalancheCenterMapRegionBounds: RegionBounds = {
-  topLeft: {latitude: 0, longitude: 0},
-  bottomRight: {latitude: 0, longitude: 0},
-};
+import Mapbox, {Camera, CameraBounds, MapView} from '@rnmapbox/maps';
+import {ViewProps} from 'react-native';
 
 export const mapViewZoneFor = (center: AvalancheCenterID, feature: MapLayerFeature): MapViewZone => {
   return {
@@ -39,43 +31,56 @@ export type MapViewZone = {
   hasWarning: boolean;
 };
 
-interface ZoneMapProps extends MapViewProps {
-  animated: boolean;
+interface ZoneMapProps extends ViewProps {
   zones: MapViewZone[];
+  initialCameraBounds: CameraBounds;
   selectedZoneId?: number | null;
   renderFillColor?: boolean;
-  onPressPolygon: (zone: MapViewZone) => void;
-  onPoiClick?: (event: PoiClickEvent) => void;
+  pitchEnabled?: boolean;
+  rotateEnabled?: boolean;
+  scrollEnabled?: boolean;
+  zoomEnabled?: boolean;
+  onPolygonPress?: (zone: MapViewZone) => void;
+  onMapPress?: (feature: GeoJSON.Feature) => void;
 }
 
-export const ZoneMap = React.forwardRef<MapView, ZoneMapProps>(({animated, zones, selectedZoneId, onPressPolygon, renderFillColor = true, children, ...props}, ref) => {
-  const [ready, {on: setReady}] = useToggle(false);
-  const MapComponent = animated ? MapView.Animated : MapView;
-  const isRunningInExpoGo = Constants.appOwnership === AppOwnership.Expo;
-
-  return (
-    <MapComponent ref={ref} onLayout={setReady} provider={isRunningInExpoGo ? undefined : 'google'} mapType={MAP_TYPES.TERRAIN} {...props}>
-      {ready &&
-        zones?.map(zone => (
-          <AvalancheForecastZonePolygon key={zone.zone_id} zone={zone} selected={selectedZoneId === zone.zone_id} renderFillColor={renderFillColor} onPress={onPressPolygon} />
+export const ZoneMap = React.forwardRef<Camera, ZoneMapProps>(
+  (
+    {
+      zones,
+      selectedZoneId,
+      initialCameraBounds,
+      renderFillColor = true,
+      pitchEnabled = true,
+      rotateEnabled = true,
+      scrollEnabled = true,
+      zoomEnabled = true,
+      onMapPress = undefined,
+      onPolygonPress = undefined,
+      children,
+      ...props
+    },
+    cameraRef,
+  ) => {
+    return (
+      <MapView
+        styleURL={Mapbox.StyleURL.Outdoors}
+        scaleBarEnabled={false}
+        zoomEnabled={zoomEnabled}
+        pitchEnabled={pitchEnabled}
+        rotateEnabled={rotateEnabled}
+        scrollEnabled={scrollEnabled}
+        onPress={onMapPress}
+        {...props}>
+        <Camera ref={cameraRef} defaultSettings={{bounds: initialCameraBounds}} />
+        {zones?.map(zone => (
+          <AvalancheForecastZonePolygon key={`${zone.zone_id}-polygon`} zone={zone} renderFillColor={renderFillColor} onPress={onPolygonPress} />
         ))}
-      {children}
-    </MapComponent>
-  );
-});
+        {selectedZoneId &&
+          zones?.filter(zone => zone.zone_id === selectedZoneId).map(zone => <SelectedAvalancheForecastZonePolygon key={`${zone.zone_id}-selectedPolygon`} zone={zone} />)}
+        {children}
+      </MapView>
+    );
+  },
+);
 ZoneMap.displayName = 'ZoneMap';
-
-export function defaultMapRegionForZones(zones: MapViewZone[]) {
-  return defaultMapRegionForGeometries(zones.map(zone => zone.feature.geometry));
-}
-
-export function defaultMapRegionForGeometries(geometries: (Geometry | undefined)[] | undefined) {
-  const avalancheCenterMapRegionBounds: RegionBounds = geometries
-    ? geometries.reduce((accumulator, currentValue) => updateBoundsToContain(accumulator, toLatLngList(currentValue).flat()), defaultAvalancheCenterMapRegionBounds)
-    : defaultAvalancheCenterMapRegionBounds;
-  const avalancheCenterMapRegion: Region = regionFromBounds(avalancheCenterMapRegionBounds);
-  // give the polygons a little buffer in the region so we don't render them at the outskirts of the screen
-  avalancheCenterMapRegion.latitudeDelta *= 1.05;
-  avalancheCenterMapRegion.longitudeDelta *= 1.05;
-  return avalancheCenterMapRegion;
-}

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -1,18 +1,20 @@
 import {AntDesign, FontAwesome} from '@expo/vector-icons';
+import {Camera} from '@rnmapbox/maps';
 import {QueryState, incompleteQueryState} from 'components/content/QueryState';
-import {MapViewZone, ZoneMap, defaultMapRegionForGeometries, defaultMapRegionForZones} from 'components/content/ZoneMap';
+import {MapViewZone, ZoneMap} from 'components/content/ZoneMap';
 import {Center, HStack, VStack, View} from 'components/core';
 import {KeysMatching} from 'components/form/TextField';
+import {AvalancheCenterRegion, defaultMapRegionForGeometries, defaultMapRegionForZones} from 'components/helpers/geographicCoordinates';
+import {AnimatedMapMarker} from 'components/map/AnimatedMapMarker';
 import {LocationPoint, ObservationFormData} from 'components/observations/ObservationFormData';
 import {Body, BodySmBlack, BodyXSm, Title3Black, bodySize} from 'components/text';
 import {useMapLayer} from 'hooks/useMapLayer';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useController} from 'react-hook-form';
-import {Modal, PanResponder, View as RNView, TouchableOpacity} from 'react-native';
-import MapView, {LatLng, MapMarker, Region} from 'react-native-maps';
+import {Modal, View as RNView, TouchableOpacity} from 'react-native';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
-import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
+import {AvalancheCenterID, Position} from 'types/nationalAvalancheCenter';
 
 interface LocationFieldProps {
   name: KeysMatching<ObservationFormData, LocationPoint>;
@@ -20,12 +22,8 @@ interface LocationFieldProps {
   center: AvalancheCenterID;
   disabled?: boolean;
 }
-
-const latLngToLocationPoint = (latLng: LatLng) => ({lat: latLng.latitude, lng: latLng.longitude});
-const locationPointToLatLng = (locationPoint: LocationPoint) => ({
-  latitude: locationPoint.lat,
-  longitude: locationPoint.lng,
-});
+const positionToLocationPoint = (position: Position) => ({lat: position[1], lng: position[0]});
+const locationPointToPosition = (locationPoint: LocationPoint) => [locationPoint.lng, locationPoint.lat];
 
 export const LocationField = React.forwardRef<RNView, LocationFieldProps>(({name, label, center, disabled}, ref) => {
   const {
@@ -86,44 +84,33 @@ interface LocationMapProps {
 const LocationMap: React.FunctionComponent<LocationMapProps> = ({center, modalVisible, initialLocation, onClose, onSelect}) => {
   const mapLayerResult = useMapLayer(center);
   const mapLayer = mapLayerResult.data;
-  const [initialRegion, setInitialRegion] = useState<Region>(defaultMapRegionForZones([]));
+  const [initialRegion, setInitialRegion] = useState<AvalancheCenterRegion>(defaultMapRegionForZones([]));
   const [selectedLocation, setSelectedLocation] = useState<LocationPoint | undefined>(initialLocation);
   const [mapReady, setMapReady] = useState<boolean>(false);
-  const mapRef = useRef<MapView>(null);
+  const mapCameraRef = useRef<Camera>(null);
 
-  const mapPanResponder = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderRelease: (event, gestureState) => {
-        if (gestureState.dx != 0 && gestureState.dy != 0) {
-          return;
-        }
-
-        void (async () => {
-          const point = {x: event.nativeEvent.locationX, y: event.nativeEvent.locationY};
-          const coordinate = await mapRef.current?.coordinateForPoint(point);
-          if (coordinate) {
-            setSelectedLocation(latLngToLocationPoint(coordinate));
-          }
-        })();
-      },
-    }),
-  ).current;
+  const onMapPress = useCallback(
+    (feature: GeoJSON.Feature) => {
+      if (feature.geometry.type === 'Point') {
+        setSelectedLocation(positionToLocationPoint(feature.geometry.coordinates));
+      }
+    },
+    [setSelectedLocation],
+  );
 
   useEffect(() => {
     if (mapLayer && !mapReady) {
       const location: LocationPoint = initialLocation || {lat: 0, lng: 0};
       const initialRegion = defaultMapRegionForGeometries(mapLayer.features.map(feature => feature.geometry));
       if (location.lat !== 0 && location.lng !== 0) {
-        initialRegion.latitude = location.lat;
-        initialRegion.longitude = location.lng;
+        initialRegion.centerCoordinate.latitude = location.lat;
+        initialRegion.centerCoordinate.longitude = location.lng;
       }
 
       setInitialRegion(initialRegion);
       setMapReady(true);
     }
-  }, [initialLocation, mapLayer, setInitialRegion, mapReady, setMapReady]);
+  }, [initialLocation, mapLayer, mapCameraRef, setInitialRegion, mapReady, setMapReady]);
 
   const zones: MapViewZone[] =
     mapLayer?.features.map(
@@ -177,18 +164,16 @@ const LocationMap: React.FunctionComponent<LocationMapProps> = ({center, modalVi
             <Center width="100%" height="100%">
               {incompleteQueryState(mapLayerResult) && <QueryState results={[mapLayerResult]} />}
               {mapReady && (
-                <View {...mapPanResponder.panHandlers}>
-                  <ZoneMap
-                    ref={mapRef}
-                    animated={false}
-                    style={{minWidth: '100%', minHeight: '100%'}}
-                    zones={zones}
-                    initialRegion={initialRegion}
-                    onPressPolygon={emptyHandler}
-                    renderFillColor={false}>
-                    {selectedLocation != null && <MapMarker coordinate={locationPointToLatLng(selectedLocation)} />}
-                  </ZoneMap>
-                </View>
+                <ZoneMap
+                  ref={mapCameraRef}
+                  style={{minWidth: '100%', minHeight: '100%'}}
+                  zones={zones}
+                  initialCameraBounds={initialRegion.cameraBounds}
+                  onPolygonPress={emptyHandler}
+                  onMapPress={onMapPress}
+                  renderFillColor={false}>
+                  {selectedLocation && <AnimatedMapMarker id="obs-location-marker" coordinate={locationPointToPosition(selectedLocation)} />}
+                </ZoneMap>
               )}
             </Center>
           </VStack>
@@ -197,4 +182,5 @@ const LocationMap: React.FunctionComponent<LocationMapProps> = ({center, modalVi
     </Modal>
   );
 };
+
 LocationField.displayName = 'LocationField';

--- a/components/helpers/geographicCoordinates.test.ts
+++ b/components/helpers/geographicCoordinates.test.ts
@@ -1,75 +1,75 @@
-import {boundsForRegions, RegionBounds, regionFromBounds, updateBoundsToContain} from 'components/helpers/geographicCoordinates';
-import {LatLng} from 'react-native-maps';
+import {AvalancheCenterRegion, avalancheCenterRegionFromRegionBounds, boundsForRegions, RegionBounds, updateBoundsToContain} from 'components/helpers/geographicCoordinates';
+import {Position} from 'types/nationalAvalancheCenter';
 
 describe('AvalancheForecastZonePolygon', () => {
   describe('updateRegionToContain', () => {
     it('returns the region bounds unchanged when no coordinates are provided', () => {
       const bounds: RegionBounds = {
-        topLeft: {latitude: 1, longitude: 1},
-        bottomRight: {latitude: 2, longitude: 2},
+        topRight: {longitude: 1, latitude: 1},
+        bottomLeft: {longitude: 2, latitude: 2},
       };
-      const coordinates: LatLng[] = [];
+      const coordinates: Position[] = [];
       expect(updateBoundsToContain(bounds, coordinates)).toStrictEqual({
-        topLeft: {latitude: 1, longitude: 1},
-        bottomRight: {latitude: 2, longitude: 2},
+        topRight: {longitude: 1, latitude: 1},
+        bottomLeft: {longitude: 2, latitude: 2},
       });
     });
 
     it('initializes an empty region bound', () => {
       const bounds: RegionBounds = {
-        topLeft: {latitude: 0, longitude: 0},
-        bottomRight: {latitude: 0, longitude: 0},
+        topRight: {longitude: 0, latitude: 0},
+        bottomLeft: {longitude: 0, latitude: 0},
       };
-      const coordinates: LatLng[] = [{latitude: 1, longitude: 1}];
+      const coordinates: Position[] = [[1, 1]];
 
       const updated: RegionBounds = updateBoundsToContain(bounds, coordinates);
       expect(updated).toStrictEqual({
-        topLeft: {latitude: 1, longitude: 1},
-        bottomRight: {latitude: 1, longitude: 1},
+        topRight: {longitude: 1, latitude: 1},
+        bottomLeft: {longitude: 1, latitude: 1},
       });
 
       expect(bounds).not.toStrictEqual(updated); // should not mutate input
     });
 
-    const coordinates: LatLng[] = [
-      {longitude: -121.9298, latitude: 45.2792},
-      {longitude: -121.952, latitude: 45.326},
-      {longitude: -121.9315, latitude: 45.3659},
-      {longitude: -121.8805, latitude: 45.4445},
-      {longitude: -121.8473, latitude: 45.4646},
-      {longitude: -121.8032, latitude: 45.4794},
-      {longitude: -121.7216, latitude: 45.4921},
-      {longitude: -121.6435, latitude: 45.4839},
-      {longitude: -121.5219, latitude: 45.4578},
-      {longitude: -121.431, latitude: 45.3475},
-      {longitude: -121.477, latitude: 45.2279},
-      {longitude: -121.5565, latitude: 45.2055},
-      {longitude: -121.623, latitude: 45.1939},
-      {longitude: -121.7036, latitude: 45.1916},
-      {longitude: -121.8579, latitude: 45.2292},
-      {longitude: -121.92, latitude: 45.2646},
-      {longitude: -121.9298, latitude: 45.2792},
+    const coordinates: Position[] = [
+      [-121.9298, 45.2792],
+      [-121.952, 45.326],
+      [-121.9315, 45.3659],
+      [-121.8805, 45.4445],
+      [-121.8473, 45.4646],
+      [-121.8032, 45.4794],
+      [-121.7216, 45.4921],
+      [-121.6435, 45.4839],
+      [-121.5219, 45.4578],
+      [-121.431, 45.3475],
+      [-121.477, 45.2279],
+      [-121.5565, 45.2055],
+      [-121.623, 45.1939],
+      [-121.7036, 45.1916],
+      [-121.8579, 45.2292],
+      [-121.92, 45.2646],
+      [-121.9298, 45.2792],
     ];
 
-    // for the US, the "top left" corner of a map will have the largest latitude and smallest longitude
-    // similarly, the "bottom right" will have the smallest latitude and largest longitude
+    // for the US, the "top right" corner of a map will have the largest latitude and largest longitude
+    // similarly, the "bottom left" will have the smallest latitude and smallest longitude
     const regionBounds: RegionBounds = {
-      topLeft: {latitude: 45.4921, longitude: -121.952},
-      bottomRight: {latitude: 45.1916, longitude: -121.431},
+      topRight: {longitude: -121.431, latitude: 45.4921},
+      bottomLeft: {longitude: -121.952, latitude: 45.1916},
     };
 
     it('minimally bounds all coordinates with the region', () => {
       const bounds: RegionBounds = {
-        topLeft: {latitude: 0, longitude: 0},
-        bottomRight: {latitude: 0, longitude: 0},
+        topRight: {longitude: 0, latitude: 0},
+        bottomLeft: {longitude: 0, latitude: 0},
       };
       expect(updateBoundsToContain(bounds, coordinates)).toStrictEqual(regionBounds);
     });
 
     it('arrives at the same result regardless of how many iterations it takes to apply all coordinates', () => {
       const bounds: RegionBounds = {
-        topLeft: {latitude: 0, longitude: 0},
-        bottomRight: {latitude: 0, longitude: 0},
+        topRight: {longitude: 0, latitude: 0},
+        bottomLeft: {longitude: 0, latitude: 0},
       };
 
       const firstPass = updateBoundsToContain(bounds, coordinates.slice(0, 5));
@@ -82,15 +82,22 @@ describe('AvalancheForecastZonePolygon', () => {
   describe('regionFromBounds', () => {
     it('returns the region from bounds', () => {
       const bounds: RegionBounds = {
-        topLeft: {latitude: 0, longitude: 0},
-        bottomRight: {latitude: 2, longitude: 2},
+        topRight: {longitude: 0, latitude: 0},
+        bottomLeft: {longitude: 2, latitude: 2},
       };
-      expect(regionFromBounds(bounds)).toStrictEqual({
-        latitude: 1,
-        longitude: 1,
+      const expectedAvalancheCenterRegion: AvalancheCenterRegion = {
+        centerCoordinate: {
+          latitude: 1,
+          longitude: 1,
+        },
         latitudeDelta: 2,
         longitudeDelta: 2,
-      });
+        cameraBounds: {
+          ne: [2, 2],
+          sw: [0, 0],
+        },
+      };
+      expect(avalancheCenterRegionFromRegionBounds(bounds)).toStrictEqual(expectedAvalancheCenterRegion);
     });
   });
 
@@ -98,17 +105,17 @@ describe('AvalancheForecastZonePolygon', () => {
     it('calculates the total bounding box for multiple regions', () => {
       const regions = [
         {
-          topLeft: {latitude: 20, longitude: -100},
-          bottomRight: {latitude: 10, longitude: -50},
+          topRight: {longitude: -50, latitude: 20},
+          bottomLeft: {longitude: -100, latitude: 10},
         },
         {
-          topLeft: {latitude: 40, longitude: -110},
-          bottomRight: {latitude: 15, longitude: -75},
+          topRight: {longitude: -75, latitude: 40},
+          bottomLeft: {longitude: -110, latitude: 15},
         },
       ];
       expect(boundsForRegions(regions)).toStrictEqual({
-        topLeft: {latitude: 40, longitude: -110},
-        bottomRight: {latitude: 10, longitude: -50},
+        topRight: {longitude: -50, latitude: 40},
+        bottomLeft: {longitude: -110, latitude: 10},
       });
     });
   });

--- a/components/map/AnimatedMapMarker.tsx
+++ b/components/map/AnimatedMapMarker.tsx
@@ -1,0 +1,39 @@
+import {MarkerView} from '@rnmapbox/maps';
+import React from 'react';
+import {Image} from 'react-native';
+import Animated, {Easing, useAnimatedProps, useSharedValue, withTiming} from 'react-native-reanimated';
+import {Position} from 'types/nationalAvalancheCenter';
+
+// Create an animated version of the MarkerView component
+const AnimatedMarkerView = Animated.createAnimatedComponent(MarkerView);
+
+export const AnimatedMapMarker: React.FunctionComponent<{id: string; coordinate: Position}> = ({id, coordinate}) => {
+  const longitude = useSharedValue(coordinate[0]);
+  const latitude = useSharedValue(coordinate[1]);
+
+  React.useEffect(() => {
+    longitude.value = withTiming(coordinate[0], {duration: 250, easing: Easing.linear});
+    latitude.value = withTiming(coordinate[1], {duration: 250, easing: Easing.linear});
+  }, [longitude, latitude, coordinate]);
+
+  // Define animated props for the coordinate
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      coordinate: [longitude.value, latitude.value],
+    };
+  }, [longitude, latitude]);
+
+  return (
+    <AnimatedMarkerView
+      id={id}
+      animatedProps={animatedProps}
+      coordinate={[longitude.value, latitude.value]}
+      anchor={{x: 0.5, y: 0.5}}
+      isSelected={false}
+      allowOverlap={false}
+      allowOverlapWithPuck={false}>
+      {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
+      <Image source={require('assets/map-marker.png')} style={{width: 40, height: 40}} />
+    </AnimatedMarkerView>
+  );
+};

--- a/components/weather_data/NWACWeatherStationList.tsx
+++ b/components/weather_data/NWACWeatherStationList.tsx
@@ -82,15 +82,7 @@ export const NWACStationsByZone = (mapLayer: MapLayer | undefined, stations: Wea
       if (!s.latitude || !s.longitude) {
         return;
       }
-      const matchingZones = zones.filter(zoneData =>
-        pointInFeature(
-          {
-            latitude: s.latitude,
-            longitude: s.longitude,
-          },
-          zoneData.feature,
-        ),
-      );
+      const matchingZones = zones.filter(zoneData => pointInFeature([s.longitude, s.latitude], zoneData.feature));
       const stationLogger = logger.child({
         station: {
           id: s.id,

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "react-native-collapsible": "^1.6.0",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-logs": "^5.0.1",
-    "react-native-maps": "1.18.0",
     "react-native-pager-view": "6.5.1",
     "react-native-reanimated": "~3.16.1",
     "react-native-render-html": "^6.3.4",

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -1186,6 +1186,12 @@ export const nwacObservationResultSchema = z.object({
 });
 export type NWACObservationResult = z.infer<typeof nwacObservationResultSchema>;
 
+export const avyPositionSchema = z.object({
+  longitude: z.number(),
+  latitude: z.number(),
+});
+export type AvyPosition = z.infer<typeof avyPositionSchema>;
+
 export const bBoxSchema = z.union([z.tuple([z.number(), z.number(), z.number(), z.number()]), z.tuple([z.number(), z.number(), z.number(), z.number(), z.number(), z.number()])]);
 export type BBox = z.infer<typeof bBoxSchema>;
 
@@ -1295,6 +1301,17 @@ export const WeatherStationSource = {
   SNOTEL: 'snotel',
 } as const;
 export type WeatherStationSource = (typeof WeatherStationSource)[keyof typeof WeatherStationSource];
+
+export const StationColorNameForSource = (source: WeatherStationSource) => {
+  switch (source) {
+    case WeatherStationSource.NWAC:
+      return 'weather.nwac.primary';
+    case WeatherStationSource.SNOTEL:
+      return 'weather.snotel.primary';
+    case WeatherStationSource.MESOWEST:
+      return 'weather.mesowest.primary';
+  }
+};
 
 export const NWACWeatherStationStatus = {
   Active: 'active',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,7 +3202,7 @@
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
   integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
 
-"@types/geojson@^7946.0.10", "@types/geojson@^7946.0.13":
+"@types/geojson@^7946.0.10":
   version "7946.0.14"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
   integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
@@ -9898,13 +9898,6 @@ react-native-logs@^5.0.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/react-native-logs/-/react-native-logs-5.3.0.tgz#49ad1ec1fd37a5ef90280cc3e27e7233727fc921"
   integrity sha512-tq4S0JFy06ggu1D/udYeV80qPy5koURNNcKrVJmv0Hf3x44akysctaE4ARybD5Pv7MnFD8fP1VFhycSLjqXHQw==
-
-react-native-maps@1.18.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.18.0.tgz#48d253041a9baa5606b4f3647043d660a93b3b01"
-  integrity sha512-S17nYUqeMptgIPaAZuVRo+eRelPreBBYQWw6jsxU7qQ12p+THSfFaqabcNn7fBmsXhT3T27iIl8ek8v1H8BaGw==
-  dependencies:
-    "@types/geojson" "^7946.0.13"
 
 react-native-pager-view@6.5.1:
   version "6.5.1"


### PR DESCRIPTION
This PR brings in mapbox, refactors the views that heavily used the old `<MapView/>`, and removes `react-native-maps`
- #1071 
- #1075
- #1072

### Where to start
- `ZoneMap.tsx` and `AvalancheForecastZonePolygon.tsx`
    - These two files contain the bulk of the changes that relate to Mapbox. The rest of the files that were changed are mainly a result of these two

### Differences between `@rnmapbox` and `react-native-maps`
- Mapbox has the idea of a `Camera` component that controls what the user is looking at. The `Camera` is used to programmatically change what the user is seeing on the map. In `react-native-maps` this is done directly on the `MapView`
- Mapbox uses layers to create the polygons that are shown on the map. They can directly receive GeoJSON data so a lot of the preprocessing that we were doing is not longer needed
- The `z-index` of the layers is determined by the order in which they are rendered in. The last layer has the highest `z-index`
    - This is why there's a conditional render for the `SelectedAvalancheForecastZonePolygon` component so that it's always the last one rendered
 - Mapbox does not have the concept of `Region` that is used heavily with `react-native-maps`. `Region` is refactored to be `AvalancheCenterRegion`. This allows a lot of the old calculations to remain the same and includes `CameraBounds` so that the view can be correctly positioned
 - Mapbox also heavily uses the GeoJSON concept of `Position` which is just a `number[]` where the first index is the longitude and the second is the latitude
- A lot of the `onPresses` that were passed to the `MapView` to handle different events are no longer required

### What's next
- Switch to the New Architecture
    - #1073 