### PR TITLE
Update Zone Colors to be consistent with NAC

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -377,15 +377,10 @@ const DangerLevelTitle: React.FunctionComponent<{
 }> = ({dangerLevel}) => {
   switch (dangerLevel) {
     case DangerLevel.GeneralInformation:
-      return (
-        <BodySmSemibold>
-          <Text style={{textTransform: 'capitalize'}}>General Information</Text>
-        </BodySmSemibold>
-      );
     case DangerLevel.None:
       return (
         <BodySmSemibold>
-          <Text style={{textTransform: 'capitalize'}}>None</Text>
+          <Text style={{textTransform: 'capitalize'}}>No Rating</Text>
         </BodySmSemibold>
       );
     case DangerLevel.Low:


### PR DESCRIPTION
- #1064 
This PR brings our zone colors in line with what is on the NAC widget when it comes to whether a zone should be blue or grey

Grey: Out of Season
Blue: Information Exchange, General Avalanche Information product (current or expired), expired forecast.