### PR TITLE
Update dev host for snowobs and remove Sentry logging for dev builds

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -164,7 +164,7 @@ if (Sentry?.init) {
       // Example: 1.0.0.54
       dist: `${Application.nativeApplicationVersion || '0.0.0'}.${Application.nativeBuildVersion || '0'}`,
       release: process.env.EXPO_PUBLIC_GIT_REVISION as string,
-      enabled: !!Updates.channel || Boolean(process.env.EXPO_PUBLIC_SENTRY_IN_DEV),
+      enabled: !!Updates.channel && Updates.channel !== '',
       enableWatchdogTerminationTracking: true,
       integrations: [routingInstrumentation],
       beforeSend: async (event, hint) => {

--- a/clientContext.ts
+++ b/clientContext.ts
@@ -20,8 +20,7 @@ export const productionHosts = {
 export const stagingHosts = {
   nationalAvalancheCenterHost: 'https://staging-api.avalanche.org',
   nationalAvalancheCenterWordpressHost: 'https://devavycenters.wpengine.com',
-  // TODO(brian): what's the Staging version for Snowbound?
-  snowboundHost: 'https://api.snowobs.com',
+  snowboundHost: 'https://dev.snowobs.com',
   nwacHost: 'https://staging.nwac.us',
 };
 


### PR DESCRIPTION
This changes the snowobs host to `dev.snowobs.com` when the staging environment flag is turned on.

This also prevents Sentry from logging if you're on a local dev build. There's not really a point to log from the local dev build since all the crash reporting and errors are shown in the terminal/on the app. I decided to do this based off of the `enabled` flag instead of the skipping the initialization because the app is wrapped in a `Sentry.wrap` call that requires `Sentry` to be initialized. There's nothing that really happens if you don't initialize it, but this seems like the more correct way to turn it off.