### PR TITLE
Remove videos from image picker options

### DIFF
--- a/components/form/ImageCaptionField.tsx
+++ b/components/form/ImageCaptionField.tsx
@@ -86,7 +86,7 @@ const useImagePicker = ({images, maxImageCount, disable, onSaveImages}: ImagePic
         const result = await ImagePicker.launchImageLibraryAsync({
           allowsMultipleSelection: true,
           exif: true,
-          mediaTypes: ['images', 'videos', 'livePhotos'],
+          mediaTypes: ['images', 'livePhotos'],
           preferredAssetRepresentationMode: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
           quality: 0.9,
           selectionLimit: maxImageCount - imageCount,


### PR DESCRIPTION
Videos are unsupported for direct upload to the AFP. They only support external links like ones to Youtube, Instagram, etc.

Live Photos are uploaded as normal photos so that's okay to still be there.