### PR TITLE
Create new WIP pipeline

### DIFF
--- a/.github/workflows/publish-WIP-preview-build.yaml
+++ b/.github/workflows/publish-WIP-preview-build.yaml
@@ -1,4 +1,4 @@
-name: publish-build
+name: publish-WIP-preview-build
 on:
   workflow_dispatch: {}
 
@@ -24,6 +24,6 @@ jobs:
           IOS_USER_ID: ${{ secrets.IOS_USER_ID }}
           IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
           IOS_APP_ID: ${{ secrets.IOS_APP_ID }}
-          PROFILE: ${{ github.ref_name }}
+          PROFILE: 'preview'
           PLATFORM: 'all'
         run: ./eas_build_and_submit.sh


### PR DESCRIPTION
This adds a new yaml file to create a new workflow that will allow us to publish builds to Preview off of any branch.

The `publish_build` pipeline uses the branch name to determine the profile to send to EAS. This pipeline copies that workflow and hardcodes `profile` to `preview`.

The main reason for this is so that we can test the map project on iOS with Preview builds both internally and to be able to have external parties test it. We're currently not set up well to make dev iOS builds on EAS as those require your device to be registered in a provisioning profile.