### PR TITLE
Remove battery voltage and soil temp from weather table

### DIFF
--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -70,7 +70,6 @@ const shortFieldMap: Record<string, string> = {
   intermittent_snow: 'I/S_Sno',
   net_solar: 'SR',
   solar_radiation: 'SR',
-  battery_voltage: 'Battery',
 };
 
 const shortField = (field: string): string => shortFieldMap[field] || field;
@@ -81,10 +80,13 @@ const shortUnitsMap: Record<string, string> = {
   degrees: 'deg',
   millibar: 'mbar',
   'MJ/m**2': 'MJ/m²',
-  volt: 'V',
 };
 
 const shortUnits = (units: string): string => shortUnitsMap[units] || units;
+
+// Don't display any of the following fields. Soil temperature can be one of soil_temperature_a/b/c
+const shouldSkipField = (fieldName: string): boolean =>
+  fieldName === 'date_time' || fieldName === 'solar_radiation' || fieldName === 'battery_voltage' || fieldName.includes('soil_temperature');
 
 const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({timeSeries}) => {
   type Column = {
@@ -102,12 +104,7 @@ const TimeSeriesTable: React.FC<{timeSeries: WeatherStationTimeseries}> = ({time
           continue; // can't record this time-less value
         }
         for (const [field, value] of Object.entries(observation)) {
-          if (field === 'date_time') {
-            // don't add station-specific date time columns
-            continue;
-          }
-          if (field === 'solar_radiation') {
-            // we don't display solar_radiation, only net_solar
+          if (shouldSkipField(field)) {
             continue;
           }
           if (!dataByTimeByField[field]) {


### PR DESCRIPTION
This remove battery voltage and soil temp from the NWAC weather station data table.
- #1095 

|Before|After|
|---|---|
|<img width="230" height="500" alt="Screenshot 2026-02-19 at 4 15 38 PM" src="https://github.com/user-attachments/assets/8584ef11-c086-4bbe-8656-684683b51eaa" />|<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-19 at 16 15 34" src="https://github.com/user-attachments/assets/a440b86f-36f7-4af5-93ec-7d26930aa653" />|
