### PR TITLE
Adjust the stale and cacheTimes of useAvalancheCenterMetadata

### DIFF
--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -25,7 +25,8 @@ export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID): UseQue
   return useQuery<AvalancheCenter, AxiosError | ZodError>({
     queryKey: key,
     queryFn: async (): Promise<AvalancheCenter> => fetchAvalancheCenterMetadata(nationalAvalancheCenterHost, center_id, thisLogger),
-    cacheTime: Infinity, // hold on to this cached data forever
+    cacheTime: 24 * 60 * 60 * 1000, // hold on to inactive query data for 1 day
+    staleTime: 24 * 60 * 80 * 1000, // don't bother fetching again for a day
   });
 };
 
@@ -47,7 +48,7 @@ export const prefetchAvalancheCenterMetadata = async (queryClient: QueryClient, 
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
-    cacheTime: Infinity, // hold this in the query cache forever
+    cacheTime: 24 * 60 * 60 * 1000,
     staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
   });
 };


### PR DESCRIPTION
This is an attempt at trying to fix
- #1023 

Every once and awhile we get alerts about avalanche centers not containing certain zones. This always seems to be an issue with the avalanche center metadata not containing the zone that it needs.

The 2 situations where I think this arises are:
1. A user hasn't used the app in a long time
2. A user switches to a center that they don't often visit

The reason why this could happen is that when the user opens the app for the first time, the metadata for every single center is prefetched and held onto forever. This means that it's possible for ReactQuery to give us data from the cache that hasn't been updated in a really long time and for the map-layer call and the metadata for the center to be out of sync.

By updating `cacheTime` here to 1 day we're letting ReactQuery know that it's okay to garbage collect the data for the query after 1 day of inactivity.

`cacheTime` and `staleTime` are confusing and in TanStack Query (ReactQuery) v5 they actually renamed `cacheTime` to `gcTime` (garbage collection time) to more accurately reflect what it does.

## Quick Overview

`staleTime` controls the fetching strategy for the query call. The default is `0` which means that immediately after fetching the data is marked as stale. *This does not impact keeping/removing data from the cache*. What this does is let the query know that fresh data needs to be fetched in the background. It immediately serves the data in the cache from previous calls, if there already is data, and updates it in the background. By setting it to 1 day here we're telling ReactQuery to not make any more calls to refetch the data for 1 day.

`cacheTime` only comes into play when a query has become *inactive*. This means that no views in the stack are currently relying on the data. While a query is active, the data is always cached. By setting it to 1 day here, we're letting ReactQuery know that it's safe to remove this data after 1 day of it not being used at all. It makes sense to me to remove data from centers that may never be shown. We refetch the data when the user is shown the Avalanche Center Selector at which point seeing a loading screen there is better than seeing "This zone doesn't exist"

We might need to go through other areas of the app to see if `cacheTime: Infinity` should be removed in other areas. It could be leading to memory leak issues as we use it in a lot of queries