### PR TITLE
Create MediaPreview Component

### DIFF
--- a/components/AvalancheProblemCard.tsx
+++ b/components/AvalancheProblemCard.tsx
@@ -5,7 +5,7 @@ import {AvalancheProblemLikelihoodLine} from 'components/AvalancheProblemLikelih
 import {AvalancheProblemSizeLine} from 'components/AvalancheProblemSizeLine';
 import {AnnotatedDangerRose} from 'components/DangerRose';
 import {Card, CardProps} from 'components/content/Card';
-import {MediaCarousel} from 'components/content/carousel/MediaCarousel';
+import {MediaPreview} from 'components/content/carousel/MediaPreview';
 import {Center, HStack, VStack} from 'components/core';
 import {AllCapsSm, Caption1Semibold, allCapsSmLineHeight} from 'components/text';
 import {HTML} from 'components/text/HTML';
@@ -76,9 +76,7 @@ export const AvalancheProblemCard: React.FunctionComponent<AvalancheProblemCardP
         />
       </HStack>
       {problem.discussion && <HTML source={{html: problem.discussion}} />}
-      {problem.media && cardWidth > 0 && (
-        <MediaCarousel mediaItems={[problem.media]} thumbnailAspectRatio={1.3} thumbnailHeight={cardWidth / 1.3} displayCaptionsWithThumbnails={true} />
-      )}
+      {problem.media && cardWidth > 0 && <MediaPreview mediaItem={problem.media} thumbnailAspectRatio={1.3} thumbnailHeight={cardWidth / 1.3} />}
     </VStack>
   );
 };

--- a/components/content/carousel/MediaCarousel.tsx
+++ b/components/content/carousel/MediaCarousel.tsx
@@ -21,18 +21,9 @@ export interface MediaCarouselProps extends ViewProps {
   thumbnailHeight: number;
   thumbnailAspectRatio?: number;
   mediaItems: MediaItem[];
-  displayCaptionsWithThumbnails?: boolean;
 }
 
-// The default for displayCaptionsWithThumbnails is set to false as it's only used for AvalancheProblemCard.
-// There will be a new component that handles this. That work is being tracked in issue 1066
-export const MediaCarousel: React.FunctionComponent<PropsWithChildren<MediaCarouselProps>> = ({
-  thumbnailHeight,
-  thumbnailAspectRatio = 1.3,
-  mediaItems,
-  displayCaptionsWithThumbnails = false,
-  ...props
-}) => {
+export const MediaCarousel: React.FunctionComponent<PropsWithChildren<MediaCarouselProps>> = ({thumbnailHeight, thumbnailAspectRatio = 1.3, mediaItems, ...props}) => {
   const thumbnailWidth = thumbnailAspectRatio * thumbnailHeight;
 
   const [modalIndex, setModalIndex] = useState<number | null>(null);
@@ -48,14 +39,7 @@ export const MediaCarousel: React.FunctionComponent<PropsWithChildren<MediaCarou
 
   return (
     <View {...props}>
-      <ThumbnailList
-        imageWidth={thumbnailWidth}
-        imageHeight={thumbnailHeight}
-        mediaItems={mediaItems}
-        displayCaptions={displayCaptionsWithThumbnails}
-        onPress={onPress}
-        imageStyle={{borderRadius: 4}}
-      />
+      <ThumbnailList imageWidth={thumbnailWidth} imageHeight={thumbnailHeight} mediaItems={mediaItems} onPress={onPress} imageStyle={{borderRadius: 4}} />
       <MediaViewerModal visible={modalIndex !== null} startIndex={modalIndex ?? 0} mediaItems={mediaItems} onClose={onClose} />
     </View>
   );

--- a/components/content/carousel/MediaPreview.tsx
+++ b/components/content/carousel/MediaPreview.tsx
@@ -1,0 +1,70 @@
+import {MediaViewerModal} from 'components/content/carousel/MediaViewerModal/MediaViewerModal';
+import {NetworkImage} from 'components/content/carousel/NetworkImage';
+import {imageToThumbnailListItem, ThumbnailListItem, videoToThumbnailListItem} from 'components/content/carousel/ThumbnailList';
+import {InternalError} from 'components/content/QueryState';
+import {View, ViewProps, VStack} from 'components/core';
+import {HTML, HTMLRendererConfig} from 'components/text/HTML';
+import React, {useCallback, useMemo, useState} from 'react';
+import {MediaItem, MediaType} from 'types/nationalAvalancheCenter';
+
+const thumbnailListItem = (mediaItem: MediaItem): ThumbnailListItem | undefined => {
+  const isYouTubeVideo = mediaItem.type === MediaType.Video && typeof mediaItem.url !== 'string' && !('external_link' in mediaItem.url);
+  if (isYouTubeVideo) {
+    return videoToThumbnailListItem(mediaItem);
+  }
+
+  if (mediaItem.type === MediaType.Image) {
+    return imageToThumbnailListItem(mediaItem);
+  }
+
+  return undefined;
+};
+
+interface MediaPreviewProps extends ViewProps {
+  thumbnailHeight: number;
+  thumbnailAspectRatio?: number;
+  mediaItem: MediaItem;
+}
+
+export const MediaPreview: React.FunctionComponent<MediaPreviewProps> = ({thumbnailHeight, thumbnailAspectRatio = 1.3, mediaItem}) => {
+  const thumbnailWidth = thumbnailAspectRatio * thumbnailHeight;
+
+  const [modalIndex, setModalIndex] = useState<number | null>(null);
+
+  const onPress = useCallback(
+    (index: number) => {
+      setModalIndex(index);
+    },
+    [setModalIndex],
+  );
+  const onClose = useCallback(() => setModalIndex(null), [setModalIndex]);
+  const thumbnailItem = useMemo(() => thumbnailListItem(mediaItem), [mediaItem]);
+
+  if (!thumbnailItem) {
+    return <InternalError />;
+  }
+
+  return (
+    <View>
+      <VStack justifyContent="center" alignItems="center" space={8}>
+        <NetworkImage
+          width={thumbnailWidth}
+          height={thumbnailHeight}
+          uri={thumbnailItem.uri}
+          index={0}
+          showVideoIndicator={thumbnailItem.isVideo}
+          onPress={onPress}
+          imageStyle={{borderRadius: 4}}
+        />
+        {thumbnailItem.caption && (
+          <View px={32}>
+            <HTMLRendererConfig baseStyle={{fontSize: 12, textAlign: 'center', fontStyle: 'italic'}}>
+              <HTML source={{html: thumbnailItem.caption}} />
+            </HTMLRendererConfig>
+          </View>
+        )}
+      </VStack>
+      <MediaViewerModal visible={modalIndex !== null} startIndex={modalIndex ?? 0} mediaItems={[mediaItem]} onClose={onClose} />
+    </View>
+  );
+};

--- a/components/content/carousel/ThumbnailList.tsx
+++ b/components/content/carousel/ThumbnailList.tsx
@@ -1,11 +1,10 @@
 import {NetworkImage, NetworkImageProps, NetworkImageState} from 'components/content/carousel/NetworkImage';
 import {VStack, View} from 'components/core';
-import {HTML, HTMLRendererConfig} from 'components/text/HTML';
 import React, {PropsWithChildren, useCallback, useMemo, useState} from 'react';
 import {FlatList, FlatListProps} from 'react-native';
 import {ImageMediaItem, MediaItem, MediaType, VideoMediaItem} from 'types/nationalAvalancheCenter';
 
-interface ThumbnailListItem {
+export interface ThumbnailListItem {
   uri: string;
   isVideo: boolean;
   caption: string | null;
@@ -27,7 +26,7 @@ const thumbnailListItems = (mediaItems: MediaItem[]): ThumbnailListItem[] => {
   return thumbnailItems;
 };
 
-const videoToThumbnailListItem = (item: VideoMediaItem): ThumbnailListItem => {
+export const videoToThumbnailListItem = (item: VideoMediaItem): ThumbnailListItem => {
   if (typeof item.url === 'string' || 'external_link' in item.url) {
     return {
       uri: '',
@@ -46,7 +45,7 @@ const videoToThumbnailListItem = (item: VideoMediaItem): ThumbnailListItem => {
   };
 };
 
-const imageToThumbnailListItem = (item: ImageMediaItem): ThumbnailListItem => {
+export const imageToThumbnailListItem = (item: ImageMediaItem): ThumbnailListItem => {
   return {
     uri: item.url['thumbnail'],
     isVideo: false,
@@ -60,7 +59,6 @@ export interface ThumbnailListProps extends Omit<FlatListProps<ThumbnailListItem
   imageWidth: number;
   space?: number;
   mediaItems: MediaItem[];
-  displayCaptions?: boolean;
   imageStyle?: NetworkImageProps['imageStyle'];
   resizeMode?: NetworkImageProps['resizeMode'];
   onPress?: (index: number) => void;
@@ -71,7 +69,6 @@ export const ThumbnailList: React.FC<PropsWithChildren<ThumbnailListProps>> = ({
   imageWidth,
   space = 16,
   mediaItems,
-  displayCaptions,
   imageStyle,
   resizeMode,
   onPress = () => undefined,
@@ -107,16 +104,9 @@ export const ThumbnailList: React.FC<PropsWithChildren<ThumbnailListProps>> = ({
           onStateChange={onStateCallback}
           onPress={onPress}
         />
-        {displayCaptions && item.caption && (
-          <View px={32}>
-            <HTMLRendererConfig baseStyle={{fontSize: 12, textAlign: 'center', fontStyle: 'italic'}}>
-              <HTML source={{html: item.caption}} />
-            </HTMLRendererConfig>
-          </View>
-        )}
       </VStack>
     ),
-    [imageWidth, imageHeight, imageStyle, resizeMode, displayCaptions, onPress, onStateCallback],
+    [imageWidth, imageHeight, imageStyle, resizeMode, onPress, onStateCallback],
   );
 
   const ItemSeparatorComponent = useCallback(() => <View width={space} />, [space]);


### PR DESCRIPTION
- #1066 

This PR creates a new `MediaPreview` component that's used in the problem card. This breaks out the responsibility for showing the caption from `MediaCarousel` to `MediaPreview` since it's only shown in the `AvalancheProblemCard`