### PR TITLE
Put cursor at the top of TextInput

### DIFF
--- a/components/form/TextField.tsx
+++ b/components/form/TextField.tsx
@@ -113,6 +113,7 @@ const _TextField = <TFieldValues extends FieldValues, TFieldName extends FieldPa
             style={textInputDefaultStyle}
             placeholderTextColor={colorLookup('text.tertiary')}
             editable={!disabled}
+            textAlignVertical="top"
             {...textInputProps}
           />
         </View>


### PR DESCRIPTION
- #749 

`textAlignVertical` fixes the cursor placement however it shifts the text up in single line text inputs. This looks like a bug introduced with Expo 52 which means that until we ship Expo 53, it'll look a little funky (see screenshot). The automatically collapsing is also fixed in Expo 53 and New Architecture so for now this seems okay to ship knowing that it'll be completely fixed soon

<img width="225" height="500" alt="share_909729033594962472" src="https://github.com/user-attachments/assets/cb8a33ec-2225-4d3b-9aba-5d0eee36228b" />
