### PR TITLE
Temporary fix for MediaPreview error state

### DIFF
--- a/components/content/carousel/MediaPreview.tsx
+++ b/components/content/carousel/MediaPreview.tsx
@@ -1,7 +1,6 @@
 import {MediaViewerModal} from 'components/content/carousel/MediaViewerModal/MediaViewerModal';
 import {NetworkImage} from 'components/content/carousel/NetworkImage';
 import {imageToThumbnailListItem, ThumbnailListItem, videoToThumbnailListItem} from 'components/content/carousel/ThumbnailList';
-import {InternalError} from 'components/content/QueryState';
 import {View, ViewProps, VStack} from 'components/core';
 import {HTML, HTMLRendererConfig} from 'components/text/HTML';
 import React, {useCallback, useMemo, useState} from 'react';
@@ -41,7 +40,7 @@ export const MediaPreview: React.FunctionComponent<MediaPreviewProps> = ({thumbn
   const thumbnailItem = useMemo(() => thumbnailListItem(mediaItem), [mediaItem]);
 
   if (!thumbnailItem) {
-    return <InternalError />;
+    return <View />;
   }
 
   return (


### PR DESCRIPTION
The is a temporary work around

When an avalanche problem has bad media data and tries to render the `<InternalError />` it makes the entire `AvalancheTab` unusable. It basically turns it into an infinite scroll.

To fix this bug quickly, we're just going to render an empty view with a better fix being tracked by this issue: #1125 