### PR TITLE
Update Expo Update Pipeline to Manually Include Mapbox Key

### DIFF
--- a/.github/workflows/publish-update.yaml
+++ b/.github/workflows/publish-update.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SENTRY_AUTH_TOKEN: $ {{ secrets.SENTRY_AUTH_TOKEN }}
+      MAPBOX_API_KEY: $ {{ secrets.MAPBOX_API_KEY }}
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3


### PR DESCRIPTION
The Mapbox API Key seems to be override when an OTA update happens. This directly adds the key to the `env` of the pipeline and the key has been added to the repository secrets