### PR TITLE
Fix AvalancheCenterSelectorModal Error State

### DIFF
--- a/components/modals/AvalancheCenterSelectionModal.tsx
+++ b/components/modals/AvalancheCenterSelectionModal.tsx
@@ -1,17 +1,17 @@
 import React, {useCallback, useState} from 'react';
-import {ScrollView, StyleSheet} from 'react-native';
+import {ScrollView} from 'react-native';
 
 import Topo from 'assets/illustrations/topo.svg';
 import {avalancheCenterList, AvalancheCenters} from 'components/avalancheCenterList';
 import {AvalancheCenterList} from 'components/content/AvalancheCenterList';
 import {Button} from 'components/content/Button';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
-import {Center, Divider, View, VStack} from 'components/core';
+import {Center, Divider, VStack} from 'components/core';
 import {Body, BodyBlack, Title3Black} from 'components/text';
 import {useAllAvalancheCenterMetadata} from 'hooks/useAllAvalancheCenterMetadata';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {Modal} from 'react-native';
-import {SafeAreaProvider, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
 import {AvalancheCenter, AvalancheCenterID} from 'types/nationalAvalancheCenter';
 
@@ -40,44 +40,37 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
   }
   const safeAreaInsets = useSafeAreaInsets();
 
-  if (incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities) {
-    return <QueryState results={[capabilitiesResult, ...metadataResults]} />;
-  }
-
   return (
     <Modal transparent visible={visible && !loading} animationType="slide" onRequestClose={closeHandler}>
-      <SafeAreaProvider>
-        <View style={{...StyleSheet.absoluteFillObject, backgroundColor: colorLookup('primary.background')}}>
-          <SafeAreaView style={{width: '100%', height: '100%'}}>
-            {/* view to paint the very bottom of the screen white  */}
-            <View style={{position: 'absolute', left: 0, right: 0, bottom: 0, height: safeAreaInsets.bottom, backgroundColor: 'white'}} />
-            {/* overflow hidden to keep the topo illustration from going beyond this view */}
-            <VStack justifyContent="space-between" height="100%" overflow="hidden">
-              {/* these magic numbers are yanked out of Figma */}
-              <Topo width={887.0152587890625} height={456.3430480957031} style={{position: 'absolute', left: -264, top: 338}} />
-              <VStack space={16} pt={96} px={16} flex={1}>
-                <Center px={32}>
-                  <Title3Black textAlign="center" color={colorLookup('NWAC-dark')}>
-                    Welcome! Get started by selecting your local avalanche center.
-                  </Title3Black>
-                </Center>
-                <Center px={32} pb={32}>
-                  <Body textAlign="center">You can change this anytime in settings.</Body>
-                </Center>
-                <ScrollView>
-                  <AvalancheCenterList selectedCenter={selectedCenter} setSelectedCenter={setSelectedCenter} data={avalancheCenterList(metadata, capabilities)} />
-                </ScrollView>
-              </VStack>
-              <Divider />
-              <Center height={100} width="100%" px={16} backgroundColor={'white'} alignItems="stretch">
-                <Button disabled={!selectedCenter} onPress={closeHandler} buttonStyle="primary" mt={16}>
-                  <BodyBlack>Continue</BodyBlack>
-                </Button>
-              </Center>
-            </VStack>
-          </SafeAreaView>
-        </View>
-      </SafeAreaProvider>
+      {incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities ? (
+        // We want to show the query state as a part of the modal so that it only shows when the modal is present
+        <QueryState results={[capabilitiesResult, ...metadataResults]} />
+      ) : (
+        // overflow hidden to keep the topo illustration from going beyond this view
+        <VStack justifyContent="space-between" height="100%" overflow="hidden" paddingBottom={safeAreaInsets.bottom} backgroundColor={colorLookup('white')}>
+          {/* these magic numbers are yanked out of Figma */}
+          <Topo width={887.0152587890625} height={456.3430480957031} style={{position: 'absolute', left: -264, top: 338}} />
+          <VStack space={16} pt={96} px={16} flex={1} backgroundColor={colorLookup('primary.background')}>
+            <Center px={32}>
+              <Title3Black textAlign="center" color={colorLookup('NWAC-dark')}>
+                Welcome! Get started by selecting your local avalanche center.
+              </Title3Black>
+            </Center>
+            <Center px={32} pb={32}>
+              <Body textAlign="center">You can change this anytime in settings.</Body>
+            </Center>
+            <ScrollView>
+              <AvalancheCenterList selectedCenter={selectedCenter} setSelectedCenter={setSelectedCenter} data={avalancheCenterList(metadata, capabilities)} />
+            </ScrollView>
+          </VStack>
+          <Divider />
+          <Center height={100} width="100%" px={16} backgroundColor={'white'} alignItems="stretch">
+            <Button disabled={!selectedCenter} onPress={closeHandler} buttonStyle="primary" mt={16}>
+              <BodyBlack>Continue</BodyBlack>
+            </Button>
+          </Center>
+        </VStack>
+      )}
     </Modal>
   );
 };


### PR DESCRIPTION
- #1138 

This fixes an issue I ran into when I didn't have good reception. It's possible for the network calls used by the `AvalancheCenterSelectorModal` to fail while the map loads fine. This causes the error state for the modal to be shown even if the modal isn't shown

<img width="230" height="500" alt="IMG_1082" src="https://github.com/user-attachments/assets/e7e468f1-c9a7-4a43-8795-df6c36dd31a2" />

The fix moves the error state inside the modal itself so that it's only rendered, if the modal needs to be rendered (based off the `visible` and `loading` flags)

Error inside the modal
<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-17 at 13 29 57" src="https://github.com/user-attachments/assets/334e9e4f-a70b-4235-8665-09fac48d32fe" />

I also cleaned up the modal in general:
- Removed `SafeAreaProvider` and `SafeAreaView` in favor of `safeAreaInsets` that was already being used in the view
- Removed the top level `View`. The `VStack` taking up 100% of the height fills the view by itself
- Remove the `View` that was needed "to paint the very bottom of the screen white". I just changed the background colors in the content so I could achieve the same effect