### PR TITLE
Allow Claude to run yarn

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,4 +32,4 @@ jobs:
 
           # Limit tools to safe operations for this codebase
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(yarn install),Bash(yarn prettify),Bash(pnpm prettify),Bash(pnpm tsc),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*),Bash(git status),Bash(git diff),Bash(git add),Bash(git commit),Bash(git checkout -b *),Bash(git push),Bash(gh pr create *),Bash(gh issue comment *),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(yarn install),Bash(yarn prettify),Bash(git status),Bash(git diff),Bash(git add),Bash(git commit),Bash(git checkout -b *),Bash(git push),Bash(gh pr create *),Bash(gh issue comment *),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
The syntax to allow `yarn` was incorrect. This allows Claude to run `yarn install` and `yarn prettify`