### PR TITLE
Remove pitch from ZoneMap

### DIFF
--- a/components/content/ZoneMap.tsx
+++ b/components/content/ZoneMap.tsx
@@ -36,7 +36,6 @@ interface ZoneMapProps extends ViewProps {
   initialCameraBounds: CameraBounds;
   selectedZoneId?: number | null;
   renderFillColor?: boolean;
-  pitchEnabled?: boolean;
   rotateEnabled?: boolean;
   scrollEnabled?: boolean;
   zoomEnabled?: boolean;
@@ -51,7 +50,6 @@ export const ZoneMap = React.forwardRef<Camera, ZoneMapProps>(
       selectedZoneId,
       initialCameraBounds,
       renderFillColor = true,
-      pitchEnabled = true,
       rotateEnabled = true,
       scrollEnabled = true,
       zoomEnabled = true,
@@ -67,7 +65,7 @@ export const ZoneMap = React.forwardRef<Camera, ZoneMapProps>(
         styleURL={Mapbox.StyleURL.Outdoors}
         scaleBarEnabled={false}
         zoomEnabled={zoomEnabled}
-        pitchEnabled={pitchEnabled}
+        pitchEnabled={false}
         rotateEnabled={rotateEnabled}
         scrollEnabled={scrollEnabled}
         onPress={onMapPress}

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -233,7 +233,6 @@ export const ObservationCard: React.FunctionComponent<{
                     <ZoneMap
                       style={{width: '100%', height: 200}}
                       zones={[]}
-                      pitchEnabled={false}
                       rotateEnabled={false}
                       scrollEnabled={true}
                       zoomEnabled={true}


### PR DESCRIPTION
- #1157 

Removes the `pitchEnabled` parameter on `ZoneMap` and defaults it to `false` when being passed into `MapView`