### PR TITLE
Fix forecast query key bug

### DIFF
--- a/utils/date.test.ts
+++ b/utils/date.test.ts
@@ -1,5 +1,13 @@
 import * as TimezoneMock from 'timezone-mock';
-import {apiDateString, nominalForecastDateString, nominalNWACWeatherForecastDate, normalizeTimeZone, utcDateToLocalDateString, utcDateToLocalTimeString} from 'utils/date';
+import {
+  apiDateString,
+  expiryTimeHoursToString,
+  nominalForecastDateString,
+  nominalNWACWeatherForecastDate,
+  normalizeTimeZone,
+  utcDateToLocalDateString,
+  utcDateToLocalTimeString,
+} from 'utils/date';
 
 describe('Dates', () => {
   describe('apiDateString', () => {
@@ -75,7 +83,7 @@ describe('Dates', () => {
 
   describe('nominalForecastDate', () => {
     it('returns the current day when requesting before the expiry time', () => {
-      expect(nominalForecastDateString(new Date('2023-01-24T09:44:27-08:00'), 'America/Los_Angeles', 18)).toBe('2023-01-24');
+      expect(nominalForecastDateString(new Date('2023-01-24T09:44:27-08:00'), 'America/Los_Angeles', 18.5)).toBe('2023-01-24');
     });
     it('returns the next day when requesting after the expiry time', () => {
       expect(nominalForecastDateString(new Date('2023-01-24T19:44:27-08:00'), 'America/Los_Angeles', 18)).toBe('2023-01-25');
@@ -103,6 +111,37 @@ describe('Dates', () => {
     });
     it('returns the current day afternoon when requesting after the expiry time using UTC', () => {
       expect(nominalNWACWeatherForecastDate(new Date('2023-01-25T03:44:27-00:00'))).toBe('2023-01-24 afternoon');
+    });
+  });
+
+  describe('expiryTimeHoursToString', () => {
+    it('formats whole hours with zero-padded minutes', () => {
+      expect(expiryTimeHoursToString(18)).toBe('18:00:00');
+    });
+
+    it('zero-pads single-digit hours', () => {
+      expect(expiryTimeHoursToString(1)).toBe('01:00:00');
+    });
+
+    it('formats midnight', () => {
+      expect(expiryTimeHoursToString(0)).toBe('00:00:00');
+    });
+
+    it('converts fractional hours to minutes', () => {
+      expect(expiryTimeHoursToString(18.5)).toBe('18:30:00');
+    });
+
+    it('converts quarter-hour fractions', () => {
+      expect(expiryTimeHoursToString(18.25)).toBe('18:15:00');
+    });
+
+    it('zero-pads single-digit minutes', () => {
+      expect(expiryTimeHoursToString(0.5)).toBe('00:30:00');
+    });
+
+    it('wraps hours >= 24 by subtracting 24', () => {
+      expect(expiryTimeHoursToString(24)).toBe('00:00:00');
+      expect(expiryTimeHoursToString(25)).toBe('01:00:00');
     });
   });
 

--- a/utils/date.test.ts
+++ b/utils/date.test.ts
@@ -139,9 +139,11 @@ describe('Dates', () => {
       expect(expiryTimeHoursToString(0.5)).toBe('00:30:00');
     });
 
-    it('wraps hours >= 24 by subtracting 24', () => {
+    it('wraps hours >= 24', () => {
       expect(expiryTimeHoursToString(24)).toBe('00:00:00');
       expect(expiryTimeHoursToString(25)).toBe('01:00:00');
+      expect(expiryTimeHoursToString(48)).toBe('00:00:00');
+      expect(expiryTimeHoursToString(49)).toBe('01:00:00');
     });
   });
 

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -55,7 +55,7 @@ export const toSnowboundStringUTC = (date: Date) => formatInTimeZone(date, 'UTC'
 export const nominalForecastDate = (requestedTime: Date, expiryTimeZone: string, expiryTimeHours: number): Date => {
   // requestedTime is in UTC, expiryTimeHours is relative to the locale-specific start of day
   const normalizedExpiryTimeZone = normalizeTimeZone(expiryTimeZone);
-  const expiryTimeString = `${formatInTimeZone(requestedTime, normalizedExpiryTimeZone.ianaName, 'yyyy-MM-dd')} ${String(expiryTimeHours).padStart(2, '0')}:00:00`;
+  const expiryTimeString = `${formatInTimeZone(requestedTime, normalizedExpiryTimeZone.ianaName, 'yyyy-MM-dd')} ${expiryTimeHoursToString(expiryTimeHours)}`;
   const expiryTime = toDate(expiryTimeString, {timeZone: normalizedExpiryTimeZone.ianaName});
   if (isAfter(expiryTime, requestedTime)) {
     return requestedTime;
@@ -74,13 +74,20 @@ export const nominalNWACWeatherForecastDate = (requestedTime: Date): string => {
   const expiryTimeZone = 'America/Los_Angeles';
   const expiryTimeHours = 10;
   // requestedTime is in UTC, expiryTimeHours is relative to the locale-specific start of day
-  const expiryTimeString = `${formatInTimeZone(requestedTime, expiryTimeZone, 'yyyy-MM-dd')} ${String(expiryTimeHours).padStart(2, '0')}:00:00`;
+  const expiryTimeString = `${formatInTimeZone(requestedTime, expiryTimeZone, 'yyyy-MM-dd')} ${expiryTimeHoursToString(expiryTimeHours)}`;
   const expiryTime = toDate(expiryTimeString, {timeZone: expiryTimeZone});
   if (isAfter(expiryTime, requestedTime)) {
     return `${formatInTimeZone(requestedTime, expiryTimeZone, 'yyyy-MM-dd')} morning`;
   } else {
     return `${formatInTimeZone(requestedTime, expiryTimeZone, 'yyyy-MM-dd')} afternoon`;
   }
+};
+
+export const expiryTimeHoursToString = (expiryTimeHours: number): string => {
+  const hours = Math.trunc(expiryTimeHours);
+  const adjustedHours = hours >= 24 ? hours - 24 : hours;
+  const minutes = Math.round((expiryTimeHours % 1) * 60);
+  return `${adjustedHours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`;
 };
 
 export const utcDateToLocalTimeString = (date: Date | string | undefined | null): string => {

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -84,10 +84,9 @@ export const nominalNWACWeatherForecastDate = (requestedTime: Date): string => {
 };
 
 export const expiryTimeHoursToString = (expiryTimeHours: number): string => {
-  const hours = Math.trunc(expiryTimeHours);
-  const adjustedHours = hours >= 24 ? hours - 24 : hours;
+  const hours = Math.trunc(expiryTimeHours) % 24;
   const minutes = Math.round((expiryTimeHours % 1) * 60);
-  return `${adjustedHours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`;
 };
 
 export const utcDateToLocalTimeString = (date: Date | string | undefined | null): string => {


### PR DESCRIPTION
- #1154 

We do not correctly calculate the `nominalDate` that we attach to the query key for the `useAvalancheForecast` call. The issue was that we were incorrectly assuming that the `expires_time` field returned in the avalanche center metadata was an integer. However, there are at least 3 centers that return a float to specify that the forecasts expired on the half hour. For example, NWAC's expires time is `18.5`.

We were creating a timestamp using the time passed in as the hour so the expires time for `18.5` was `18.5:00:00` instead of `18:30:00`. The invalid time was being changed to `00:00:00` and leading to an incorrect nominal date because `requestedTime` was guaranteed to be before `expiresTime`.

I created a helper function that correctly creates the string and added tests
