### PR TITLE
Fix Avalanche Problems in Observations Schema

### DIFF
--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -1087,7 +1087,7 @@ export const observationSchema = z.object({
         .array(
           z.object({
             rank: z.number().optional(),
-            type: z.nativeEnum(AvalancheProblemName).or(z.string().length(0)).nullable().optional(/* only because of NWAC */),
+            type: z.nativeEnum(AvalancheProblemName).or(z.string()).nullable().optional(/* only because of NWAC */),
             depth: z.string().nullable().optional(/* only because of NWAC */),
             layer: z.string().nullable().optional(/* only because of NWAC */),
             location: z.array(avalancheProblemLocationSchema).nullable().optional(/* only because of NWAC */),


### PR DESCRIPTION
A Zod Error came in that uncovered an issue with the `observation -> advanced_fields -> avalanche_problems -> type` schema where if the type didn't match the specific `AvalancheProblems` enum, then we failed to parse.

The problem was that one of the avalanche problems had a type of 'Cornice' instead of 'Cornice Fall'

Obs that had the issue:
https://nwac.us/observations/#/view/observations/9801b523-356b-440c-9f30-1fe0607ce9fa

Zod Error:
```
ZodError: [
  {
    "code": "too_big",
    "maximum": 0,
    "type": "string",
    "inclusive": true,
    "exact": true,
    "message": "String must contain exactly 0 character(s)",
    "path": [
      "advanced_fields",
      "avalanche_problems",
      2,
```