### PR TITLE
Replace CorniceFall problem type with Cornice

### DIFF
--- a/components/AvalancheProblemIcon.tsx
+++ b/components/AvalancheProblemIcon.tsx
@@ -19,7 +19,7 @@ const icons: Record<AvalancheProblemType, ImageSourcePropType> = {
   [AvalancheProblemType.DeepPersistentSlab]: require('../assets/problem-icons/DeepPersistentSlab.png'),
   [AvalancheProblemType.WetLoose]: require('../assets/problem-icons/WetLoose.png'),
   [AvalancheProblemType.WetSlab]: require('../assets/problem-icons/WetSlab.png'),
-  [AvalancheProblemType.Cornice]: require('../assets/problem-icons/CorniceFall.png'),
+  [AvalancheProblemType.CorniceFall]: require('../assets/problem-icons/CorniceFall.png'),
   [AvalancheProblemType.Glide]: require('../assets/problem-icons/Glide.png'),
 };
 
@@ -33,7 +33,7 @@ const sizes: Record<AvalancheProblemType, ImageResolvedAssetSource> = {
   [AvalancheProblemType.DeepPersistentSlab]: Image.resolveAssetSource(require('../assets/problem-icons/DeepPersistentSlab.png')),
   [AvalancheProblemType.WetLoose]: Image.resolveAssetSource(require('../assets/problem-icons/WetLoose.png')),
   [AvalancheProblemType.WetSlab]: Image.resolveAssetSource(require('../assets/problem-icons/WetSlab.png')),
-  [AvalancheProblemType.Cornice]: Image.resolveAssetSource(require('../assets/problem-icons/CorniceFall.png')),
+  [AvalancheProblemType.CorniceFall]: Image.resolveAssetSource(require('../assets/problem-icons/CorniceFall.png')),
   [AvalancheProblemType.Glide]: Image.resolveAssetSource(require('../assets/problem-icons/Glide.png')),
 };
 

--- a/components/AvalancheProblemIcon.tsx
+++ b/components/AvalancheProblemIcon.tsx
@@ -19,7 +19,7 @@ const icons: Record<AvalancheProblemType, ImageSourcePropType> = {
   [AvalancheProblemType.DeepPersistentSlab]: require('../assets/problem-icons/DeepPersistentSlab.png'),
   [AvalancheProblemType.WetLoose]: require('../assets/problem-icons/WetLoose.png'),
   [AvalancheProblemType.WetSlab]: require('../assets/problem-icons/WetSlab.png'),
-  [AvalancheProblemType.CorniceFall]: require('../assets/problem-icons/CorniceFall.png'),
+  [AvalancheProblemType.Cornice]: require('../assets/problem-icons/CorniceFall.png'),
   [AvalancheProblemType.Glide]: require('../assets/problem-icons/Glide.png'),
 };
 
@@ -33,7 +33,7 @@ const sizes: Record<AvalancheProblemType, ImageResolvedAssetSource> = {
   [AvalancheProblemType.DeepPersistentSlab]: Image.resolveAssetSource(require('../assets/problem-icons/DeepPersistentSlab.png')),
   [AvalancheProblemType.WetLoose]: Image.resolveAssetSource(require('../assets/problem-icons/WetLoose.png')),
   [AvalancheProblemType.WetSlab]: Image.resolveAssetSource(require('../assets/problem-icons/WetSlab.png')),
-  [AvalancheProblemType.CorniceFall]: Image.resolveAssetSource(require('../assets/problem-icons/CorniceFall.png')),
+  [AvalancheProblemType.Cornice]: Image.resolveAssetSource(require('../assets/problem-icons/CorniceFall.png')),
   [AvalancheProblemType.Glide]: Image.resolveAssetSource(require('../assets/problem-icons/Glide.png')),
 };
 

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -89,7 +89,7 @@ export enum AvalancheProblemType {
   DeepPersistentSlab,
   WetLoose,
   WetSlab,
-  CorniceFall,
+  Cornice,
   Glide,
 }
 
@@ -101,7 +101,7 @@ export enum AvalancheProblemName {
   DeepPersistentSlab = 'Deep Persistent Slab',
   WetLoose = 'Wet Loose',
   WetSlab = 'Wet Slab',
-  CorniceFall = 'Cornice Fall',
+  Cornice = 'Cornice',
   Glide = 'Glide',
   GlideAvalanches = 'Glide Avalanches',
 }

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -101,6 +101,7 @@ export enum AvalancheProblemName {
   DeepPersistentSlab = 'Deep Persistent Slab',
   WetLoose = 'Wet Loose',
   WetSlab = 'Wet Slab',
+  CorniceFall = 'Cornice Fall',
   Cornice = 'Cornice',
   Glide = 'Glide',
   GlideAvalanches = 'Glide Avalanches',

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -89,7 +89,7 @@ export enum AvalancheProblemType {
   DeepPersistentSlab,
   WetLoose,
   WetSlab,
-  Cornice,
+  CorniceFall,
   Glide,
 }
 


### PR DESCRIPTION
A Zod Error came in that uncovered an issue with the `observation -> advanced_fields -> avalanche_problems -> type` schema where if the type didn't match the specific `AvalancheProblemName` enum, then we failed to parse.

The problem was that one of the avalanche problems had a type of 'Cornice' instead of 'Cornice Fall'.

Both the AFP widget to create an observation and the AFP dashboard to create a forecast have this value set to `Cornice` so the best fix seems to be to update our schema to match.

I updated `AvalancheProblemType` to match as well just for consistency

Obs that had the issue:
https://nwac.us/observations/#/view/observations/9801b523-356b-440c-9f30-1fe0607ce9fa

Zod Error:
```
ZodError: [
  {
    "code": "too_big",
    "maximum": 0,
    "type": "string",
    "inclusive": true,
    "exact": true,
    "message": "String must contain exactly 0 character(s)",
    "path": [
      "advanced_fields",
      "avalanche_problems",
      2,
```