### PR TITLE
Add Xcode image to EAS builds

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -32,13 +32,19 @@
     "preview": {
       "channel": "preview",
       "autoIncrement": true,
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
+      },
       "env": {
         "APP_VARIANT": "preview"
       }
     },
     "release": {
       "channel": "release",
-      "autoIncrement": true
+      "autoIncrement": true,
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
- #1107 

We need to explicitly specify a MacOS/Xcode image so that EAS builds the app with a higher Xcode version than the default. This will allow us to keep releasing Preview/Release apps to Apple.

"90725: SDK version issue. This app was built with the iOS 18.5 SDK. Starting April 28, 2026, all iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution."

Once upgrade to Expo 54/55 this will no longer be needed