### PR TITLE
Undo Xcode Image EAS

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -32,19 +32,13 @@
     "preview": {
       "channel": "preview",
       "autoIncrement": true,
-      "ios": {
-        "image": "macos-sequoia-15.6-xcode-26.2"
-      },
       "env": {
         "APP_VARIANT": "preview"
       }
     },
     "release": {
       "channel": "release",
-      "autoIncrement": true,
-      "ios": {
-        "image": "macos-sequoia-15.6-xcode-26.2"
-      }
+      "autoIncrement": true
     }
   },
   "submit": {


### PR DESCRIPTION
Undoes PR #1176 now that the project is on Expo 56. The original changes was needed because we had to build the project on Xcode 26+ but Expo 53 defaulted to Xcode 18 on EAS. Expo 56 defaults to Xcode 26.4 on EAS