### PR TITLE
Expo 56 Follow Up

### DIFF
--- a/FeatureFlags.tsx
+++ b/FeatureFlags.tsx
@@ -9,8 +9,9 @@ import * as Application from 'expo-application';
 import * as Updates from 'expo-updates';
 
 import {useNetInfo} from '@react-native-community/netinfo';
-import PostHog, {useFeatureFlags, usePostHog} from 'posthog-react-native';
+import PostHog, {useFeatureFlags} from 'posthog-react-native';
 
+import {Analytics, useAnalytics} from 'hooks/useAnalytics';
 import {useAppState} from 'hooks/useAppState';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {logger} from 'logger';
@@ -42,11 +43,15 @@ interface FeatureFlagsProviderProps {
   children?: ReactNode;
 }
 
-const tryReloadFeatureFlags = (posthog: PostHog) => {
+const tryReloadFeatureFlags = (analytics: Analytics) => {
   logger.debug('fetching feature flags');
   void (async () => {
-    const featureFlags = await posthog.reloadFeatureFlagsAsync();
-    logger.debug(`reloaded feature flags: ${JSON.stringify(featureFlags)}`);
+    try {
+      const featureFlags = await analytics.reloadFeatureFlags();
+      logger.debug(`reloaded feature flags: ${JSON.stringify(featureFlags)}`);
+    } catch (error) {
+      logger.error({error}, 'failed to reload feature flags');
+    }
   })();
 };
 
@@ -56,11 +61,11 @@ const FEATURE_FLAG_REFRESH_INTERVAL_MS = Updates.channel ? 30 * 60 * 1000 : 0;
 const tryReloadFeatureFlagsWithDebounce = _.debounce(tryReloadFeatureFlags, FEATURE_FLAG_REFRESH_INTERVAL_MS);
 
 export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({children}) => {
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
   const [registered, setRegistered] = React.useState(false);
   useEffect(() => {
-    if (postHog && !registered) {
-      void postHog.register({
+    if (!registered) {
+      analytics.register({
         // Posthog automatically captures `Application.nativeBuildVersion` as `App Build`, but stores it as a string.
         // We additionally capture it as a number here, so that we can use < and > in feature flag rules.
         buildNumber: Number.parseInt(Application.nativeBuildVersion || '0'),
@@ -71,36 +76,36 @@ export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({child
       logger.debug('registered user');
       setRegistered(true);
     }
-  }, [postHog, registered, setRegistered]);
+  }, [analytics, registered, setRegistered]);
   // We use the mixpanel user id (a unique UUID generated for each install of the app) as the posthog distinct id as well.
   const {
     preferences: {mixpanelUserId: distinctUserId},
   } = usePreferences();
   const [userIdentified, setUserIdentified] = useState(false);
   useEffect(() => {
-    if (postHog && distinctUserId && !userIdentified && registered) {
-      postHog.identify(distinctUserId);
+    if (distinctUserId && !userIdentified && registered) {
+      analytics.identify(distinctUserId);
       setUserIdentified(true);
       logger.debug('identified user, reloading feature flags', {distinctUserId});
-      tryReloadFeatureFlagsWithDebounce(postHog);
+      tryReloadFeatureFlagsWithDebounce(analytics);
     }
-  }, [postHog, distinctUserId, userIdentified, registered]);
+  }, [analytics, distinctUserId, userIdentified, registered]);
 
   const appState = useAppState();
   useEffect(() => {
-    if (postHog && appState === 'active' && registered && userIdentified) {
+    if (appState === 'active' && registered && userIdentified) {
       logger.debug('appState changed to active, reloading feature flags');
-      tryReloadFeatureFlagsWithDebounce(postHog);
+      tryReloadFeatureFlagsWithDebounce(analytics);
     }
-  }, [appState, postHog, registered, userIdentified]);
+  }, [appState, analytics, registered, userIdentified]);
 
   const netInfo = useNetInfo();
   useEffect(() => {
-    if (postHog && netInfo.isConnected && netInfo.isInternetReachable && registered && userIdentified) {
+    if (netInfo.isConnected && netInfo.isInternetReachable && registered && userIdentified) {
       logger.debug('network online, reloading feature flags');
-      tryReloadFeatureFlagsWithDebounce(postHog);
+      tryReloadFeatureFlagsWithDebounce(analytics);
     }
-  }, [netInfo, postHog, registered, userIdentified]);
+  }, [netInfo, analytics, registered, userIdentified]);
 
   const featureFlags: FeatureFlags = useFeatureFlags() ?? defaultFeatureFlags;
   const [clientSideFeatureFlagOverrides, setClientSideFeatureFlagOverrides] = useState<FeatureFlags>({});

--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -8,8 +8,8 @@ import {avalancheCenterList, AvalancheCenters} from 'components/avalancheCenterL
 import {AvalancheCenterList} from 'components/content/AvalancheCenterList';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {useAllAvalancheCenterMetadata} from 'hooks/useAllAvalancheCenterMetadata';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
-import {usePostHog} from 'posthog-react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MainStackNavigationProps, MainStackParamList} from 'routes';
 import {AvalancheCenter, AvalancheCenterID} from 'types/nationalAvalancheCenter';
@@ -32,11 +32,11 @@ export const AvalancheCenterSelector: React.FunctionComponent<{
     },
     [setAvalancheCenter, navigation],
   );
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    void postHog?.screen('centerSelector');
-  }, [postHog]);
+    analytics.screen('centerSelector');
+  }, [analytics]);
   useFocusEffect(recordAnalytics);
 
   const insets = useSafeAreaInsets();

--- a/components/KillSwitchMonitor.tsx
+++ b/components/KillSwitchMonitor.tsx
@@ -3,26 +3,26 @@ import * as Linking from 'expo-linking';
 import React, {useCallback} from 'react';
 import {Modal, Platform} from 'react-native';
 
-import {usePostHog} from 'posthog-react-native';
-
 import {useOneFeatureFlag} from 'FeatureFlags';
 import NoConnection from 'assets/illustrations/NoConnection.svg';
 import {Button} from 'components/content/Button';
 import {Outcome} from 'components/content/Outcome';
 import {VStack} from 'components/core';
 import {BodyBlack} from 'components/text';
+import {useAnalytics} from 'hooks/useAnalytics';
+import {fireAndForget} from 'utils/fireAndForget';
 
 type KillSwitchMonitorProps = {
   children: React.ReactNode;
 };
 
 export const KillSwitchMonitor: React.FC<KillSwitchMonitorProps> = ({children}) => {
-  const posthog = usePostHog();
+  const analytics = useAnalytics();
 
   const downForMaintenance = !!useOneFeatureFlag('down-for-maintenance');
   const updateRequired = !!useOneFeatureFlag(`update-required`);
 
-  const reloadFeatureFlags = useCallback(() => void posthog?.reloadFeatureFlagsAsync(), [posthog]);
+  const reloadFeatureFlags = useCallback(() => fireAndForget(analytics.reloadFeatureFlags(), 'failed to reload feature flags'), [analytics]);
 
   let storeUrl: string | undefined = undefined;
   if (Platform.OS === 'android' && Constants.expoConfig?.android?.playStoreUrl) {

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -20,12 +20,12 @@ import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, BodySm, BodySm
 import {HTML} from 'components/text/HTML';
 import helpStrings from 'content/helpStrings';
 import {toDate} from 'date-fns-tz';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useAvalancheForecast} from 'hooks/useAvalancheForecast';
 import {useAvalancheWarning} from 'hooks/useAvalancheWarning';
 import {useRefresh} from 'hooks/useRefresh';
 import {useToggle} from 'hooks/useToggle';
-import {usePostHog} from 'posthog-react-native';
 import {RefreshControl, ScrollView, TouchableOpacity} from 'react-native';
 import Toast from 'react-native-toast-message';
 import {MainStackNavigationProps} from 'routes';
@@ -73,7 +73,7 @@ export const AvalancheTab: React.FunctionComponent<{
   const warning = warningResult.data;
   const {isRefreshing, refresh} = useRefresh(forecastResult.refetch, warningResult.refetch);
   const onRefresh = useCallback(() => void refresh(), [refresh]);
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   // When navigating from elsewhere in the app, the screen title should already
   // be set to the zone name. But if we warp directly to a forecast link, we
@@ -114,13 +114,13 @@ export const AvalancheTab: React.FunctionComponent<{
   );
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id && zoneName) {
-      void postHog.screen('avalancheForecastTab', {
+    if (center_id && zoneName) {
+      analytics.screen('avalancheForecastTab', {
         center: center_id,
         zone: zoneName,
       });
     }
-  }, [postHog, center_id, zoneName]);
+  }, [analytics, center_id, zoneName]);
   useFocusEffect(recordAnalytics);
 
   if (incompleteQueryState(centerResult, forecastResult, warningResult) || !center || !forecast || !warning) {

--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -11,6 +11,7 @@ import {HTML} from 'components/text/HTML';
 import {NWACStationsByZone, ZoneWithWeatherStations} from 'components/weather_data/NWACWeatherStationList';
 import helpStrings from 'content/helpStrings';
 import {useAllMapLayers} from 'hooks/useAllMapLayers';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useAvalancheForecast} from 'hooks/useAvalancheForecast';
 import {FormatTimeOfDay, useNWACWeatherForecast} from 'hooks/useNWACWeatherForecast';
@@ -19,7 +20,6 @@ import {useWeatherForecast} from 'hooks/useWeatherForecast';
 import {useWeatherStationsMetadata} from 'hooks/useWeatherStationsMetadata';
 import {isArray} from 'lodash';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {RefreshControl, ScrollView} from 'react-native';
 import {MainStackParamList, TabNavigationProps} from 'routes';
@@ -142,16 +142,16 @@ export const NACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, reque
     void refresh();
   }, [refresh]);
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id && zone.name) {
-      void postHog.screen('weatherForecastTab', {
+    if (center_id && zone.name) {
+      analytics.screen('weatherForecastTab', {
         center: center_id,
         zone: zone.name,
       });
     }
-  }, [postHog, center_id, zone.name]);
+  }, [analytics, center_id, zone.name]);
   useFocusEffect(recordAnalytics);
 
   if (incompleteQueryState(avalancheCenterMetadataResult, avalancheForecastResult) || !metadata || !avalancheForecast) {
@@ -233,16 +233,16 @@ export const NWACWeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, requ
     }
   }, [metadata, weatherStations, mapLayer, center_id]);
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id && zone.name) {
-      void postHog.screen('weatherForecastTab', {
+    if (center_id && zone.name) {
+      analytics.screen('weatherForecastTab', {
         center: center_id,
         zone: zone.name,
       });
     }
-  }, [postHog, center_id, zone.name]);
+  }, [analytics, center_id, zone.name]);
   useFocusEffect(recordAnalytics);
 
   // In the UI, we show weather station groups, which may contain 1 or more weather stations.

--- a/components/map/AvalancheForecastZoneMap.tsx
+++ b/components/map/AvalancheForecastZoneMap.tsx
@@ -7,11 +7,11 @@ import {MapViewZone, mapViewZoneFor} from 'components/map/ZoneMap';
 import {AvalancheCenterSelectionModal} from 'components/modals/AvalancheCenterSelectionModal';
 import {isAfter} from 'date-fns';
 import {toDate} from 'date-fns-tz';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useMapLayerAvalancheForecasts} from 'hooks/useMapLayerAvalancheForecasts';
 import {useMapLayerAvalancheWarnings} from 'hooks/useMapLayerAvalancheWarnings';
 import {useMapPersistence} from 'MapPersistence';
-import {usePostHog} from 'posthog-react-native';
 import {usePreferences} from 'Preferences';
 import {AvalancheCenterID, DangerLevel, ForecastPeriod, MapLayerFeature, ProductType} from 'types/nationalAvalancheCenter';
 import {RequestedTime, requestedTimeToUTCDate} from 'utils/date';
@@ -55,14 +55,14 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
   const [userLocation, setUserLocation] = useState<Position | undefined>(undefined);
   const [topElementMeasurements, setTopElementMeasurements] = useState<TopElementMeasurments>({yPos: 0, height: 0});
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('avalancheForecastMap', {
+    if (center_id) {
+      analytics.screen('avalancheForecastMap', {
         center: center_id,
       });
     }
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   // Default to the values in the map layer, but update it with the forecasts and warnings we've fetched

--- a/components/modals/AvalancheCenterSelectionModal.tsx
+++ b/components/modals/AvalancheCenterSelectionModal.tsx
@@ -11,6 +11,7 @@ import {Body, BodyBlack, Title3Black} from 'components/text';
 import {useAllAvalancheCenterMetadata} from 'hooks/useAllAvalancheCenterMetadata';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {Modal} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
 import {AvalancheCenter, AvalancheCenterID} from 'types/nationalAvalancheCenter';
 
@@ -37,7 +38,7 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
       metadata.push(result.data);
     }
   }
-
+  const safeAreaInsets = useSafeAreaInsets();
   return (
     <Modal transparent visible={visible && !loading} animationType="slide" onRequestClose={closeHandler} statusBarTranslucent>
       {incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities ? (
@@ -62,7 +63,7 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
             </ScrollView>
           </VStack>
           <Divider />
-          <Center height={100} width="100%" px={16} paddingBottom={16} backgroundColor={'white'} alignItems="stretch">
+          <Center height={100} width="100%" px={16} paddingBottom={safeAreaInsets.bottom} backgroundColor={'white'} alignItems="stretch">
             <Button disabled={!selectedCenter} onPress={closeHandler} buttonStyle="primary" mt={16}>
               <BodyBlack>Continue</BodyBlack>
             </Button>

--- a/components/observations/AvalancheObservationForm.tsx
+++ b/components/observations/AvalancheObservationForm.tsx
@@ -21,9 +21,9 @@ import {AvalancheObservationFormData, avalancheObservationFormSchema, defaultAva
 import {BodySemibold, Title3Semibold} from 'components/text';
 import helpStrings from 'content/helpStrings';
 import {add} from 'date-fns';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useKeyboardBehavior} from 'hooks/useKeyboardBehavior';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import {
   AvalancheAspect,
   AvalancheCenterID,
@@ -68,15 +68,15 @@ export const AvalancheObservationForm: React.FC<{
 
   const insets = useSafeAreaInsets();
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('avalancheObservationForm', {
+    if (center_id) {
+      analytics.screen('avalancheObservationForm', {
         center: center_id,
       });
     }
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   const today = new Date();

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -17,9 +17,9 @@ import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, bodySize} from 'components/text';
 import {HTML} from 'components/text/HTML';
 import {useAllMapLayers} from 'hooks/useAllMapLayers';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useNACObservation} from 'hooks/useNACObservation';
-import {usePostHog} from 'posthog-react-native';
 import {MainStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {
@@ -171,16 +171,16 @@ export const ObservationCard: React.FunctionComponent<{
 }> = ({observation, capabilities}) => {
   const {avalanches_observed, avalanches_triggered, avalanches_caught} = observation.instability;
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && observation.center_id && observation.id) {
-      void postHog.screen('observation', {
+    if (observation.center_id && observation.id) {
+      analytics.screen('observation', {
         center: observation.center_id,
         id: observation.id,
       });
     }
-  }, [postHog, observation.center_id, observation.id]);
+  }, [analytics, observation.center_id, observation.id]);
   useFocusEffect(recordAnalytics);
 
   const insets = useSafeAreaInsets();

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -30,11 +30,11 @@ import {UploaderState, getUploader} from 'components/observations/uploader/Obser
 import {TaskStatus} from 'components/observations/uploader/Task';
 import {Body, BodySemibold, Title3Semibold} from 'components/text';
 import helpStrings from 'content/helpStrings';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useKeyboardBehavior} from 'hooks/useKeyboardBehavior';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import Toast from 'react-native-toast-message';
 import {MainStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
@@ -75,15 +75,15 @@ export const ObservationForm: React.FC<{
 
   const keyboardVerticalOffset = useKeyboardVerticalOffset();
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('observationForm', {
+    if (center_id) {
+      analytics.screen('observationForm', {
         center: center_id,
       });
     }
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   useEffect(() => {

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -15,9 +15,9 @@ import {DateField} from 'components/form/DateField';
 import {SwitchField} from 'components/form/SwitchField';
 import {BodyBlack, BodySemibold, BodySmBlack, Title3Semibold} from 'components/text';
 import {endOfDay, isAfter, isBefore, parseISO} from 'date-fns';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useKeyboardBehavior} from 'hooks/useKeyboardBehavior';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import {FieldErrors, FormProvider, Resolver, useForm} from 'react-hook-form';
 import {KeyboardAvoidingView, View as RNView, ScrollView, TouchableOpacity, findNodeHandle} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -216,11 +216,11 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
     return true;
   });
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    void postHog?.screen('observationsFilter');
-  }, [postHog]);
+    analytics.screen('observationsFilter');
+  }, [analytics]);
   useFocusEffect(recordAnalytics);
 
   const onResetHandler = useCallback(() => formContext.reset(initialFilterConfig), [formContext, initialFilterConfig]);

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -16,11 +16,11 @@ import {usePendingObservations} from 'components/observations/uploader/usePendin
 import {Body, BodyBlack, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
 import {compareDesc, formatDuration, isBefore, parseISO, sub} from 'date-fns';
 import {useAllMapLayers} from 'hooks/useAllMapLayers';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useNACObservations} from 'hooks/useNACObservations';
 import {useRefresh} from 'hooks/useRefresh';
 import {useToggle} from 'hooks/useToggle';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import {
   ActivityIndicator,
   ColorValue,
@@ -74,16 +74,16 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
 
   const mapFeatures = useMemo(() => mapFeaturesForCenter(mapLayer, center_id), [mapLayer, center_id]);
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('observations', {
+    if (center_id) {
+      analytics.screen('observations', {
         center: center_id,
         zone: additionalFilters && additionalFilters.zones && additionalFilters.zones.length > 0 ? additionalFilters.zones[0] : 'global',
       });
     }
-  }, [postHog, additionalFilters, center_id]);
+  }, [analytics, additionalFilters, center_id]);
   useFocusEffect(recordAnalytics);
 
   // Filter inputs changed via render props should overwrite our current state

--- a/components/observations/ObservationsPortal.tsx
+++ b/components/observations/ObservationsPortal.tsx
@@ -4,8 +4,8 @@ import {Button} from 'components/content/Button';
 import {QueryState, incompleteQueryState} from 'components/content/QueryState';
 import {VStack, View} from 'components/core';
 import {Body, BodyBlack, Title3Black} from 'components/text';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
-import {usePostHog} from 'posthog-react-native';
 import React, {useCallback} from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {MainStackNavigationProps, TabNavigationProps} from 'routes';
@@ -23,13 +23,13 @@ export const ObservationsPortal: React.FC<{
     [center_id, tabNavigation, requestedTime],
   );
   const onSubmit = useCallback(() => mainNavigation.navigate('observationSubmit'), [mainNavigation]);
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    void postHog?.screen('observationsPortal', {
+    analytics.screen('observationsPortal', {
       center: center_id,
     });
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   const capabilitiesResult = useAvalancheCenterCapabilities();

--- a/components/screens/main/AboutScreen.tsx
+++ b/components/screens/main/AboutScreen.tsx
@@ -14,8 +14,8 @@ import {ActionList} from 'components/content/ActionList';
 import {Center, HStack, View, VStack} from 'components/core';
 import {getVersionInfoFull} from 'components/screens/main/Version';
 import {Body, BodyBlack, BodyXSm, Title3Black} from 'components/text';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
-import {usePostHog} from 'posthog-react-native';
 import {usePreferences} from 'Preferences';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MainStackParamList} from 'routes';
@@ -32,13 +32,13 @@ export const AboutScreen = (_: NativeStackScreenProps<MainStackParamList, 'about
     })();
   }, [mixpanelUserId, updateGroupId]);
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const insets = useSafeAreaInsets();
 
   const recordAnalytics = useCallback(() => {
-    void postHog?.screen('about');
-  }, [postHog]);
+    analytics.screen('about');
+  }, [analytics]);
   useFocusEffect(recordAnalytics);
 
   return (

--- a/components/screens/navigation/Drawer.tsx
+++ b/components/screens/navigation/Drawer.tsx
@@ -13,12 +13,12 @@ import {BodyBlack} from 'components/text';
 import {settingsMenuItems} from 'data/settingsMenuItems';
 import * as Updates from 'expo-updates';
 import * as WebBrowser from 'expo-web-browser';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {getUpdateGroupId} from 'hooks/useEASUpdateStatus';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {sendMail} from 'network/sendMail';
-import {usePostHog} from 'posthog-react-native';
 import {usePreferences} from 'Preferences';
 import React, {useCallback, useMemo} from 'react';
 import {ScrollView} from 'react-native';
@@ -87,11 +87,11 @@ const DrawerMenu: React.FunctionComponent<DrawerMenuProps> = ({navigation, avala
   } = usePreferences();
   const [updateGroupId] = getUpdateGroupId();
 
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    void postHog?.screen('menu');
-  }, [postHog]);
+    analytics.screen('menu');
+  }, [analytics]);
   useFocusEffect(recordAnalytics);
   const sendMailHandler = useCallback(
     () =>

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -12,10 +12,10 @@ import {BodyBlack, bodySize, BodyXSm, BodyXSmBlack} from 'components/text';
 import {formatDateTime} from 'components/weather_data/WeatherStationsDetail';
 import {centerOrPartnerCenter} from 'components/weather_data/WeatherUtils';
 import {compareDesc} from 'date-fns';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useWeatherStationTimeseries} from 'hooks/useWeatherStationTimeseries';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, StationNote, Variable, WeatherStationSource, WeatherStationTimeseries} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
@@ -42,16 +42,16 @@ export const WeatherStationDetail: React.FC<Props> = ({center_id, stationId, sou
   identifier[stationId] = source;
   const timeseriesResult = useWeatherStationTimeseries(metadata?.widget_config.stations?.token, identifier, requestedTimeDate, {days: days});
   const timeseries = timeseriesResult.data;
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id && stationId) {
-      void postHog.screen('weatherStation', {
+    if (center_id && stationId) {
+      analytics.screen('weatherStation', {
         center: center_id,
         stationId: stationId,
       });
     }
-  }, [postHog, center_id, stationId]);
+  }, [analytics, center_id, stationId]);
   useFocusEffect(recordAnalytics);
 
   if (incompleteQueryState(avalancheCenterMetadataResult, timeseriesResult) || !metadata || !timeseries) {

--- a/components/weather_data/WeatherStationFilterForm.tsx
+++ b/components/weather_data/WeatherStationFilterForm.tsx
@@ -12,8 +12,8 @@ import {SelectField} from 'components/form/SelectField';
 import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {BodyBlack, BodySemibold, Title3Semibold} from 'components/text';
 import {isAfter, isBefore, parseISO, sub} from 'date-fns';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import {FieldErrors, FormProvider, Resolver, useForm} from 'react-hook-form';
 import {KeyboardAvoidingView, Platform, View as RNView, ScrollView, TouchableOpacity, findNodeHandle} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -165,11 +165,11 @@ export const WeatherStationFilterForm: React.FunctionComponent<WeatherStationFil
   React.useEffect(() => {
     formContext.reset(currentFilterConfig);
   }, [formContext, currentFilterConfig]);
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    void postHog?.screen('weatherStationsFilter');
-  }, [postHog]);
+    analytics.screen('weatherStationsFilter');
+  }, [analytics]);
   useFocusEffect(recordAnalytics);
 
   const closeWithoutSaving = useCallback(() => {

--- a/components/weather_data/WeatherStationList.tsx
+++ b/components/weather_data/WeatherStationList.tsx
@@ -5,8 +5,8 @@ import {Divider, HStack, VStack, View} from 'components/core';
 import {FilterPillButton} from 'components/observations/ObservationsListView';
 import {WeatherStationFilterConfig, WeatherStationFilterForm, filtersForConfig} from 'components/weather_data/WeatherStationFilterForm';
 import {WeatherStationCard} from 'components/weather_data/WeatherStationMap';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useToggle} from 'hooks/useToggle';
-import {usePostHog} from 'posthog-react-native';
 import React, {useCallback, useMemo} from 'react';
 import {FlatList, ListRenderItemInfo, Modal, ScrollView, TouchableOpacity} from 'react-native';
 import {colorLookup} from 'theme';
@@ -32,15 +32,15 @@ export const WeatherStationList: React.FunctionComponent<{
   const currentTime = requestedTimeToUTCDate(parsedTime);
   const [filterConfig, setFilterConfig] = React.useState<WeatherStationFilterConfig>({...initialFilterConfig});
   const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal, off: hideFilterModal}] = useToggle(false);
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('weatherStations', {
+    if (center_id) {
+      analytics.screen('weatherStations', {
         center: center_id,
       });
     }
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   // when the initial filter inputs change, we should honor those

--- a/components/weather_data/WeatherStationMap.tsx
+++ b/components/weather_data/WeatherStationMap.tsx
@@ -20,8 +20,8 @@ import {BodySm, BodySmSemibold, Title3Black} from 'components/text';
 import {formatData, formatTime, formatUnits, orderStationVariables} from 'components/weather_data/WeatherStationDetail';
 import {formatInTimeZone} from 'date-fns-tz';
 import {FeatureCollection, Point} from 'geojson';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {LoggerContext, LoggerProps} from 'loggerContext';
-import {usePostHog} from 'posthog-react-native';
 import {MainStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {
@@ -85,15 +85,15 @@ export const WeatherStationMap: React.FunctionComponent<{
 }> = ({mapLayerFeatures, weatherStations, center_id, requestedTime, tabBarHeight, toggleList}) => {
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const avalancheCenterMapRegion = defaultMapRegionForGeometries(mapLayerFeatures.map(feature => feature.geometry));
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('weatherStationsMap', {
+    if (center_id) {
+      analytics.screen('weatherStationsMap', {
         center: center_id,
       });
     }
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   const navigation = useNavigation<MainStackNavigationProps>();

--- a/components/weather_data/WeatherStationPage.tsx
+++ b/components/weather_data/WeatherStationPage.tsx
@@ -5,10 +5,10 @@ import {WeatherStationList} from 'components/weather_data/WeatherStationList';
 import {WeatherStationMap} from 'components/weather_data/WeatherStationMap';
 import {centerOrPartnerCenter} from 'components/weather_data/WeatherUtils';
 import {useAllMapLayers} from 'hooks/useAllMapLayers';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useToggle} from 'hooks/useToggle';
 import {useWeatherStationsMetadata} from 'hooks/useWeatherStationsMetadata';
-import {usePostHog} from 'posthog-react-native';
 import React, {useCallback, useMemo} from 'react';
 import {AvalancheCenterID, mapFeaturesForCenter} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
@@ -23,15 +23,15 @@ interface Props {
 export const WeatherStationPage: React.FC<Props> = ({center_id, requestedTime, tabBarHeight}) => {
   const avalancheCenterMetadataResult = useAvalancheCenterMetadata(centerOrPartnerCenter(center_id));
   const metadata = avalancheCenterMetadataResult.data;
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id) {
-      void postHog.screen('weatherTab', {
+    if (center_id) {
+      analytics.screen('weatherTab', {
         center: center_id,
       });
     }
-  }, [postHog, center_id]);
+  }, [analytics, center_id]);
   useFocusEffect(recordAnalytics);
 
   if (incompleteQueryState(avalancheCenterMetadataResult) || !metadata) {

--- a/components/weather_data/WeatherStationsDetail.tsx
+++ b/components/weather_data/WeatherStationsDetail.tsx
@@ -2,8 +2,8 @@ import React, {useCallback, useMemo, useState} from 'react';
 
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {compareDesc} from 'date-fns';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {uniq} from 'lodash';
-import {usePostHog} from 'posthog-react-native';
 
 import {ButtonBar} from 'components/content/ButtonBar';
 import {DataGrid} from 'components/content/DataGrid';
@@ -278,16 +278,16 @@ export const WeatherStationsDetail: React.FC<Props> = ({center_id, name, station
   const requestedTimeDate = parseRequestedTimeString(requestedTime);
   const timeseriesResult = useWeatherStationTimeseries(metadata?.widget_config.stations?.token, stations, requestedTimeDate, {days: days});
   const timeseries = timeseriesResult.data;
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   const recordAnalytics = useCallback(() => {
-    if (postHog && center_id && name) {
-      void postHog.screen('weatherStations', {
+    if (center_id && name) {
+      analytics.screen('weatherStations', {
         center: center_id,
         name: name,
       });
     }
-  }, [postHog, center_id, name]);
+  }, [analytics, center_id, name]);
   useFocusEffect(recordAnalytics);
 
   React.useEffect(() => {

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,7 +1,3 @@
-/// <reference types="jest" />
-// TypeScript 6 no longer auto-includes @types/jest's ambient globals (describe/it/expect),
-// so we reference it explicitly here to keep them available in test files.
-
 declare module '*.svg' {
   import React from 'react';
   import {SvgProps} from 'react-native-svg';

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -1,0 +1,36 @@
+import {useContext, useMemo} from 'react';
+
+import {Logger} from 'browser-bunyan';
+import PostHog, {usePostHog} from 'posthog-react-native';
+
+import {LoggerContext} from 'loggerContext';
+import {fireAndForget} from 'utils/fireAndForget';
+
+// A thin wrapper around the PostHog client. Several PostHog v4 methods return a Promise; this wraps the
+// fire-and-forget calls (screen, register) so rejections are logged instead of silently swallowed.
+// `reloadFeatureFlags` returns its promise so callers that want the resolved flags can await it.
+export interface Analytics {
+  screen(...args: Parameters<PostHog['screen']>): void;
+  capture(...args: Parameters<PostHog['capture']>): void;
+  identify(...args: Parameters<PostHog['identify']>): void;
+  register(...args: Parameters<PostHog['register']>): void;
+  reloadFeatureFlags(...args: Parameters<PostHog['reloadFeatureFlagsAsync']>): ReturnType<PostHog['reloadFeatureFlagsAsync']> | undefined;
+}
+
+export const createAnalytics = (postHog: PostHog | undefined, logger: Logger): Analytics => ({
+  screen: (...args) => fireAndForget(postHog?.screen(...args), `failed to capture ${args[0]} screen view`, logger),
+  register: (...args) => fireAndForget(postHog?.register(...args), 'failed to register analytics super properties', logger),
+  capture: (...args) => {
+    postHog?.capture(...args);
+  },
+  identify: (...args) => {
+    postHog?.identify(...args);
+  },
+  reloadFeatureFlags: (...args) => postHog?.reloadFeatureFlagsAsync(...args),
+});
+
+export const useAnalytics = (): Analytics => {
+  const postHog = usePostHog();
+  const {logger} = useContext(LoggerContext);
+  return useMemo(() => createAnalytics(postHog, logger), [postHog, logger]);
+};

--- a/tests/mockReanimated.ts
+++ b/tests/mockReanimated.ts
@@ -1,8 +1,12 @@
 // require() is required here: jest.mock factories are hoisted above imports, so imported bindings can't be referenced inside them.
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return */
-// react-native-reanimated's native runtime (react-native-worklets) isn't available under Jest and throws on
-// import. Swap both packages for the mocks they ship so components that import reanimated can be tested.
-// reanimated exposes a top-level `mock` entry; worklets ships its mock as published source (`src/mock`), which is
-// the same path reanimated's own mock entry references internally.
+// In Reanimated 4 the native runtime lives in react-native-worklets, which throws when imported under Jest. Per the
+// official Worklets Jest guide, swap it for the mock it ships as published source (`src/mock` for TypeScript). With
+// Worklets mocked, the real Reanimated module runs under Jest without touching native — the legacy
+// `jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'))` module swap is no longer needed.
 jest.mock('react-native-worklets', () => require('react-native-worklets/src/mock'));
-jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
+
+import {setUpTests} from 'react-native-reanimated';
+
+// Registers Reanimated's custom Jest matchers (toHaveAnimatedStyle / toHaveAnimatedProps) and frame timing config.
+setUpTests();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "outDir": "dist",
     "sourceMap": true,
     "strict": true,
-    "jsx": "react-native"
+    "jsx": "react-native",
+    "types": ["jest"]
   },
   "ts-node": {
     "compilerOptions": {}

--- a/utils/fireAndForget.ts
+++ b/utils/fireAndForget.ts
@@ -1,0 +1,13 @@
+import {Logger} from 'browser-bunyan';
+
+import {logger as defaultLogger} from 'logger';
+
+// Some APIs (e.g. PostHog's v4 client) return a Promise from methods we want to call in a
+// fire-and-forget fashion. Using the `void` operator on those promises silences the floating-promise
+// lint, but it also swallows any rejection silently. `fireAndForget` keeps the call fire-and-forget
+// while attaching a `.catch` so that an unexpected rejection is logged instead of disappearing.
+export function fireAndForget(promise: Promise<unknown> | undefined, message = 'fire-and-forget promise rejected', logger: Logger = defaultLogger): void {
+  void promise?.catch((error: unknown) => {
+    logger.error({error}, message);
+  });
+}


### PR DESCRIPTION
This address comments from the initial Expo 56 PR: #1189 

## Introducing `useAnalytics`

PostHog introduced return `Promises` for a few of their API calls in v4. As per the comment on the last PR, I was going to create a `fireAndForget` helper function so that the calls to PostHog that are now using `void` will log errors that come from PostHog. However, that means that anytime we add a `screen` call, we need to remember to wrap it in `fireAndForget`. To make it easier/less error prone, I introduced a `useAnalytics` hook that wraps PostHog so that we can call the functions correctly without having to wrap them in `fireAndForget`. There still is a new `fireAnForget` utility function that we can use for other things.

## @types/jest

Removed the reference to jest from `declarations.d.ts` into the `types` property in `tsconfig.js`

## `reanimated` mocks

The mocking for `react-native-reanimated` now uses their approved `setupTests()`

## Small tweak

Added the `paddingBottom={safeAreaInsets.bottom}` back to the selection modal, but on the button instead of the scroll view content