### PR TITLE
Orient forecast map to north on location button tap

### DIFF
--- a/components/map/AvalancheForecastMapView.tsx
+++ b/components/map/AvalancheForecastMapView.tsx
@@ -159,7 +159,8 @@ export const AvalancheForecastMapView: React.FunctionComponent<AvalancheForecast
 
   useEffect(() => {
     if (userLocation) {
-      mapCameraRef.current?.setCamera({centerCoordinate: userLocation, zoomLevel: 7});
+      // Center on the user's location and re-orient the map to north (heading: 0).
+      mapCameraRef.current?.setCamera({centerCoordinate: userLocation, zoomLevel: 7, heading: 0});
     }
   }, [mapCameraRef, userLocation]);
 


### PR DESCRIPTION
When tapping the location button on the forecast map, the map now re-orients to north (`heading: 0`) in addition to centering on the user's location.

Fixes #1194

Generated with [Claude Code](https://claude.ai/code)