### PR TITLE
Use panning to trigger no center experience

### DIFF
--- a/components/helpers/geographicCoordinates.test.ts
+++ b/components/helpers/geographicCoordinates.test.ts
@@ -1,5 +1,15 @@
-import {AvalancheCenterRegion, avalancheCenterRegionFromRegionBounds, boundsForRegions, RegionBounds, updateBoundsToContain} from 'components/helpers/geographicCoordinates';
+import {
+  AvalancheCenterRegion,
+  avalancheCenterRegionFromRegionBounds,
+  boundsForRegions,
+  insetViewportBounds,
+  RegionBounds,
+  regionBoundsVisible,
+  updateBoundsToContain,
+} from 'components/helpers/geographicCoordinates';
 import {Position} from 'types/nationalAvalancheCenter';
+
+import {CameraBounds} from '@rnmapbox/maps';
 
 describe('AvalancheForecastZonePolygon', () => {
   describe('updateRegionToContain', () => {
@@ -117,6 +127,75 @@ describe('AvalancheForecastZonePolygon', () => {
         topRight: {longitude: -50, latitude: 40},
         bottomLeft: {longitude: -110, latitude: 10},
       });
+    });
+  });
+
+  describe('regionBoundsVisible', () => {
+    // center box: lng -110..-100, lat 40..50
+    const centerBounds: CameraBounds = {ne: [-100, 50], sw: [-110, 40]};
+
+    it('is visible when the viewport fully contains the center', () => {
+      expect(regionBoundsVisible(centerBounds, {ne: [-95, 55], sw: [-115, 35]})).toBe(true);
+    });
+
+    it('is visible when the viewport is entirely inside the center', () => {
+      expect(regionBoundsVisible(centerBounds, {ne: [-105, 45], sw: [-108, 42]})).toBe(true);
+    });
+
+    it('is visible when only a sliver of the center overlaps the viewport', () => {
+      // viewport lng -101..-99 overlaps the center's eastern edge at -100..-101
+      expect(regionBoundsVisible(centerBounds, {ne: [-99, 45], sw: [-101, 42]})).toBe(true);
+    });
+
+    it('is not visible when the viewport is entirely east of the center', () => {
+      expect(regionBoundsVisible(centerBounds, {ne: [-90, 45], sw: [-95, 42]})).toBe(false);
+    });
+
+    it('is not visible when the viewport is entirely west of the center', () => {
+      expect(regionBoundsVisible(centerBounds, {ne: [-115, 45], sw: [-120, 42]})).toBe(false);
+    });
+
+    it('is not visible when the viewport is entirely north of the center', () => {
+      expect(regionBoundsVisible(centerBounds, {ne: [-105, 60], sw: [-108, 55]})).toBe(false);
+    });
+
+    it('is not visible when the viewport is entirely south of the center', () => {
+      expect(regionBoundsVisible(centerBounds, {ne: [-105, 35], sw: [-108, 30]})).toBe(false);
+    });
+  });
+
+  describe('insetViewportBounds', () => {
+    // viewport lat 40..50 (span 10) over a 1000px-tall map; longitude untouched.
+    const viewport = {ne: [-100, 50] as Position, sw: [-110, 40] as Position};
+
+    it('moves the north edge south by the header fraction and the south edge north by the tab bar fraction', () => {
+      // 100px header of 1000px = 10% of the 10deg span = 1deg off the north edge; 200px tab bar = 2deg off the south edge.
+      expect(insetViewportBounds(viewport, {topInset: 100, bottomInset: 200, mapHeight: 1000})).toStrictEqual({
+        ne: [-100, 49],
+        sw: [-110, 42],
+      });
+    });
+
+    it('leaves longitude unchanged', () => {
+      const result = insetViewportBounds(viewport, {topInset: 100, bottomInset: 200, mapHeight: 1000});
+      expect(result.ne[0]).toBe(-100);
+      expect(result.sw[0]).toBe(-110);
+    });
+
+    it('returns the viewport unchanged with zero insets', () => {
+      expect(insetViewportBounds(viewport, {topInset: 0, bottomInset: 0, mapHeight: 1000})).toStrictEqual(viewport);
+    });
+
+    it('returns the viewport unchanged when the map height is non-positive', () => {
+      expect(insetViewportBounds(viewport, {topInset: 100, bottomInset: 200, mapHeight: 0})).toStrictEqual(viewport);
+    });
+
+    it('shrinks the visible viewport enough to drop a center hidden behind the header', () => {
+      // center sits in the top 1deg of the viewport (lat 49..50), which a 200px/1000px header (2deg) hides.
+      const centerBounds: CameraBounds = {ne: [-104, 50], sw: [-106, 49]};
+      const inset = insetViewportBounds(viewport, {topInset: 200, bottomInset: 0, mapHeight: 1000});
+      expect(regionBoundsVisible(centerBounds, viewport)).toBe(true); // visible against the full (untrimmed) bounds
+      expect(regionBoundsVisible(centerBounds, inset)).toBe(false); // hidden once the header inset is applied
     });
   });
 });

--- a/components/helpers/geographicCoordinates.ts
+++ b/components/helpers/geographicCoordinates.ts
@@ -96,6 +96,30 @@ export const boundsForRegions = (bounds: RegionBounds[]): RegionBounds => ({
   bottomLeft: {longitude: Math.min(...bounds.map(b => b.bottomLeft.longitude)), latitude: Math.min(...bounds.map(b => b.bottomLeft.latitude))},
 });
 
+// The map fills the whole screen (absoluteFill), so its reported bounds include the area hidden behind the
+// header (top) and tab bar (bottom). Shrink the viewport's latitude span to the unobstructed area so a center
+// hidden behind that chrome counts as off-screen. Longitude is unchanged because the header/tab bar span the full width.
+export const insetViewportBounds = (viewport: CameraBounds, {topInset, bottomInset, mapHeight}: {topInset: number; bottomInset: number; mapHeight: number}): CameraBounds => {
+  if (mapHeight <= 0) {
+    return viewport;
+  }
+  const latSpan = viewport.ne[1] - viewport.sw[1];
+  return {
+    // ne[1] is the north edge at the top of the screen; the header obstructs it, so move it south.
+    ne: [viewport.ne[0], viewport.ne[1] - (topInset / mapHeight) * latSpan],
+    // sw[1] is the south edge at the bottom of the screen; the tab bar obstructs it, so move it north.
+    sw: [viewport.sw[0], viewport.sw[1] + (bottomInset / mapHeight) * latSpan],
+  };
+};
+
+// True when the avalanche center's bounding box overlaps the visible map viewport at all.
+// Both args are {ne, sw} where ne = [maxLng, maxLat], sw = [minLng, minLat].
+export const regionBoundsVisible = (centerBounds: CameraBounds, viewport: CameraBounds): boolean =>
+  centerBounds.sw[0] <= viewport.ne[0] && // center's west edge is at/left of viewport's east edge
+  centerBounds.ne[0] >= viewport.sw[0] && // center's east edge is at/right of viewport's west edge
+  centerBounds.sw[1] <= viewport.ne[1] && // center's south edge is at/below viewport's north edge
+  centerBounds.ne[1] >= viewport.sw[1]; //   center's north edge is at/above viewport's south edge
+
 export const pointInBounds = (position: AvyPosition, {topRight, bottomLeft}: RegionBounds): boolean =>
   position.latitude >= bottomLeft.latitude && position.latitude <= topRight.latitude && position.longitude >= bottomLeft.longitude && position.longitude >= topRight.longitude;
 

--- a/components/map/AvalancheForecastMapView.tsx
+++ b/components/map/AvalancheForecastMapView.tsx
@@ -14,7 +14,7 @@ import {AvalancheCenterID, isSupportedCenter} from 'types/nationalAvalancheCente
 import {formatRequestedTime, RequestedTime} from 'utils/date';
 
 import {Camera, CameraStop, MapState} from '@rnmapbox/maps';
-import {defaultMapRegionForGeometries} from 'components/helpers/geographicCoordinates';
+import {defaultMapRegionForGeometries, insetViewportBounds, regionBoundsVisible} from 'components/helpers/geographicCoordinates';
 import {AvalancheForecastZoneCards} from 'components/map/AvalancheForecastZoneCards';
 import {TopElementMeasurments} from 'components/map/AvalancheForecastZoneMap';
 import {Position} from 'geojson';
@@ -29,12 +29,6 @@ interface AvalancheForecastMapViewProps {
   topElementMeasurements?: TopElementMeasurments;
   userLocation?: Position | undefined;
 }
-
-// These map zoom level thresholds control when the AnimatedCards are automatically hidden and when the isInNoCenterExperience triggers
-// In Mapbox, the levels start at 0 (most zoomed out) and go to 22 (most zoomed in). The card threshold therefore happens first and then the no center experience is triggered
-// This prevents all the changes from happening at once
-const CARD_HIDDEN_ZOOM_THRESHOLD = 6;
-const NO_CENTER_EXPERIENCE_ZOOM_THRESHOLD = 5;
 
 export const AvalancheForecastMapView: React.FunctionComponent<AvalancheForecastMapViewProps> = ({
   preferredCenterId,
@@ -132,13 +126,23 @@ export const AvalancheForecastMapView: React.FunctionComponent<AvalancheForecast
 
   const onCameraChanged = useCallback(
     (mapState: MapState) => {
-      if (mapState.gestures.isGestureActive) {
-        if (mapState.properties.zoom < CARD_HIDDEN_ZOOM_THRESHOLD && controller.current.state !== AnimatedDrawerState.Hidden) {
-          controller.current.setState(AnimatedDrawerState.Hidden, false);
+      // Guard: with no preferred-center zones the center bounds are degenerate (0,0); skip detection.
+      if (mapState.gestures.isGestureActive && preferredCenterZones.length > 0 && !isInNoCenterExperienceRef.current) {
+        // The map fills the whole screen, so trim its bounds to the area not covered by the header and tab bar
+        // before testing visibility — otherwise a center hidden behind that chrome would still count as on-screen.
+        const visibleViewport = insetViewportBounds(mapState.properties.bounds, {
+          topInset: topElementMeasurements.yPos + topElementMeasurements.height,
+          bottomInset: tabBarHeight,
+          mapHeight: windowHeight,
+        });
+        const centerVisible = regionBoundsVisible(avalancheCenterMapRegion.cameraBounds, visibleViewport);
+        if (!centerVisible) {
+          // The preferred center has been panned fully off-screen: hide the cards, clear the selection,
+          // and enter the no-center experience together as a single event.
+          if (controller.current.state !== AnimatedDrawerState.Hidden) {
+            controller.current.setState(AnimatedDrawerState.Hidden, false);
+          }
           setSelectedZoneId(null);
-        }
-
-        if (!isInNoCenterExperienceRef.current && mapState.properties.zoom < NO_CENTER_EXPERIENCE_ZOOM_THRESHOLD) {
           // Updating the ref here helps prevent unnecessary calls to setIsInNoCenterExperience.
           isInNoCenterExperienceRef.current = true;
           setIsInNoCenterExperience(true);
@@ -154,7 +158,7 @@ export const AvalancheForecastMapView: React.FunctionComponent<AvalancheForecast
         });
       }
     },
-    [controller, setIsInNoCenterExperience, saveMapCamera, setSelectedZoneId],
+    [controller, avalancheCenterMapRegion, preferredCenterZones, topElementMeasurements, tabBarHeight, windowHeight, setIsInNoCenterExperience, saveMapCamera, setSelectedZoneId],
   );
 
   useEffect(() => {


### PR DESCRIPTION
-#1187

Replaces the zoom gesture with a pan gesture to trigger the no center experience. Now when the center center is out of view on the screen, the no center experience is trigger.

<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-06-15 at 11 14 26" src="https://github.com/user-attachments/assets/306ea64a-f63a-4cc8-a80c-af8a6a2a68fd" />
