### PR TITLE
Fix Time Machine

### DIFF
--- a/components/screens/main/DeveloperMenu.tsx
+++ b/components/screens/main/DeveloperMenu.tsx
@@ -770,7 +770,14 @@ export const TimeMachine = () => {
   const {requestedTime, setRequestedTime} = React.useContext(ClientContext);
   const changeTime = useCallback(
     (time: RequestedTime) => {
-      setRequestedTime(time);
+      // The TimeMachine picks a calendar *day*, but a Date also carries a time-of-day. The map layer and warnings
+      // format requestedTime in UTC, while forecasts convert it to the center's *nominal* forecast day (which rolls
+      // forward at the evening expiry hour). An off-hours instant can therefore make those projections land on
+      // different days (e.g. map shows 2/16 while the forecast resolves to 2/17). Collapse any selected day to noon
+      // UTC — early morning across every US timezone, and safely before any expiry hour — so both projections resolve
+      // to the same date.
+      const normalized: RequestedTime = time === 'latest' ? 'latest' : new Date(Date.UTC(time.getFullYear(), time.getMonth(), time.getDate(), 12, 0, 0, 0));
+      setRequestedTime(normalized);
     },
     [setRequestedTime],
   );


### PR DESCRIPTION
This adds a hard coded timestamp to the date that's set from Time Machine to keep API calls consistent.

We noticed an issue where depending on the time of day you change Time Machine, some APIs are returning different day results. The most noticeable example was the difference between the `map-layer` and `products?avalanche_center=&date_start=&date_end=` calls we're making. The reason is that `fetchAvalancheForecast` in `useAvalancheForecast` calls `nominalForecastDate` when fetching an avalanche forecast fragment. This calculates the date based off the avalanche center's `expiry_time` and changes the date based on if we know that the the avalanche center has a new forecast available. 

The fix here forces the calls to be made within the same day so that there's no mismatch by adding a timestamp to the date instead of using the on device timestamp. This is only used for testing in Time Machine so it should give us the results we want even if under the hood we're potentially showing "wrong" data.