### PR TITLE
Turn animated cards into paging view

### DIFF
--- a/components/map/AnimatedCards.tsx
+++ b/components/map/AnimatedCards.tsx
@@ -382,16 +382,17 @@ export const AnimatedCards = <T, U>(props: AnimatedCardsProps<T, U>) => {
   const [programmaticallyScrolling, setProgrammaticallyScrolling] = useState<boolean>(false);
   const isUserScrolling = useRef(false);
 
-  const offsets = items?.map((_itemData, index) => index * CARD_WIDTH * width + (index - 1) * CARD_SPACING * width);
+  const cardInterval = (CARD_WIDTH + CARD_SPACING) * width;
+  const offsets = items?.map((_itemData, index) => index * cardInterval - (CARD_SPACING + CARD_MARGIN) * width);
   const flatListProps = {
     snapToAlignment: 'center',
     decelerationRate: 'fast',
-    snapToOffsets: offsets,
+    snapToInterval: cardInterval,
+    disableIntervalMomentum: true,
     contentInset: {
       left: CARD_MARGIN * width,
       right: CARD_MARGIN * width,
     },
-    contentContainerStyle: {paddingHorizontal: CARD_MARGIN * width},
   } as const;
 
   const panResponder = useRef(
@@ -489,11 +490,11 @@ export const AnimatedCards = <T, U>(props: AnimatedCardsProps<T, U>) => {
 
   const getItemLayout = useCallback(
     (_data: unknown, index: number) => ({
-      length: width * (CARD_WIDTH + CARD_SPACING),
+      length: cardInterval,
       offset: offsets[index],
       index,
     }),
-    [offsets, width],
+    [offsets, cardInterval],
   );
 
   const getItemCount = useCallback(() => items.length, [items]);


### PR DESCRIPTION
@rustynwac was hitting an issue where it seemed to take multiple taps on the cards to take him to the forecast. This was caused, in part, by the cards decelerating after a swipe to snap to a specific interview. What happens is the first tap stops the animation, and the second tap does the navigation. 

As a way to make this less noticeable, I updated the cards to page 1 zone/weather station at a time so that there's less decelerating/animating happening. This frees up the card faster so it feels more responsive. One thing to note with this change is that before it was possible to swipe fast and have the list go through multiple cards at once. Now, no matter how fast the swipe is it'll only ever go to the next card.

Instead of snapping to an offset like before it uses a combination of `snapToInterval` and `disableIntervalMomentum` to achieve the same effect as having `pagingEnabled` set to true.  This is the documented method of paging with views that do not take up the entire screen width.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786227917&installation_id=144816107&pr_number=1210&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1210&signature=86972110a29fe7b9a730c6b37e1ec0cef22ee92cf12f58e443433d7291a7c61c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->