### PR TITLE
Add NYSAC to the list of known avalanche centers

### DIFF
--- a/components/AvalancheCenterLogo.tsx
+++ b/components/AvalancheCenterLogo.tsx
@@ -53,6 +53,7 @@ export const AvalancheCenterLogo: React.FunctionComponent<AvalancheCenterLogoPro
     ['EARAC']: Image.resolveAssetSource(require('../assets/logos/WCMAC.png')),
     ['CAC']: Image.resolveAssetSource(require('../assets/logos/WCMAC.png')),
     ['CAAC']: Image.resolveAssetSource(require('../assets/logos/WCMAC.png')),
+    ['NYSAC']: Image.resolveAssetSource(require('../assets/logos/WCMAC.png')),
   };
 
   const {data: uri} = useCachedImageURI(source[avalancheCenterId].uri);
@@ -149,6 +150,9 @@ export const AvalancheCenterLogo: React.FunctionComponent<AvalancheCenterLogoPro
     ['CAAC']: (s: ImageStyle) => {
       return <Image style={s} source={{uri: uri}} />;
     },
+    ['NYSAC']: (s: ImageStyle) => {
+      return <Image style={s} source={{uri: uri}} />;
+    },
   };
   const actualStyle: ImageStyle = {...style};
   if (actualStyle.resizeMode !== 'contain') {
@@ -222,6 +226,8 @@ export const preloadAvalancheCenterLogo = async (queryClient: QueryClient, logge
     case 'CAC':
       return ImageCache.prefetch(queryClient, logger, Image.resolveAssetSource(require('../assets/logos/WCMAC.png')).uri);
     case 'CAAC':
+      return ImageCache.prefetch(queryClient, logger, Image.resolveAssetSource(require('../assets/logos/WCMAC.png')).uri);
+    case 'NYSAC':
       return ImageCache.prefetch(queryClient, logger, Image.resolveAssetSource(require('../assets/logos/WCMAC.png')).uri);
   }
   const invalid: never = avalancheCenter;

--- a/data/settingsMenuItems.ts
+++ b/data/settingsMenuItems.ts
@@ -263,4 +263,5 @@ export const settingsMenuItems: Record<AvalancheCenterID, {title: string; url: s
   CAC: [],
   CAAC: [],
   UAC: [],
+  NYSAC: [],
 };

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -15,6 +15,7 @@ export const avalancheCenterIDSchema = z.enum([
   'MSAC', // Mount Shasta: CA
   'MWAC', // Mount Washington: NH
   'NWAC', // Northwest: WA, OR
+  'NYSAC', // New York State - Currently Unsupported with plans to fully support them
   'PAC', // Payette: ID
   'SAC', // Sierra: CA
   'SNFAC', // Sawtooths: ID
@@ -65,6 +66,7 @@ export const isSupportedCenter = (centerId: AvalancheCenterID): boolean => {
     case 'EARAC':
     case 'CAC':
     case 'CAAC':
+    case 'NYSAC':
       return false;
   }
 };
@@ -104,6 +106,7 @@ export const AvalancheCenterWebsites: Record<AvalancheCenterID, string> = {
   ['EARAC']: 'https://alaskasnow.org/eastern-ak-range/',
   ['CAC']: 'https://alaskasnow.org/cordova/',
   ['CAAC']: 'https://www.coastalakavalanche.org/',
+  ['NYSAC']: '',
 };
 
 export enum DangerLevel {
@@ -806,7 +809,7 @@ export type AvalancheCenter = z.infer<typeof avalancheCenterSchema>;
 export const mapLayerPropertiesSchema = z.object({
   name: z.string(),
   center_id: avalancheCenterIDSchema,
-  center_link: z.string(),
+  center_link: z.string().nullable(), // Optional for NYSAC. This will be reverted once NYSAC is onboarded
   state: z.string(),
   link: z.string(),
   off_season: z.boolean(),


### PR DESCRIPTION
Adds New York State Avalanche Center to the list of known, but unsupported, centers. This unblocks Preview as information for the new center is being returned in the full map layer call. Production is okay since we're still using the center specific map layer call for that.

The plan is for them to be fully supported in the App. That work is being tracked here https://github.com/NWACus/avy/issues/1212

NYSAC in the app
<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-21 at 12 42 22" src="https://github.com/user-attachments/assets/50ccb74a-c2e8-47e0-a268-66be6441a151" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787255488&installation_model_id=426131&pr_number=1213&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1213&signature=fbafb0d5544e82c8620d33159b4ba2edfb50c9de4e63f8ba6297e2b451018d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->