### PR TITLE
Add GNFAC to Prod

### DIFF
--- a/components/avalancheCenterList.ts
+++ b/components/avalancheCenterList.ts
@@ -16,6 +16,7 @@ export const supportedAvalancheCenters = (): {center: AvalancheCenterID; descrip
     {center: 'COAA', description: 'Avalanche forecasts for central Oregon.'},
     {center: 'ESAC', description: 'Avalanche forecasts for the Eastern Sierra region in California.'},
     {center: 'FAC', description: 'Avalanche forecasts for Northwestern Montana.'},
+    {center: 'GNFAC', description: 'Avalanche forecasts for Southwest Montana.'},
     {center: 'HPAC', description: 'Avalanche forecasts for the Hatcher Pass region in Alaska.'},
     {center: 'IPAC', description: 'Avalanche forecasts for the Idaho panhandle.'},
     {center: 'MSAC', description: 'Avalanche forecasts for the Mount Shasta region in California.'},
@@ -31,7 +32,6 @@ export const supportedAvalancheCenters = (): {center: AvalancheCenterID; descrip
     centers.push(
       // { center: 'AAIC', description: 'Avalanche forecasts for Alaska.' }, // This is needed to fetch the metadata for AAIC but it is not a selectable center
       {center: 'HAC', description: 'Avalanche forecasts for the Haines region in Alaska.'},
-      {center: 'GNFAC', description: 'Avalanche forecasts for Southwest Montana.'},
       {center: 'KPAC', description: 'Avalanche forecasts for the Kachina region in Arizona.'},
       {center: 'TAC', description: 'Avalanche forecasts for the Taos Valley in New Mexico.'},
       {center: 'VAC', description: 'Avalanche forecasts for the Valdez region of Alaska.'},


### PR DESCRIPTION
Moved GNFAC up in the avalanche center list so that it appears in Prod.

@rustynwac let me know if they have any support URLs that they would like to see in the Drawer Menu. I'll leave the PR open until we have those ready to go

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787271310&installation_model_id=426131&pr_number=1214&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1214&signature=94be2dc80992b9d386d598b1f2129b36df67a2d550cdbd63a8b7ed6597f19dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->