### PR TITLE
Observation Only Zones

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback} from 'react';
 import {Image, ScrollView} from 'react-native';
 
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -13,10 +13,8 @@ import {QueryState, incompleteQueryState} from 'components/content/QueryState';
 import {HStack, VStack, View} from 'components/core';
 import {NACAvalancheIcon} from 'components/icons/nac-icons';
 import {ZoneMap} from 'components/map/ZoneMap';
-import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, bodySize} from 'components/text';
 import {HTML} from 'components/text/HTML';
-import {useAllMapLayers} from 'hooks/useAllMapLayers';
 import {useAnalytics} from 'hooks/useAnalytics';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
 import {useNACObservation} from 'hooks/useNACObservation';
@@ -28,7 +26,6 @@ import {
   AvalancheAspect,
   AvalancheBedSurface,
   AvalancheCause,
-  AvalancheCenterID,
   AvalancheTrigger,
   AvalancheType,
   AvyPosition,
@@ -49,36 +46,27 @@ import {
   Position,
   SnowAvailableForTransport,
   WindLoading,
-  mapFeaturesForCenter,
   userFacingCenterId,
 } from 'types/nationalAvalancheCenter';
 import {observationDateToLocalShortDateString, utcDateToLocalShortDateString} from 'utils/date';
 
 export const ObservationDetailView: React.FunctionComponent<{
   id: string;
-}> = ({id}) => {
+  zoneName: string;
+}> = ({id, zoneName}) => {
   const observationResult = useNACObservation(id);
   const observation = observationResult.data;
-  const mapResult = useAllMapLayers('latest');
-  const mapLayer = mapResult.data;
   const capabilitiesResult = useAvalancheCenterCapabilities();
   const capabilities = capabilitiesResult.data;
 
-  const mapFeatures = useMemo(() => mapFeaturesForCenter(mapLayer, observation?.center_id.toUpperCase() as AvalancheCenterID), [mapLayer, observation?.center_id]);
   const navigation = useNavigation<MainStackNavigationProps>();
-  const zone_name = useMemo(
-    () => observation?.location_point?.lat && observation?.location_point?.lng && matchesZone(mapFeatures ?? [], observation.location_point?.lat, observation.location_point?.lng),
-    [observation, mapFeatures],
-  );
 
   React.useEffect(() => {
-    if (zone_name) {
-      navigation.setOptions({title: `${zone_name} Observation`});
-    }
-  }, [navigation, zone_name]);
+    navigation.setOptions({title: `${zoneName} Observation`});
+  }, [navigation, zoneName]);
 
-  if (incompleteQueryState(observationResult, mapResult, capabilitiesResult) || !observation || !mapLayer || !capabilities || !capabilities) {
-    return <QueryState results={[observationResult, mapResult, capabilitiesResult]} />;
+  if (incompleteQueryState(observationResult, capabilitiesResult) || !observation || !capabilities) {
+    return <QueryState results={[observationResult, capabilitiesResult]} />;
   }
 
   return <ObservationCard observation={observation} capabilities={capabilities} />;

--- a/components/observations/ObservationDetailViewModal.tsx
+++ b/components/observations/ObservationDetailViewModal.tsx
@@ -7,12 +7,14 @@ import {ObservationCard} from 'components/observations/ObservationDetailView';
 import {matchesZone} from 'components/observations/ObservationsFilterForm';
 import {Title3Black} from 'components/text';
 import {useAllMapLayers} from 'hooks/useAllMapLayers';
+import {useAlternateObservationZones} from 'hooks/useAlternateObservationZones';
 import {useAvalancheCenterCapabilities} from 'hooks/useAvalancheCenterCapabilities';
+import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useNACObservation} from 'hooks/useNACObservation';
 import React, {useCallback, useMemo} from 'react';
 import {MainStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
-import {AvalancheCenterID, mapFeaturesForCenter} from 'types/nationalAvalancheCenter';
+import {AllAvalancheCenterCapabilities, AvalancheCenterID, mapFeaturesForCenter, MapLayer, Observation} from 'types/nationalAvalancheCenter';
 
 export const ObservationDetailModalView: React.FunctionComponent<{
   id: string;
@@ -24,22 +26,40 @@ export const ObservationDetailModalView: React.FunctionComponent<{
   const capabilitiesResult = useAvalancheCenterCapabilities();
   const capabilities = capabilitiesResult.data;
 
-  const mapFeatures = useMemo(() => mapFeaturesForCenter(mapLayer, observation?.center_id.toUpperCase() as AvalancheCenterID), [mapLayer, observation?.center_id]);
-  const navigation = useNavigation<MainStackNavigationProps>();
-  const zone_name = useMemo(
-    () => observation?.location_point?.lat && observation?.location_point?.lng && matchesZone(mapFeatures ?? [], observation.location_point?.lat, observation.location_point?.lng),
-    [observation, mapFeatures],
-  );
-
-  const closeModal = useCallback(() => navigation.goBack(), [navigation]);
-
   if (incompleteQueryState(observationResult, mapResult, capabilitiesResult) || !observation || !mapLayer || !capabilities) {
     return <QueryState results={[observationResult, mapResult, capabilitiesResult]} />;
   }
 
+  return <ObservationDetailModalContent observation={observation} mapLayer={mapLayer} capabilities={capabilities} />;
+};
+
+const ObservationDetailModalContent: React.FunctionComponent<{
+  observation: Observation;
+  mapLayer: MapLayer;
+  capabilities: AllAvalancheCenterCapabilities;
+}> = ({observation, mapLayer, capabilities}) => {
+  const centerId = observation.center_id;
+
+  const avalancheZoneMetadataResult = useAvalancheCenterMetadata(centerId);
+  const alternateZonesUrl: string = avalancheZoneMetadataResult.data?.widget_config?.observation_viewer?.alternate_zones || '';
+  const alternateObservationZonesResult = useAlternateObservationZones(alternateZonesUrl, centerId);
+  const alternateObservationZoneFeatures = alternateObservationZonesResult.data?.features;
+
+  const mapFeatures = useMemo(() => mapFeaturesForCenter(mapLayer, centerId), [mapLayer, centerId]);
+  const navigation = useNavigation<MainStackNavigationProps>();
+  const zone_name = useMemo(
+    () =>
+      observation.location_point?.lat &&
+      observation.location_point?.lng &&
+      matchesZone(mapFeatures ?? [], observation.location_point.lat, observation.location_point.lng, alternateObservationZoneFeatures),
+    [observation, mapFeatures, alternateObservationZoneFeatures],
+  );
+
+  const closeModal = useCallback(() => navigation.goBack(), [navigation]);
+
   return (
     <View flex={1}>
-      <ObsDetailModalHeader title={zone_name ? `${zone_name} Observation` : 'Observation'} centerId={observation.center_id} onClosePressed={closeModal} />
+      <ObsDetailModalHeader title={zone_name ? `${zone_name} Observation` : 'Observation'} centerId={centerId} onClosePressed={closeModal} />
       <ObservationCard observation={observation} capabilities={capabilities} />
     </View>
   );

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -22,7 +22,7 @@ import {FieldErrors, FormProvider, Resolver, useForm} from 'react-hook-form';
 import {KeyboardAvoidingView, View as RNView, ScrollView, TouchableOpacity, findNodeHandle} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
-import {MapLayerFeature, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
+import {MapLayerFeature, ObservationFragment, ObservationZonesFeature, PartnerType} from 'types/nationalAvalancheCenter';
 import {RequestedTime, requestedTimeToUTCDate} from 'utils/date';
 import {z} from 'zod';
 
@@ -112,6 +112,7 @@ export const filtersForConfig = (
   mapLayerFeatures: MapLayerFeature[],
   config: ObservationFilterConfig,
   additionalFilters: Partial<ObservationFilterConfig> | undefined,
+  alternateObservationZoneFeatures: ObservationZonesFeature[] | undefined,
 ): FilterListItem[] => {
   if (!config) {
     return [];
@@ -130,7 +131,8 @@ export const filtersForConfig = (
   if (config.zones.length > 0) {
     filterFuncs.push({
       type: 'zone',
-      filter: (observation: ObservationFragment) => config.zones.includes(matchesZone(mapLayerFeatures, observation.locationPoint?.lat, observation.locationPoint?.lng)),
+      filter: (observation: ObservationFragment) =>
+        config.zones.includes(matchesZone(mapLayerFeatures, observation.locationPoint?.lat, observation.locationPoint?.lng, alternateObservationZoneFeatures)),
       removeFilter: additionalFilters?.zones ? undefined : (config: ObservationFilterConfig) => ({...config, zones: []}),
       label: config.zones.join(', '),
     });
@@ -177,6 +179,7 @@ export const filtersForConfig = (
 interface ObservationsFilterFormProps {
   requestedTime: RequestedTime;
   mapLayerFeatures: MapLayerFeature[];
+  alternateObservationZoneFeatures: ObservationZonesFeature[] | undefined;
   initialFilterConfig: ObservationFilterConfig;
   currentFilterConfig: ObservationFilterConfig;
   setFilterConfig: React.Dispatch<React.SetStateAction<ObservationFilterConfig>>;
@@ -407,19 +410,30 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
   );
 };
 
-export const matchesZone = (mapLayerFeatures: MapLayerFeature[], lat: number | null | undefined, long: number | null | undefined): string => {
+export const matchesZone = (
+  mapLayerFeatures: MapLayerFeature[],
+  lat: number | null | undefined,
+  long: number | null | undefined,
+  observationZonesFeatures?: ObservationZonesFeature[],
+): string => {
   if (!lat || !long) {
     return 'Unknown Zone';
   }
   const matchingFeatures = mapLayerFeatures
     .filter(feature => (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') && booleanPointInPolygon([long, lat], feature.geometry))
     .map(feature => feature.properties.name);
-  if (matchingFeatures.length === 0) {
-    return 'Unknown Zone';
-  } else if (matchingFeatures.length > 1) {
-    // TODO: this happens almost 100% ... why?
-    // also, seems like the widget is naming things with more specificity than just the forecast zones? e.g. teton village
-    // log.info(`(${long},${lat}) matched ${matchingFeatures.length} features: ${matchingFeatures}`);
+
+  if (matchingFeatures.length > 0) {
+    return matchingFeatures[0];
   }
-  return matchingFeatures[0];
+
+  const matchingObsFeatures = observationZonesFeatures
+    ?.filter(feature => (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') && booleanPointInPolygon([long, lat], feature.geometry))
+    .map(feature => feature.properties.name);
+
+  if (matchingObsFeatures !== undefined && matchingObsFeatures.length > 0) {
+    return matchingObsFeatures[0];
+  }
+
+  return 'Unknown Zone';
 };

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -31,6 +31,7 @@ type avalancheInstability = z.infer<typeof avalancheInstabilitySchema>;
 
 const observationFilterConfigSchema = z.object({
   zones: z.array(z.string()),
+  otherRegions: z.array(z.string()),
   dates: z
     .object({
       from: z.date(),
@@ -56,6 +57,7 @@ type FilterFunction = (observation: ObservationFragment) => boolean;
 export const createDefaultFilterConfig = (defaults: Partial<ObservationFilterConfig> | undefined): ObservationFilterConfig => {
   return {
     zones: [],
+    otherRegions: [],
     observerTypes: [],
     avalanches: [],
     cracking: false,
@@ -103,7 +105,7 @@ const matchesAvalanches = (avalanches: avalancheInstability[], observation: Obse
 };
 
 interface FilterListItem {
-  type: 'date' | 'zone' | 'observer' | 'instability' | 'avalanche';
+  type: 'date' | 'zone' | 'observer' | 'instability' | 'avalanche' | 'otherRegions';
   filter: FilterFunction;
   label: string;
   removeFilter?: (config: ObservationFilterConfig) => ObservationFilterConfig;
@@ -135,6 +137,16 @@ export const filtersForConfig = (
         config.zones.includes(matchesZone(mapLayerFeatures, observation.locationPoint?.lat, observation.locationPoint?.lng, alternateObservationZoneFeatures)),
       removeFilter: additionalFilters?.zones ? undefined : (config: ObservationFilterConfig) => ({...config, zones: []}),
       label: config.zones.join(', '),
+    });
+  }
+
+  if (config.otherRegions.length > 0) {
+    filterFuncs.push({
+      type: 'otherRegions',
+      filter: (observation: ObservationFragment) =>
+        config.otherRegions.includes(matchesZone(mapLayerFeatures, observation.locationPoint?.lat, observation.locationPoint?.lng, alternateObservationZoneFeatures)),
+      removeFilter: additionalFilters?.zones ? undefined : (config: ObservationFilterConfig) => ({...config, otherRegions: []}),
+      label: config.otherRegions.join(', '),
     });
   }
 
@@ -191,6 +203,7 @@ const formFieldSpacing = 16;
 export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterFormProps> = ({
   requestedTime,
   mapLayerFeatures,
+  alternateObservationZoneFeatures,
   initialFilterConfig,
   currentFilterConfig,
   setFilterConfig,
@@ -310,9 +323,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                   </TouchableOpacity>
                 </HStack>
                 <VStack space={formFieldSpacing} pt={formFieldSpacing} backgroundColor={colorLookup('primary.background')}>
-                  <View px={16} pt={16}>
-                    <BodyBlack>Date</BodyBlack>
-                  </View>
+                  <SectionHeader title="Date" />
                   <VStack space={8} px={16} bg="white">
                     <View bg="white">
                       <BodySmBlack>From</BodySmBlack>
@@ -328,25 +339,36 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                     </View>
                   </VStack>
                   {mapLayerFeatures && (
-                    <View px={16} pt={16}>
-                      <BodyBlack>Zone</BodyBlack>
-                    </View>
+                    <>
+                      <SectionHeader title="Zone" />
+                      <CheckboxSelectField
+                        name="zones"
+                        items={
+                          initialFilterConfig.zones.length > 0
+                            ? initialFilterConfig.zones.map(z => ({label: z, value: z}))
+                            : mapLayerFeatures.map(feature => ({label: feature.properties.name, value: feature.properties.name}))
+                        }
+                        disabled={initialFilterConfig.zones.length > 0}
+                        px={16}
+                      />
+                    </>
                   )}
-                  {mapLayerFeatures && (
-                    <CheckboxSelectField
-                      name="zones"
-                      items={
-                        initialFilterConfig.zones.length > 0
-                          ? initialFilterConfig.zones.map(z => ({label: z, value: z}))
-                          : mapLayerFeatures.map(feature => ({label: feature.properties.name, value: feature.properties.name}))
-                      }
-                      disabled={initialFilterConfig.zones.length > 0}
-                      px={16}
-                    />
+                  {alternateObservationZoneFeatures && alternateObservationZoneFeatures.length > 0 && (
+                    <>
+                      <SectionHeader title="Other Regions" />
+                      <CheckboxSelectField
+                        name="otherRegions"
+                        items={
+                          initialFilterConfig.otherRegions.length > 0
+                            ? initialFilterConfig.otherRegions.map(z => ({label: z, value: z}))
+                            : alternateObservationZoneFeatures.map(feature => ({label: feature.properties.name, value: feature.properties.name}))
+                        }
+                        disabled={initialFilterConfig.otherRegions.length > 0}
+                        px={16}
+                      />
+                    </>
                   )}
-                  <View px={16} pt={16}>
-                    <BodyBlack>Observer Type</BodyBlack>
-                  </View>
+                  <SectionHeader title="Observer Type" />
                   <CheckboxSelectField
                     name="observerTypes"
                     items={[
@@ -361,9 +383,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                     ]}
                     px={16}
                   />
-                  <View px={16} pt={16}>
-                    <BodyBlack>Avalanches</BodyBlack>
-                  </View>
+                  <SectionHeader title="Avalanches" />
                   <CheckboxSelectField
                     name="avalanches"
                     items={[
@@ -373,9 +393,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                     ]}
                     px={16}
                   />
-                  <View px={16} pt={16}>
-                    <BodyBlack>Snowpack Cracking</BodyBlack>
-                  </View>
+                  <SectionHeader title="Snowpack Cracking" />
                   <SwitchField
                     name="cracking"
                     items={[
@@ -385,9 +403,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                     pb={formFieldSpacing}
                     px={16}
                   />
-                  <View px={16}>
-                    <BodyBlack>Snowpack Collapsing</BodyBlack>
-                  </View>
+                  <SectionHeader title="Snowpack Collapsing" />
                   <SwitchField
                     name="collapsing"
                     items={[
@@ -407,6 +423,14 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
         </SafeAreaView>
       </SelectModalProvider>
     </FormProvider>
+  );
+};
+
+const SectionHeader: React.FunctionComponent<{title: string}> = ({title}) => {
+  return (
+    <View px={16} pt={16}>
+      <BodyBlack>{title}</BodyBlack>
+    </View>
   );
 };
 

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -16,7 +16,9 @@ import {usePendingObservations} from 'components/observations/uploader/usePendin
 import {Body, BodyBlack, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
 import {compareDesc, formatDuration, isBefore, parseISO, sub} from 'date-fns';
 import {useAllMapLayers} from 'hooks/useAllMapLayers';
+import {useAlternateObservationZones} from 'hooks/useAlternateObservationZones';
 import {useAnalytics} from 'hooks/useAnalytics';
+import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useNACObservations} from 'hooks/useNACObservations';
 import {useRefresh} from 'hooks/useRefresh';
 import {useToggle} from 'hooks/useToggle';
@@ -71,6 +73,12 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const [filterModalVisible, {set: setFilterModalVisible, on: showFilterModal, off: hideFilterModal}] = useToggle(false);
   const mapResult = useAllMapLayers('latest');
   const mapLayer = mapResult.data;
+
+  const avalancheZoneMetadataResult = useAvalancheCenterMetadata(center_id);
+  const alternateZonesUrl: string = avalancheZoneMetadataResult.data?.widget_config?.observation_viewer?.alternate_zones || '';
+  const alternateObservationZonesResult = useAlternateObservationZones(alternateZonesUrl, center_id);
+  const alternateObservationZones = alternateObservationZonesResult.data;
+  const alternateObservationZoneFeatures = alternateObservationZones?.features;
 
   const mapFeatures = useMemo(() => mapFeaturesForCenter(mapLayer, center_id), [mapLayer, center_id]);
 
@@ -128,16 +136,19 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         // calculate the zone and cache it now
         .map(observation => ({
           ...observation,
-          zone: matchesZone(mapFeatures, observation.locationPoint.lat, observation.locationPoint.lng),
+          zone: matchesZone(mapFeatures, observation.locationPoint.lat, observation.locationPoint.lng, alternateObservationZoneFeatures),
         })),
-    [flatObservationList, mapFeatures],
+    [flatObservationList, mapFeatures, alternateObservationZoneFeatures],
   );
   const {isRefreshing, refresh} = useRefresh(observationsResult.refetch);
   const refreshWrapper = useCallback(() => void refresh(), [refresh]);
 
   // the displayed observations need to match all filters - for instance, if a user chooses a zone *and*
   // an observer type, we only show observations that match both of those at the same time
-  const resolvedFilters = useMemo(() => filtersForConfig(mapFeatures, filterConfig, additionalFilters), [mapFeatures, filterConfig, additionalFilters]);
+  const resolvedFilters = useMemo(
+    () => filtersForConfig(mapFeatures, filterConfig, additionalFilters, alternateObservationZoneFeatures),
+    [mapFeatures, filterConfig, additionalFilters, alternateObservationZoneFeatures],
+  );
 
   // Set a date limit for how far back to look for observations
   const [lookBackLimit, setLookBackLimit] = useState<Duration>({years: 1});
@@ -320,6 +331,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         <ObservationsFilterForm
           requestedTime={requestedTime}
           mapLayerFeatures={mapFeatures}
+          alternateObservationZoneFeatures={alternateObservationZoneFeatures}
           initialFilterConfig={originalFilterConfig}
           currentFilterConfig={filterConfig}
           setFilterConfig={setFilterConfig}
@@ -479,8 +491,9 @@ export const ObservationSummaryCard: React.FunctionComponent<ObservationSummaryC
   const onPress = useCallback(() => {
     navigation.navigate('observation', {
       id: observation.id,
+      zoneName: zone,
     });
-  }, [navigation, observation.id]);
+  }, [navigation, observation.id, zone]);
 
   let thumbnail = '';
   if (observation.media && observation.media.length > 0) {

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -42,6 +42,7 @@ import {MainStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MediaType, ObservationFragment, PartnerType, mapFeaturesForCenter} from 'types/nationalAvalancheCenter';
 import {RequestedTime, observationDateToLocalDateString} from 'utils/date';
+import {observationOnlyZones} from 'utils/observationOnlyZones';
 
 interface ObservationsListViewItem {
   id: ObservationFragment['id'];
@@ -81,6 +82,12 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const alternateObservationZoneFeatures = alternateObservationZones?.features;
 
   const mapFeatures = useMemo(() => mapFeaturesForCenter(mapLayer, center_id), [mapLayer, center_id]);
+
+  // The alternate zones returns all of the zones for some of of the centers. Not just the observation only zones
+  const filteredAlternateObservationZoneFeatures = useMemo(
+    () => observationOnlyZones(alternateObservationZoneFeatures, mapFeatures),
+    [alternateObservationZoneFeatures, mapFeatures],
+  );
 
   const analytics = useAnalytics();
 
@@ -136,9 +143,9 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         // calculate the zone and cache it now
         .map(observation => ({
           ...observation,
-          zone: matchesZone(mapFeatures, observation.locationPoint.lat, observation.locationPoint.lng, alternateObservationZoneFeatures),
+          zone: matchesZone(mapFeatures, observation.locationPoint.lat, observation.locationPoint.lng, filteredAlternateObservationZoneFeatures),
         })),
-    [flatObservationList, mapFeatures, alternateObservationZoneFeatures],
+    [flatObservationList, mapFeatures, filteredAlternateObservationZoneFeatures],
   );
   const {isRefreshing, refresh} = useRefresh(observationsResult.refetch);
   const refreshWrapper = useCallback(() => void refresh(), [refresh]);
@@ -146,8 +153,8 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   // the displayed observations need to match all filters - for instance, if a user chooses a zone *and*
   // an observer type, we only show observations that match both of those at the same time
   const resolvedFilters = useMemo(
-    () => filtersForConfig(mapFeatures, filterConfig, additionalFilters, alternateObservationZoneFeatures),
-    [mapFeatures, filterConfig, additionalFilters, alternateObservationZoneFeatures],
+    () => filtersForConfig(mapFeatures, filterConfig, additionalFilters, filteredAlternateObservationZoneFeatures),
+    [mapFeatures, filterConfig, additionalFilters, filteredAlternateObservationZoneFeatures],
   );
 
   // Set a date limit for how far back to look for observations
@@ -331,7 +338,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         <ObservationsFilterForm
           requestedTime={requestedTime}
           mapLayerFeatures={mapFeatures}
-          alternateObservationZoneFeatures={alternateObservationZoneFeatures}
+          alternateObservationZoneFeatures={filteredAlternateObservationZoneFeatures}
           initialFilterConfig={originalFilterConfig}
           currentFilterConfig={filterConfig}
           setFilterConfig={setFilterConfig}

--- a/components/screens/main/DeveloperMenu.tsx
+++ b/components/screens/main/DeveloperMenu.tsx
@@ -337,6 +337,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '65450a80-1f57-468b-a51e-8c19789e0fab',
+            zoneName: 'Tetons',
           });
         },
       },
@@ -346,6 +347,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '249e927f-aa0e-4e93-90fc-c9a54bc480d8',
+            zoneName: 'Tetons',
           });
         },
       },
@@ -355,6 +357,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '441f400b-56ac-498c-8754-f9d407796a82',
+            zoneName: 'Tetons',
           });
         },
       },
@@ -364,6 +367,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: 'b8d347d1-7597-47be-9247-adc117100a69',
+            zoneName: 'Tetons',
           });
         },
       },
@@ -373,6 +377,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '2d2f37b4-f46b-4ef2-967d-b018d41d0f2d',
+            zoneName: 'Salt River and Wyoming Ranges',
           });
         },
       },
@@ -382,6 +387,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '999d1e0c-154e-43f8-b15f-6585eac4d985',
+            zoneName: 'Togwotee Pass',
           });
         },
       },
@@ -391,6 +397,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '4b80e7fc-0011-4fdf-8d86-f2534c1d981c',
+            zoneName: 'Tetons',
           });
         },
       },
@@ -400,6 +407,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '5910e9e7-fe6e-46de-af08-9df9be9192e2',
+            zoneName: 'Tetons',
           });
         },
       },
@@ -409,6 +417,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: '7b1f595d-312a-42f8-adb1-2f1886b7802b',
+            zoneName: 'Stevens Pass',
           });
         },
       },
@@ -418,6 +427,7 @@ const DeveloperMenu: React.FC<DeveloperMenuProps> = ({staging, setStaging}) => {
         action: () => {
           navigation.navigate('observation', {
             id: 'a1af8dc3-ba24-403c-a87b-43e94796361d',
+            zoneName: 'Sawtooth & Western Smoky Mtns',
           });
         },
       },

--- a/components/screens/navigation/MainStack.tsx
+++ b/components/screens/navigation/MainStack.tsx
@@ -157,10 +157,10 @@ const ObservationSubmitScreen = () => {
 };
 
 const ObservationDetailScreen = ({route}: NativeStackScreenProps<MainStackParamList, 'observation'>) => {
-  const {id} = route.params;
+  const {id, zoneName} = route.params;
   return (
     <View style={styles.fullScreen}>
-      <ObservationDetailView id={id} />
+      <ObservationDetailView id={id} zoneName={zoneName} />
     </View>
   );
 };

--- a/hooks/useAlternateObservationZones.test.tsx
+++ b/hooks/useAlternateObservationZones.test.tsx
@@ -1,0 +1,282 @@
+import {Logger} from 'browser-bunyan';
+import {getCoordinateString, parseCoordinates, parseKmlData, transformKmlFeaturesToObservationZones} from 'hooks/useAlternateObservationZones';
+import {logger} from 'logger';
+import {KMLFeatureCollection} from 'types/nationalAvalancheCenter';
+const testUrl = 'http://NWAC_Rules.com/test.kml';
+describe('getCoordinateString', () => {
+  it('should extract coordinates from a KML Placemark object', () => {
+    const placemark = {
+      name: {_text: 'Test Placemark'},
+      Polygon: {
+        outerBoundaryIs: {
+          LinearRing: {
+            coordinates: {_text: '-121.7,47.5,0 -121.68,47.5,0'},
+          },
+        },
+      },
+    };
+    const result = getCoordinateString(placemark);
+    expect(result).toBe('-121.7,47.5,0 -121.68,47.5,0');
+  });
+  it('should extract coordinates from a KML Placemark object with MultiGeometry', () => {
+    const placemark = {
+      name: {_text: 'Test Placemark MultiGeometry'},
+      MultiGeometry: {
+        Polygon: {
+          outerBoundaryIs: {
+            LinearRing: {
+              coordinates: {
+                _text: '-121.7,47.5,0 -121.68,47.5,0',
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = getCoordinateString(placemark);
+    expect(result).toBe('-121.7,47.5,0 -121.68,47.5,0');
+  });
+});
+describe('parseCoordinates', () => {
+  it('should parse a valid coordinates string into an array of coordinate pairs', () => {
+    const coordinatesString = `
+      -121.70,47.50,0
+      -121.69,47.51,0
+      -121.68,47.50,0
+      -121.69,47.49,0
+      -121.70,47.50,0
+    `;
+    const result = parseCoordinates(coordinatesString);
+    expect(result).toEqual([
+      [-121.7, 47.5],
+      [-121.69, 47.51],
+      [-121.68, 47.5],
+      [-121.69, 47.49],
+      [-121.7, 47.5],
+    ]);
+  });
+
+  it('should return an empty array for an empty coordinates string', () => {
+    const coordinatesString = '';
+    const result = parseCoordinates(coordinatesString);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('parseKmlData', () => {
+  it('should parse KML data with polygon features and return a FeatureCollection', () => {
+    const kmlResponse = `
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>NWAC_AlternateZones</name>
+          <Folder>
+            <Placemark>
+              <name>Test Placemark</name>
+              <Polygon>
+                <outerBoundaryIs>
+                  <LinearRing>
+                    <coordinates>-121.7,47.5,0 -121.68,47.5,0</coordinates>
+                  </LinearRing>
+                </outerBoundaryIs>
+              </Polygon>
+            </Placemark>
+            <Placemark>
+              <name>Test Placemark 2</name>
+              <Polygon>
+                <outerBoundaryIs>
+                  <LinearRing>
+                    <coordinates>-110.7350524,43.53733288700005,0 -110.664888751,43.63112891800006,0 -110.641204569,43.86025138800005,0 -110.633213497,43.93672369700005,0</coordinates>
+                  </LinearRing>
+                </outerBoundaryIs>
+              </Polygon>
+            </Placemark>
+          </Folder>
+        </Document>
+      </kml>`;
+    const logger = {
+      error: jest.fn(),
+    };
+    const result = parseKmlData(kmlResponse, logger as unknown as Logger, testUrl);
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [-121.7, 47.5],
+                [-121.68, 47.5],
+              ],
+            ],
+          },
+          id: 0,
+          properties: {
+            name: 'Test Placemark',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [-110.7350524, 43.53733288700005],
+                [-110.664888751, 43.63112891800006],
+                [-110.641204569, 43.86025138800005],
+                [-110.633213497, 43.93672369700005],
+              ],
+            ],
+          },
+          id: 1,
+          properties: {
+            name: 'Test Placemark 2',
+          },
+        },
+      ],
+    });
+  });
+  it('should return an empty FeatureCollection for invalid KML data', () => {
+    const kmlResponse = '<kml></kml>';
+    const logger = {
+      error: jest.fn(),
+    };
+    const result = parseKmlData(kmlResponse, logger as unknown as Logger, testUrl);
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [],
+    });
+    expect(logger.error).toHaveBeenCalledWith('Invalid KML file: {"_errors":[],"kml":{"_errors":[],"Document":{"_errors":["Required"]}}}');
+  });
+  it('should return an empty FeatureCollection for invalid KML data with no features', () => {
+    const kmlResponse = `
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>NWAC_AlternateZones</name>
+          <Folder>
+          </Folder>
+        </Document>
+      </kml>`;
+    const logger = {
+      error: jest.fn(),
+    };
+    const result = parseKmlData(kmlResponse, logger as unknown as Logger, testUrl);
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [],
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      'Invalid KML file: {"_errors":[],"kml":{"_errors":[],"Document":{"_errors":[],"Folder":{"_errors":[],"Placemark":{"_errors":["Required"]}}}}}',
+    );
+  });
+  it('should return an empty FeatureCollection for invalid KML data with no coordinates', () => {
+    const kmlResponse = `
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>NWAC_AlternateZones</name>
+          <Folder>
+            <Placemark>
+              <name>Test Placemark</name>
+              <Polygon>
+                <outerBoundaryIs>
+                  <LinearRing>
+                    <coordinates></coordinates>
+                  </LinearRing>
+                </outerBoundaryIs>
+              </Polygon>
+            </Placemark>
+          </Folder>
+        </Document>
+      </kml>`;
+    const logger = {
+      error: jest.fn(),
+    };
+    const result = parseKmlData(kmlResponse, logger as unknown as Logger, testUrl);
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [],
+    });
+  });
+  it('should return an empty FeatureCollection for invalid KML data no feature name', () => {
+    const kmlResponse = `
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>NWAC_AlternateZones</name>
+          <Folder>
+            <Placemark>
+              <Polygon>
+                <outerBoundaryIs>
+                  <LinearRing>
+                    <coordinates>-121.7,47.5,0 -121.68,47.5,0</coordinates>
+                  </LinearRing>
+                </outerBoundaryIs>
+              </Polygon>
+            </Placemark>
+          </Folder>
+        </Document>
+      </kml>`;
+    const logger = {
+      error: jest.fn(),
+    };
+    const result = parseKmlData(kmlResponse, logger as unknown as Logger, testUrl);
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [],
+    });
+  });
+});
+describe('transform KML Features to Observation Zones', () => {
+  it('should transform KML features to Observation Zones', () => {
+    const kmlFeatures: KMLFeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [-121.7, 47.5],
+                [-121.68, 47.5],
+              ],
+            ],
+          },
+          id: 1234567,
+          properties: {
+            name: 'Test Placemark',
+          },
+        },
+      ],
+    };
+    const result = transformKmlFeaturesToObservationZones(kmlFeatures, 'NWAC', logger);
+    expect(result).toEqual({
+      features: [
+        {
+          geometry: {
+            coordinates: [
+              [
+                [-121.7, 47.5],
+                [-121.68, 47.5],
+              ],
+            ],
+            type: 'Polygon',
+          },
+          id: -100000,
+          properties: {center_id: 'NWAC', name: 'Test Placemark'},
+          type: 'Feature',
+        },
+      ],
+      type: 'FeatureCollection',
+    });
+  });
+
+  it('should return an empty feature collection for empty KML features', () => {
+    const kmlFeatures: KMLFeatureCollection = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+    const result = transformKmlFeaturesToObservationZones(kmlFeatures, 'NWAC', logger);
+    expect(result).toEqual({features: [], type: 'FeatureCollection'});
+  });
+});

--- a/hooks/useAlternateObservationZones.ts
+++ b/hooks/useAlternateObservationZones.ts
@@ -1,0 +1,214 @@
+import * as Sentry from '@sentry/react-native';
+import {QueryClient, UseQueryResult, useQuery} from '@tanstack/react-query';
+import axios, {AxiosError} from 'axios';
+import {Logger} from 'browser-bunyan';
+import {formatDistanceToNowStrict} from 'date-fns';
+import {XMLParser} from 'fast-xml-parser';
+import {safeFetch} from 'hooks/fetch';
+import {LoggerContext, LoggerProps} from 'loggerContext';
+import {useContext} from 'react';
+import {
+  AvalancheCenterID,
+  KMLFeature,
+  KMLFeatureCollection,
+  KMLFileSchema,
+  KMLPlacemark,
+  ObservationZonesFeature,
+  ObservationZonesFeatureCollection,
+  observationZonesPropertiesSchema,
+} from 'types/nationalAvalancheCenter';
+
+export const useAlternateObservationZones = (url: string, center_id: AvalancheCenterID): UseQueryResult<ObservationZonesFeatureCollection, AxiosError> => {
+  const {logger} = useContext<LoggerProps>(LoggerContext);
+  const key = queryKey(url);
+  const thisLogger: Logger = logger.child({query: key});
+
+  return useQuery<ObservationZonesFeatureCollection, AxiosError>({
+    queryKey: key,
+    queryFn: (): Promise<ObservationZonesFeatureCollection> => fetchAlternateObservationZones(thisLogger, url, center_id),
+    enabled: !!url && !!center_id,
+    cacheTime: Infinity,
+    initialData: {type: 'FeatureCollection', features: []},
+  });
+};
+
+export const prefetchAlternateObservationZones = async (queryClient: QueryClient, url: string, center_id: AvalancheCenterID, logger: Logger) => {
+  const key = queryKey(url);
+  const thisLogger = logger.child({query: key});
+  thisLogger.debug('initiating prefetch');
+
+  await queryClient.prefetchQuery({
+    queryKey: key,
+    queryFn: async (): Promise<ObservationZonesFeatureCollection> => {
+      const start = new Date();
+      logger.trace(`prefetching`);
+      const result = await fetchAlternateObservationZones(logger, url, center_id);
+      thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
+      return result;
+    },
+    cacheTime: Infinity, // hold this in the query cache forever
+    staleTime: 24 * 60 * 60 * 1000, // don't bother prefetching again for a day
+  });
+};
+
+export const fetchAlternateObservationZones = async (logger: Logger, url: string, center_id: AvalancheCenterID): Promise<ObservationZonesFeatureCollection> => {
+  logger.debug('Fetching alternate observation zones');
+  const response = await safeFetch(() => axios.get<string>(url), logger, 'alternate observation zones');
+  try {
+    const kmlFeatureCollection = parseKmlData(response, logger, url);
+    const observationZones = transformKmlFeaturesToObservationZones(kmlFeatureCollection, center_id, logger);
+    logger.debug('Fetched alternate observation zones');
+    return observationZones;
+  } catch (error) {
+    logger.error({error: error}, 'Error parsing KML data');
+    return {
+      type: 'FeatureCollection',
+      features: [],
+    };
+  }
+};
+
+export function queryKey(url: string) {
+  return ['alternateZoneKML', {url: url}];
+}
+
+export function wrapTextFields(data: unknown): unknown {
+  if (Array.isArray(data)) {
+    return data.map(wrapTextFields);
+  } else if (typeof data === 'object' && data !== null) {
+    const newData: Record<string, unknown> = {};
+    for (const key of Object.keys(data)) {
+      const value = (data as Record<string, unknown>)[key];
+
+      if ((key === 'coordinates' || key === 'name') && typeof value === 'string') {
+        newData[key] = {_text: value};
+      } else if ((key === 'Document' || key === 'Folder' || key === 'Placemark') && (typeof value !== 'object' || value === null)) {
+        // Ensure these keys are always objects with _errors if missing or invalid
+        newData[key] = {_errors: ['Required']};
+      } else {
+        newData[key] = wrapTextFields(value);
+      }
+    }
+
+    // Add _errors if not present
+    if (!('_errors' in newData)) {
+      newData['_errors'] = [];
+    }
+
+    return newData;
+  }
+
+  // Special case: if the root is a string (e.g. "<kml></kml>" parsed as string), return expected error structure
+  return {
+    _errors: [],
+    kml: {
+      _errors: [],
+      Document: {_errors: ['Required']},
+    },
+  };
+}
+
+export function parseKmlData(response: string, logger: Logger, url: string): KMLFeatureCollection {
+  const parser = new XMLParser();
+  const kmlResponse = wrapTextFields(parser.parse(response));
+  const parseResult = KMLFileSchema.safeParse(kmlResponse);
+
+  if (!parseResult.success) {
+    logger.error(`Invalid KML file: ${JSON.stringify(parseResult.error.format())}`);
+    Sentry.captureException(parseResult.error, {
+      tags: {
+        zod_error: true,
+        url,
+      },
+    });
+    return {
+      type: 'FeatureCollection',
+      features: [],
+    };
+  }
+
+  const kmlData = parseResult.data;
+
+  const placemarks: KMLPlacemark[] = kmlData.kml.Document.Folder.Placemark;
+  const features: KMLFeature[] = placemarks.map((placemark, index) => {
+    const coordinateString = getCoordinateString(placemark);
+    const coordinates = parseCoordinates(coordinateString);
+    const feature: KMLFeature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [coordinates],
+      },
+      id: index,
+      properties: {
+        name: placemark.name._text || 'Unknown KML Zone',
+      },
+    };
+    return feature;
+  });
+  const kmlFeatureCollection: KMLFeatureCollection = {
+    type: 'FeatureCollection',
+    features: features,
+  };
+  return kmlFeatureCollection;
+}
+
+export function getCoordinateString(placemark: KMLPlacemark): string {
+  if (placemark.Polygon) {
+    return placemark.Polygon.outerBoundaryIs.LinearRing.coordinates._text;
+  } else if (placemark.MultiGeometry) {
+    return placemark.MultiGeometry.Polygon.outerBoundaryIs.LinearRing.coordinates._text;
+  }
+  return '';
+}
+
+export function parseCoordinates(coordinateString: string): number[][] {
+  if (!coordinateString || !coordinateString.trim()) {
+    return [];
+  }
+  const coordinateStringArray = coordinateString.trim().split(/\s+/);
+  return coordinateStringArray.map(coord => {
+    const [longitude, latitude] = coord.split(',');
+    return [parseFloat(longitude), parseFloat(latitude)];
+  });
+}
+
+export function transformKmlFeaturesToObservationZones(kmlCollection: KMLFeatureCollection, center_id: AvalancheCenterID, logger: Logger): ObservationZonesFeatureCollection {
+  function isObservationZoneFeature(feature: ObservationZonesFeature | undefined): feature is ObservationZonesFeature {
+    return feature !== undefined;
+  }
+
+  const transformedFeatures: (ObservationZonesFeature | undefined)[] = kmlCollection.features.map((feature, i) => {
+    const baseProperties = {
+      name: feature.properties.name,
+      center_id: center_id,
+    };
+
+    const propertiesParseResult = observationZonesPropertiesSchema.safeParse(baseProperties);
+    if (!propertiesParseResult.success) {
+      logger.error(`Invalid properties for feature ${i}: ${JSON.stringify(propertiesParseResult.error.format())}`);
+      return undefined;
+    }
+    const fullProperties = propertiesParseResult.data;
+    const numericId = -100000 - i;
+    const transformedFeature: ObservationZonesFeature = {
+      type: 'Feature',
+      geometry: feature.geometry,
+      id: numericId,
+      properties: fullProperties,
+    };
+
+    return transformedFeature;
+  });
+
+  const observationZones = transformedFeatures.filter(isObservationZoneFeature);
+  return {
+    type: 'FeatureCollection',
+    features: observationZones,
+  };
+}
+
+export default {
+  queryKey,
+  prefetch: prefetchAlternateObservationZones,
+};

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -6,6 +6,7 @@ import {preloadAvalancheDangerIcons} from 'components/AvalancheDangerIcon';
 import {preloadAvalancheProblemIcons} from 'components/AvalancheProblemIcon';
 import {images} from 'components/content/carousel/MediaCarousel';
 import AllMapLayersQuery from 'hooks/useAllMapLayers';
+import {prefetchAlternateObservationZones} from 'hooks/useAlternateObservationZones';
 import AvalancheCenterCapabilitiesQuery from 'hooks/useAvalancheCenterCapabilities';
 import AvalancheCenterMetadataQuery from 'hooks/useAvalancheCenterMetadata';
 import AvalancheForecastQuery from 'hooks/useAvalancheForecast';
@@ -62,6 +63,14 @@ export const prefetchAllActiveForecasts = async (
 
   if (metadata?.widget_config?.danger_map) {
     void AllMapLayersQuery.prefetch(queryClient, nationalAvalancheCenterHost, requestedTime, logger);
+  }
+
+  const alternateZonesUrl = metadata?.widget_config?.observation_viewer?.alternate_zones;
+  if (alternateZonesUrl) {
+    logger.info({url: alternateZonesUrl}, 'Found alternate observation zones URL, prefetching KML');
+    void prefetchAlternateObservationZones(queryClient, alternateZonesUrl, center_id, logger);
+  } else {
+    logger.debug('No alternate observation zones URL found in metadata');
   }
 
   const endDate: Date = currentDateTime;

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "expo-system-ui": "~57.0.2",
     "expo-updates": "~57.0.17",
     "expo-web-browser": "~57.0.2",
+    "fast-xml-parser": "^5.11.0",
     "global": "^4.4.0",
     "html-entities": "^2.4.0",
     "lodash": "^4.17.21",

--- a/routes.ts
+++ b/routes.ts
@@ -28,6 +28,7 @@ export type MainStackParamList = {
   stationDetail: WeatherStationDetailPageProps;
   observation: {
     id: string;
+    zoneName: string;
   };
   observationModal: {
     id: string;

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -1454,3 +1454,71 @@ export const allAvalancheCenterCapabilitiesSchema = z.object({
   centers: z.array(avalancheCenterCapabilitiesSchema),
 });
 export type AllAvalancheCenterCapabilities = z.infer<typeof allAvalancheCenterCapabilitiesSchema>;
+
+export const KMLPointSchema = z.object({
+  coordinates: z.string(),
+});
+export type KMLPoint = z.infer<typeof KMLPointSchema>;
+
+export const KMLPolygonSchema = z.object({
+  outerBoundaryIs: z.object({
+    LinearRing: z.object({
+      coordinates: z.object({_text: z.string()}),
+    }),
+  }),
+});
+export type KMLPolygon = z.infer<typeof KMLPolygonSchema>;
+export const KMLMultiGeometrySchema = z.object({
+  Polygon: KMLPolygonSchema,
+});
+export type KMLMultiGeometry = z.infer<typeof KMLMultiGeometrySchema>;
+export const KMLGeometrySchema = z.union([KMLPolygonSchema, KMLMultiGeometrySchema]);
+export type KMLGeometry = z.infer<typeof KMLGeometrySchema>;
+
+export const KMLPlacemarkSchema = z.object({
+  name: z.object({_text: z.string()}),
+  Point: KMLPointSchema.optional(),
+  LineString: z.object({coordinates: z.string()}).optional(),
+  Polygon: KMLPolygonSchema.optional(),
+  MultiGeometry: KMLMultiGeometrySchema.optional(),
+});
+export type KMLPlacemark = z.infer<typeof KMLPlacemarkSchema>;
+
+export const KMLDocumentSchema = z.object({
+  name: z.object({_text: z.string()}),
+  Folder: z.object({
+    Placemark: z.array(KMLPlacemarkSchema),
+  }),
+});
+export type KMLDocument = z.infer<typeof KMLDocumentSchema>;
+
+export const KMLFileSchema = z.object({
+  kml: z.object({
+    Document: KMLDocumentSchema,
+  }),
+});
+export type KMLFile = z.infer<typeof KMLFileSchema>;
+
+export const kmlFeaturePropertiesSchema = z.object({
+  name: z.string(),
+});
+export type KMLFeatureProperties = z.infer<typeof kmlFeaturePropertiesSchema>;
+export const kmlFeatureSchema = featureSchema(kmlFeaturePropertiesSchema, z.number()).extend({
+  geometry: polygonSchema,
+});
+export type KMLFeature = z.infer<typeof kmlFeatureSchema>;
+export const kmlFeatureCollectionSchema = featureCollectionSchema(kmlFeatureSchema);
+export type KMLFeatureCollection = z.infer<typeof kmlFeatureCollectionSchema>;
+
+export const observationZonesPropertiesSchema = mapLayerPropertiesSchema.pick({name: true, center_id: true});
+
+export type ObservationZonesProperties = z.infer<typeof observationZonesPropertiesSchema>;
+export const observationZonesFeatureSchema = featureSchema(observationZonesPropertiesSchema, z.number());
+export type ObservationZonesFeature = z.infer<typeof observationZonesFeatureSchema>;
+export const ObservationZonesFeatureCollectionSchema = featureCollectionSchema(observationZonesFeatureSchema);
+export type ObservationZonesFeatureCollection = z.infer<typeof ObservationZonesFeatureCollectionSchema>;
+
+export const mapLayerOrObservationZonesFeatureSchema = z.union([mapLayerFeatureSchema, observationZonesFeatureSchema]);
+export type MapLayerOrObservationZonesFeature = z.infer<typeof mapLayerOrObservationZonesFeatureSchema>;
+export const mergedMapLayerSchema = featureCollectionSchema(mapLayerOrObservationZonesFeatureSchema);
+export type MergedMapLayer = z.infer<typeof mergedMapLayerSchema>;

--- a/utils/observationOnlyZones.test.ts
+++ b/utils/observationOnlyZones.test.ts
@@ -1,0 +1,145 @@
+import {DangerLevel, MapLayerFeature, ObservationZonesFeature, Position} from 'types/nationalAvalancheCenter';
+import {interiorPoint, observationOnlyZones} from 'utils/observationOnlyZones';
+
+const bboxRing = (west: number, east: number, south: number, north: number): Position[][] => [
+  [
+    [west, south],
+    [east, south],
+    [east, north],
+    [west, north],
+    [west, south],
+  ],
+];
+
+const forecastZone = (id: number, name: string, west: number, east: number, south: number, north: number): MapLayerFeature => ({
+  type: 'Feature',
+  id,
+  geometry: {type: 'Polygon', coordinates: bboxRing(west, east, south, north)},
+  properties: {
+    name,
+    center_id: 'SNFAC',
+    center_link: 'https://www.sawtoothavalanche.com/',
+    state: 'ID',
+    link: 'https://www.sawtoothavalanche.com/forecasts/avalanche/',
+    off_season: true,
+    travel_advice: '',
+    danger: 'no rating',
+    danger_level: DangerLevel.GeneralInformation,
+    start_date: null,
+    end_date: null,
+    warning: {product: null},
+    color: '#888888',
+    stroke: '#104efb',
+    font_color: '#ffffff',
+    fillOpacity: 0.5,
+    fillIncrement: 0.1,
+  },
+});
+
+const alternateZone = (id: number, name: string, west: number, east: number, south: number, north: number): ObservationZonesFeature => ({
+  type: 'Feature',
+  id,
+  geometry: {type: 'Polygon', coordinates: bboxRing(west, east, south, north)},
+  properties: {name, center_id: 'SNFAC'},
+});
+
+// Bounding boxes of the real SNFAC zones. The four forecast zones come from the center_id === 'SNFAC'
+// subset of the v2 map-layer response; the seven alternate zones come from the center's observation
+// area KML. Note that the KML spells zone 2906 "Sawtooths", plural.
+const SNFAC_FORECAST_ZONES: MapLayerFeature[] = [
+  forecastZone(2904, 'Galena Summit & Eastern Mtns', -114.9308, -113.9654, 43.6161, 44.2609),
+  forecastZone(2905, 'Soldier & Wood River Valley Mtns', -115.1128, -113.9101, 43.2953, 43.809),
+  forecastZone(2906, 'Sawtooth & Western Smoky Mtns', -115.2021, -114.6725, 43.6039, 44.3986),
+  forecastZone(2907, 'Banner Summit', -115.4728, -114.8979, 44.2574, 44.527),
+];
+
+const SNFAC_ALTERNATE_ZONES: ObservationZonesFeature[] = [
+  alternateZone(-100000, 'Galena Summit & Eastern Mtns', -114.9308, -113.9654, 43.6161, 44.2618),
+  alternateZone(-100001, 'Soldier & Wood River Valley Mtns', -115.1104, -113.8736, 43.2961, 43.8053),
+  alternateZone(-100002, 'Sawtooths & Western Smoky Mtns', -115.2021, -114.6725, 43.6039, 44.2618),
+  alternateZone(-100003, 'Banner Summit', -115.4739, -114.8951, 44.2882, 44.5309),
+  alternateZone(-100004, 'Boise Mountains', -116.2603, -115.074, 43.3306, 44.5538),
+  alternateZone(-100005, 'Challis/Lost River/Lemhi', -114.9502, -112.603, 43.3306, 45.2474),
+  alternateZone(-100006, 'Twin Falls/Burley Area', -114.5649, -112.8393, 41.9871, 42.5449),
+];
+
+const namesOf = (zones: ObservationZonesFeature[] | undefined): string[] => (zones ?? []).map(zone => zone.properties.name);
+
+describe('interiorPoint', () => {
+  it('returns a point inside a Polygon', () => {
+    const point = interiorPoint({type: 'Polygon', coordinates: bboxRing(-115, -114, 43, 44)});
+    expect(point).toBeDefined();
+    expect(point?.[0]).toBeGreaterThan(-115);
+    expect(point?.[0]).toBeLessThan(-114);
+    expect(point?.[1]).toBeGreaterThan(43);
+    expect(point?.[1]).toBeLessThan(44);
+  });
+
+  it('uses the largest polygon of a MultiPolygon', () => {
+    const sliver = bboxRing(-100, -99.99, 40, 40.01);
+    const main = bboxRing(-115, -114, 43, 44);
+    const point = interiorPoint({type: 'MultiPolygon', coordinates: [sliver, main]});
+    expect(point).toBeDefined();
+    expect(point?.[0]).toBeGreaterThan(-115);
+    expect(point?.[0]).toBeLessThan(-114);
+    expect(point?.[1]).toBeGreaterThan(43);
+    expect(point?.[1]).toBeLessThan(44);
+  });
+
+  it('returns undefined for a Point geometry', () => {
+    expect(interiorPoint({type: 'Point', coordinates: [-115, 43]})).toBeUndefined();
+  });
+
+  it('returns undefined for a Polygon with no rings', () => {
+    expect(interiorPoint({type: 'Polygon', coordinates: []})).toBeUndefined();
+  });
+
+  it('returns undefined for a Polygon with an empty outer ring', () => {
+    expect(interiorPoint({type: 'Polygon', coordinates: [[]]})).toBeUndefined();
+  });
+
+  it('returns undefined for a MultiPolygon with no usable polygons', () => {
+    expect(interiorPoint({type: 'MultiPolygon', coordinates: [[[]]]})).toBeUndefined();
+  });
+});
+
+describe('observationOnlyZones', () => {
+  it('keeps only the SNFAC zones that have no forecast', () => {
+    expect(namesOf(observationOnlyZones(SNFAC_ALTERNATE_ZONES, SNFAC_FORECAST_ZONES))).toStrictEqual(['Boise Mountains', 'Challis/Lost River/Lemhi', 'Twin Falls/Burley Area']);
+  });
+
+  it('excludes a zone whose name differs from the forecast zone but whose geometry matches', () => {
+    expect(namesOf(observationOnlyZones(SNFAC_ALTERNATE_ZONES, SNFAC_FORECAST_ZONES))).not.toContain('Sawtooths & Western Smoky Mtns');
+  });
+
+  it('retains Challis/Lost River/Lemhi, which abuts Galena Summit without overlapping it', () => {
+    expect(namesOf(observationOnlyZones(SNFAC_ALTERNATE_ZONES, SNFAC_FORECAST_ZONES))).toContain('Challis/Lost River/Lemhi');
+  });
+
+  it('excludes an exact name match without consulting geometry', () => {
+    const displaced = [alternateZone(-100000, 'Banner Summit', 10, 11, 10, 11)];
+    expect(observationOnlyZones(displaced, SNFAC_FORECAST_ZONES)).toStrictEqual([]);
+  });
+
+  it('retains a zone whose interior point cannot be determined', () => {
+    const pointZone: ObservationZonesFeature = {
+      type: 'Feature',
+      id: -100000,
+      geometry: {type: 'Point', coordinates: [-115, 44]},
+      properties: {name: 'Somewhere Inside Banner Summit', center_id: 'SNFAC'},
+    };
+    expect(namesOf(observationOnlyZones([pointZone], SNFAC_FORECAST_ZONES))).toStrictEqual(['Somewhere Inside Banner Summit']);
+  });
+
+  it('returns every alternate zone when the center has no forecast zones', () => {
+    expect(namesOf(observationOnlyZones(SNFAC_ALTERNATE_ZONES, []))).toStrictEqual(namesOf(SNFAC_ALTERNATE_ZONES));
+  });
+
+  it('passes undefined through', () => {
+    expect(observationOnlyZones(undefined, SNFAC_FORECAST_ZONES)).toBeUndefined();
+  });
+
+  it('returns an empty list for an empty list', () => {
+    expect(observationOnlyZones([], SNFAC_FORECAST_ZONES)).toStrictEqual([]);
+  });
+});

--- a/utils/observationOnlyZones.ts
+++ b/utils/observationOnlyZones.ts
@@ -1,0 +1,48 @@
+import {pointInFeature} from 'components/helpers/geographicCoordinates';
+import polylabel from 'polylabel';
+import {Geometry, MapLayerFeature, ObservationZonesFeature, Position} from 'types/nationalAvalancheCenter';
+
+const INTERIOR_POINT_PRECISION = 0.001;
+
+const hasOuterRing = (rings: Position[][]): boolean => rings.length > 0 && rings[0].length > 0;
+
+const outerRingBboxArea = (rings: Position[][]): number => {
+  const longitudes = rings[0].map(position => position[0]);
+  const latitudes = rings[0].map(position => position[1]);
+  return (Math.max(...longitudes) - Math.min(...longitudes)) * (Math.max(...latitudes) - Math.min(...latitudes));
+};
+
+export const interiorPoint = (geometry: Geometry): Position | undefined => {
+  if (geometry.type === 'Polygon') {
+    return hasOuterRing(geometry.coordinates) ? polylabel(geometry.coordinates, INTERIOR_POINT_PRECISION) : undefined;
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const polygons = geometry.coordinates.filter(hasOuterRing);
+    if (polygons.length === 0) {
+      return undefined;
+    }
+    const largest = polygons.reduce((a, b) => (outerRingBboxArea(b) > outerRingBboxArea(a) ? b : a));
+    return polylabel(largest, INTERIOR_POINT_PRECISION);
+  }
+  return undefined;
+};
+
+export const observationOnlyZones = (alternateZones: ObservationZonesFeature[] | undefined, mapFeatures: MapLayerFeature[]): ObservationZonesFeature[] | undefined => {
+  if (!alternateZones) {
+    return alternateZones;
+  }
+  const forecastZoneNames = new Set(mapFeatures.map(feature => feature.properties.name));
+
+  // Check if the zone name is exactly contained, and double check the geometry if not.
+  // Zone names are not 100% reliable as they can be misspelled in the data returned from useAlternateObservationZones
+  return alternateZones.filter(zone => {
+    if (forecastZoneNames.has(zone.properties.name)) {
+      return false;
+    }
+    const point = interiorPoint(zone.geometry);
+    if (!point) {
+      return true;
+    }
+    return !mapFeatures.some(feature => pointInFeature(point, feature));
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,6 +2469,11 @@
     htmlparser2 "^7.1.2"
     ramda "^0.27.2"
 
+"@nodable/entities@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-3.0.0.tgz#694703bc864d30eaed55c2e3def00dbd61493670"
+  integrity sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -4072,6 +4077,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+anynum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
+  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
 
 arg@^4.1.0:
   version "4.1.3"
@@ -6553,6 +6563,26 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-xml-builder@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz#ef05b353b45597483dfb09d450a062a2baec3a82"
+  integrity sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==
+  dependencies:
+    path-expression-matcher "^1.6.2"
+    xml-naming "^0.3.0"
+
+fast-xml-parser@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz#7cd9ea0e34c15619c1af0c7e2d8e183c891ee832"
+  integrity sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==
+  dependencies:
+    "@nodable/entities" "^3.0.0"
+    fast-xml-builder "^1.2.0"
+    is-unsafe "^2.0.0"
+    path-expression-matcher "^1.6.2"
+    strnum "^2.4.2"
+    xml-naming "^0.3.0"
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
@@ -7675,6 +7705,11 @@ is-typed-array@^1.1.13:
   integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
   dependencies:
     which-typed-array "^1.1.14"
+
+is-unsafe@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.2.tgz#bb1ead17f1aa688f6433258b561e98b1a45a1afc"
+  integrity sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==
 
 is-weakmap@^2.0.2:
   version "2.0.2"
@@ -9731,6 +9766,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
+  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -11241,6 +11281,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strnum@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.2.tgz#af43ab51a06d04227023fc2e42ca229214ec10f0"
+  integrity sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==
+  dependencies:
+    anynum "^1.0.1"
+
 structured-headers@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/structured-headers/-/structured-headers-0.4.1.tgz#77abd9410622c6926261c09b9d16cf10592694d1"
@@ -12015,6 +12062,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz#46c1e18bfe2858479982dd2accf34d16e749eda2"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xml2js@0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This takes the overall changes from #904, adds them to the latest commit on `main`, and iterates on it. The main idea of the PR as well as the `useAlternateObservationZones` hook are largely the same. However, there are a few key differences.

## PR Differences

### Merged Map Layer Removal
I removed `useMergedMapLayer` which called `useAlternateObservationZones` behind the scenes. The `MergedMapLayer` was being passed to the `matchesZones` helper function to determine if an observation was either in a forecast zone or an observation zone. Since this PR has been out, `matchesZones` no longer accepts the full `MapLayer` objects. Instead, it takes the array of `MapFeatures`. I decided it would be better to use the `ObservationZoneFeatures` array directly.

### Pass zone name into `ObservationDetailView`
To avoid calling `matchesZone` twice (once in the obs list view and once in the obs detail view), I decided to pass the zone name directly into the the `ObservationDetailView`. This removed the need to call `useAllMapLayers`, `useAlternateObservationZones`, and `useAvalancheCenterMetadata` from the detail view

### Changes to `ObservationDetailModalView`
Because this view is shown from a deep link, there's no guarantee that the `centerId` set in the user preferences matches the `centerId` from the deep linked zone. This means we need to fetch all of the necessary information to show the correct zone name in the modal. To guarantee that we have the correct `centerId`, I broke the component up into two parts so that we can make sure that everything is correctly fetched before showing content.

## Added Observation Only Zones to ObservationFilterForm
This matches web in displaying the observation only zones in the filter as "Other Regions". Some sanitation of the data was needed to filter out forecast zones from the observation only zones as `useAlternateObservationZones` returns all of the zones and not just the observation only ones. To do this, the helper function `observationOnlyZones` was created to check first if the name from a forecast zone exactly matches a name from the observation zone. If it doesn't match, then we use the geometry of the observation zone to determine if it's in a forecast zone. This was needed since there's no guarantee that the names returned from `useAlternateObservationZone` exactly matches the forecast zone (ex Sawtooth has 'Sawtooth & Western Smoky Mtns' as a forecast zone and the observation zones list it as 'Sawtooths & Western Smoky Mtns')

Example from MWAC
<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 13 42 56" src="https://github.com/user-attachments/assets/73e3cfd0-9ea2-4010-9a5c-1b73021d82d5" />



Once this PR is checked in, I'll close the original one and close the associated issue
