### PR TITLE
Add Nokian sponsor watermark with intro animation to the map view

### DIFF
--- a/components/map/AvalancheForecastZoneMap.tsx
+++ b/components/map/AvalancheForecastZoneMap.tsx
@@ -20,6 +20,7 @@ import {RequestedTime, requestedTimeToUTCDate} from 'utils/date';
 import {ForecastNavigationHeader} from 'components/content/navigation/ForecastMapNavigationHeader';
 import {DangerScale} from 'components/DangerScale';
 import {AvalancheForecastMapView} from 'components/map/AvalancheForecastMapView';
+import {SponsorWatermark} from 'components/map/SponsorWatermark';
 import {FirstRunExperienceModal} from 'components/modals/FirstRunExperienceModal';
 import * as Location from 'expo-location';
 import {Position} from 'geojson';
@@ -282,6 +283,8 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
 
       <AvalancheCenterSelectionModal visible={showAvalancheCenterSelectionModal} initialSelection={preferences.center} onClose={onSelectCenter} />
       <FirstRunExperienceModal visible={showFREModal} onClose={onFREClose} />
+
+      <SponsorWatermark tabBarHeight={tabBarHeight} active={splashComplete && !showAvalancheCenterSelectionModal && !showFREModal} />
     </>
   );
 };

--- a/components/map/SponsorWatermark.tsx
+++ b/components/map/SponsorWatermark.tsx
@@ -1,0 +1,188 @@
+// Title-sponsor watermark for the map view: a small logo chip pinned bottom-right (clear of the
+// Mapbox attribution bottom-left). Once per session — after the splash finishes and no first-run
+// modal is covering the map — it springs open into a "BROUGHT TO YOU BY" card with a larger
+// sponsor graphic, holds while a thin bottom bar drains as a countdown, then collapses back to
+// the chip. Tapping the chip replays the expansion; tapping the expanded card opens the sponsor
+// campaign URL.
+import React, {useCallback, useEffect, useMemo, useRef} from 'react';
+
+import {sponsorLogoSize} from 'data/sponsors';
+import * as WebBrowser from 'expo-web-browser';
+import {useAnalytics} from 'hooks/useAnalytics';
+import {useTitleSponsor} from 'hooks/useTitleSponsor';
+import {LoggerContext, LoggerProps} from 'loggerContext';
+import {Alert, Image, ImageResolvedAssetSource, Text, TouchableOpacity, View} from 'react-native';
+import Animated, {Easing, useAnimatedStyle, useSharedValue, withDelay, withSpring, withTiming} from 'react-native-reanimated';
+import {colorLookup} from 'theme';
+
+// Underdamped springs so size changes overshoot and bounce once before settling. The collapse
+// spring is slightly calmer: its undershoot dips the pill below chip size, which clips the logo,
+// so it gets more damping than the expand.
+const EXPAND_SPRING = {damping: 13, stiffness: 190, mass: 1};
+const COLLAPSE_SPRING = {damping: 15, stiffness: 190, mass: 1};
+
+// Approximate visual settle time of EXPAND_SPRING — the drain and auto-collapse timers key off this.
+const EXPAND_MS = 460;
+const HOLD_MS = 2200;
+
+const COLLAPSED_WIDTH = 68;
+const COLLAPSED_HEIGHT = 40;
+const EXPANDED_WIDTH = 168;
+const EXPANDED_HEIGHT = 92;
+const PILL_RADIUS = 20;
+
+// Countdown drain: a thin bar along the pill's flat bottom edge (inset past the rounded corners)
+// that shrinks toward its center over the hold, so the pill reads as "on a timer" rather than
+// permanently parked over the map. Laid out inside the pill so it tracks the spring overshoot.
+const TRACE_BAR_HEIGHT = 2;
+const TRACE_BAR_BOTTOM = 6;
+const TRACE_COLOR = '#9CA3AF';
+
+const COLLAPSED_LOGO_VISIBLE_WIDTH = 50;
+const EXPANDED_LOGO_VISIBLE_WIDTH = 116;
+
+// The Nokian logo asset carries transparent padding on both sides (same fractions the first-run
+// modal compensates for), so size by the width we want the *visible* mark to occupy.
+const LOGO_BLANK_LEFT_FRACTION = 0.107;
+const LOGO_BLANK_RIGHT_FRACTION = 0.064;
+const LOGO_VISIBLE_FRACTION = 1 - LOGO_BLANK_LEFT_FRACTION - LOGO_BLANK_RIGHT_FRACTION;
+
+const logoStyleForVisibleWidth = (logo: ImageResolvedAssetSource, visibleWidth: number) => {
+  const assetWidth = visibleWidth / LOGO_VISIBLE_FRACTION;
+  return {...sponsorLogoSize(logo, assetWidth), marginLeft: -assetWidth * LOGO_BLANK_LEFT_FRACTION, marginRight: -assetWidth * LOGO_BLANK_RIGHT_FRACTION};
+};
+
+export interface SponsorWatermarkProps {
+  tabBarHeight: number;
+  // True once the splash is done and no first-run modal is covering the map — the moment the
+  // intro animation should auto-play.
+  active: boolean;
+}
+
+export const SponsorWatermark: React.FC<SponsorWatermarkProps> = ({tabBarHeight, active}) => {
+  const {logger} = React.useContext<LoggerProps>(LoggerContext);
+  const analytics = useAnalytics();
+  const sponsor = useTitleSponsor();
+  const collapsedLogoStyle = useMemo(() => logoStyleForVisibleWidth(sponsor.logoOnLight, COLLAPSED_LOGO_VISIBLE_WIDTH), [sponsor.logoOnLight]);
+  const expandedLogoStyle = useMemo(() => logoStyleForVisibleWidth(sponsor.logoOnLight, EXPANDED_LOGO_VISIBLE_WIDTH), [sponsor.logoOnLight]);
+
+  const width = useSharedValue(COLLAPSED_WIDTH);
+  const height = useSharedValue(COLLAPSED_HEIGHT);
+  const collapsedOpacity = useSharedValue(1);
+  const expandedOpacity = useSharedValue(0);
+  const traceProgress = useSharedValue(0);
+
+  const pillState = useRef<'collapsed' | 'expanded'>('collapsed');
+  const collapseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoPlayed = useRef(false);
+
+  const collapse = useCallback(() => {
+    pillState.current = 'collapsed';
+    if (collapseTimer.current) clearTimeout(collapseTimer.current);
+    expandedOpacity.value = withTiming(0, {duration: 180});
+    collapsedOpacity.value = withDelay(200, withTiming(1, {duration: 220}));
+    width.value = withDelay(120, withSpring(COLLAPSED_WIDTH, COLLAPSE_SPRING));
+    height.value = withDelay(120, withSpring(COLLAPSED_HEIGHT, COLLAPSE_SPRING));
+  }, [width, height, collapsedOpacity, expandedOpacity]);
+
+  const expand = useCallback(() => {
+    pillState.current = 'expanded';
+    if (collapseTimer.current) clearTimeout(collapseTimer.current);
+    width.value = withSpring(EXPANDED_WIDTH, EXPAND_SPRING);
+    height.value = withSpring(EXPANDED_HEIGHT, EXPAND_SPRING);
+    collapsedOpacity.value = withTiming(0, {duration: 150});
+    expandedOpacity.value = withDelay(150, withTiming(1, {duration: 250}));
+    traceProgress.value = 0;
+    traceProgress.value = withDelay(EXPAND_MS, withTiming(1, {duration: HOLD_MS, easing: Easing.linear}));
+    collapseTimer.current = setTimeout(collapse, EXPAND_MS + HOLD_MS);
+  }, [width, height, collapsedOpacity, expandedOpacity, traceProgress, collapse]);
+
+  useEffect(() => {
+    if (active && !autoPlayed.current) {
+      autoPlayed.current = true;
+      expand();
+    }
+  }, [active, expand]);
+
+  useEffect(
+    () => () => {
+      if (collapseTimer.current) clearTimeout(collapseTimer.current);
+    },
+    [],
+  );
+
+  const onPressPill = useCallback(() => {
+    if (pillState.current === 'collapsed') {
+      analytics.capture('sponsorWatermarkTapped');
+      expand();
+    } else {
+      analytics.capture('vistSponsorURLTapped', {eventOrigin: 'mapWatermark'});
+      WebBrowser.openBrowserAsync(sponsor.campaignUrl).catch((e: unknown) => {
+        logger.error({error: e}, 'Failed to open title sponsor URL');
+        Alert.alert('Unable to Open Web Browser', 'An error occured when trying to open the web browser. Please try again.', [
+          {
+            text: 'Okay',
+            style: 'default',
+          },
+        ]);
+      });
+    }
+  }, [analytics, expand, logger, sponsor.campaignUrl]);
+
+  const pillStyle = useAnimatedStyle(() => ({width: width.value, height: height.value}));
+  const collapsedStyle = useAnimatedStyle(() => ({opacity: collapsedOpacity.value}));
+  const expandedStyle = useAnimatedStyle(() => ({opacity: expandedOpacity.value}));
+  const traceBarStyle = useAnimatedStyle(() => ({opacity: expandedOpacity.value, transform: [{scaleX: 1 - traceProgress.value}]}));
+
+  return (
+    <View pointerEvents="box-none" style={{position: 'absolute', left: 0, right: 0, bottom: tabBarHeight + 12}}>
+      <Animated.View
+        style={[
+          {
+            position: 'absolute',
+            right: 12,
+            bottom: 0,
+            backgroundColor: colorLookup('white'),
+            borderRadius: PILL_RADIUS,
+            overflow: 'hidden',
+            shadowColor: '#000',
+            shadowOpacity: 0.15,
+            shadowRadius: 6,
+            shadowOffset: {width: 0, height: 2},
+            elevation: 4,
+          },
+          pillStyle,
+        ]}>
+        <TouchableOpacity activeOpacity={0.85} onPress={onPressPill} style={{flex: 1}}>
+          <Animated.View style={[{position: 'absolute', right: 0, top: 0, bottom: 0, width: COLLAPSED_WIDTH, alignItems: 'center', justifyContent: 'center'}, collapsedStyle]}>
+            <Text numberOfLines={1} style={{fontSize: 7, fontWeight: '700', letterSpacing: 0.6, color: colorLookup('text.secondary'), marginBottom: 1}}>
+              SPONSOR
+            </Text>
+            <Image source={sponsor.logoOnLight} resizeMode="contain" style={collapsedLogoStyle} />
+          </Animated.View>
+          <Animated.View style={[{position: 'absolute', right: 0, top: 0, bottom: 0, width: EXPANDED_WIDTH, alignItems: 'center', justifyContent: 'center'}, expandedStyle]}>
+            <Text numberOfLines={1} style={{fontSize: 10, fontWeight: '700', letterSpacing: 1.2, color: colorLookup('text.secondary'), marginBottom: 8}}>
+              BROUGHT TO YOU BY
+            </Text>
+            <Image source={sponsor.logoOnLight} resizeMode="contain" style={expandedLogoStyle} />
+          </Animated.View>
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              {
+                position: 'absolute',
+                left: PILL_RADIUS,
+                right: PILL_RADIUS,
+                bottom: TRACE_BAR_BOTTOM,
+                height: TRACE_BAR_HEIGHT,
+                borderRadius: TRACE_BAR_HEIGHT / 2,
+                backgroundColor: TRACE_COLOR,
+              },
+              traceBarStyle,
+            ]}
+          />
+        </TouchableOpacity>
+      </Animated.View>
+    </View>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a title-sponsor watermark to the main map view, building on the Nokian title sponsor work from #1219. A small chip with a "SPONSOR" caption and the Nokian logo sits pinned bottom-right on the map, clear of the Mapbox attribution bottom-left.

Once per session — after the splash screen finishes, and only when neither the center picker nor the first-run experience modal is covering the map — the chip springs open into a larger "BROUGHT TO YOU BY" card with a bigger sponsor logo, holds for ~2.2s while a thin bottom bar drains toward its center as a countdown, then springs back down to the chip. Both the expand and collapse use underdamped springs (the collapse slightly calmer to minimize undershoot clipping), so they read as the same snappy gesture in reverse.

## Demo

<img width="394" height="800" alt="CleanShot 2026-08-27 at 15 14 47" src="https://github.com/user-attachments/assets/4a0522e3-a838-42bd-a51d-33b3cbfcd395" />


## Behavior details

- Tapping the collapsed chip replays the expansion (captures `sponsorWatermarkTapped`).
- Tapping the expanded card opens the sponsor campaign URL in the in-app browser, reusing the sponsor drawer's error handling and its `vistSponsorURLTapped` analytics event with `eventOrigin: 'mapWatermark'` so click-through funnels aggregate across both surfaces.
- The Nokian logo asset carries transparent horizontal padding, so logo sizes are specified by visible mark width using the same blank-fraction compensation as the first-run experience modal.
- The countdown bar is laid out inside the pill with edge insets (past the rounded corners), so it stretches and rebounds with the spring overshoot instead of detaching from the border.

## Test plan

- [ ] Cold start as a returning user (center picker and FRE already seen): intro animation auto-plays once after the splash, then never again that session
- [ ] First run: watermark stays collapsed while the center picker / FRE modal are up; intro plays after the FRE modal closes
- [ ] Tap collapsed chip → expands with spring + countdown; tap expanded card → opens nokiantyres.com campaign URL in the in-app browser
- [ ] Watermark doesn't collide with Mapbox attribution or the tab bar on a small screen (e.g. iPhone SE)
- [ ] `yarn ci` passes (prettier, eslint, tsc, 154 tests) — verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790811298&installation_model_id=426131&pr_number=1225&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1225&signature=661f9029aa5f2812953c7107984821c04e858ec66a9a0feae2e6c7728cbd0e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->