### PR TITLE
Fix the ObservationFilterForm

### DIFF
--- a/components/form/DateField.tsx
+++ b/components/form/DateField.tsx
@@ -1,11 +1,12 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import DateTimePicker, {DateTimePickerAndroid, DateTimePickerEvent} from '@react-native-community/datetimepicker';
-import {Center, HStack, VStack, View, ViewProps} from 'components/core';
+import DateTimePicker, {DateTimePickerAndroid, DateTimePickerChangeEvent, DateTimePickerEvent} from '@react-native-community/datetimepicker';
+import {Button} from 'components/content/Button';
+import {Center, HStack, View, ViewProps, VStack} from 'components/core';
 import {FieldLabel} from 'components/form/FieldLabel';
 import {Body, bodySize} from 'components/text';
 import React, {useCallback, useState} from 'react';
 import {useController} from 'react-hook-form';
-import {Platform, TouchableOpacity} from 'react-native';
+import {ColorValue, Platform, TouchableOpacity} from 'react-native';
 import {colorLookup} from 'theme';
 import {utcDateToLocalDateString} from 'utils/date';
 
@@ -20,8 +21,10 @@ interface DateFieldProps extends ViewProps {
 export const DateField: React.FC<DateFieldProps> = ({name, label, minimumDate, maximumDate, disabled, ...props}) => {
   const {field} = useController({name: name});
   const [datePickerVisible, setDatePickerVisible] = useState(false);
+  const value: Date | undefined = field.value as Date | undefined;
+  const [pendingDate, setPendingDate] = useState<Date>(value ?? new Date());
 
-  const onDateSelected = useCallback(
+  const onDateSelectedAndroid = useCallback(
     (event: DateTimePickerEvent, date?: Date) => {
       if (event.type === 'set') {
         field.onChange(date);
@@ -31,7 +34,24 @@ export const DateField: React.FC<DateFieldProps> = ({name, label, minimumDate, m
     [field, setDatePickerVisible],
   );
 
-  const value: Date | undefined = field.value as Date | undefined;
+  const onDateSelectedIOS = useCallback((_: DateTimePickerChangeEvent, date: Date) => {
+    setPendingDate(date);
+  }, []);
+
+  const confirmDateIOS = useCallback(() => {
+    field.onChange(pendingDate);
+    setDatePickerVisible(false);
+  }, [field, pendingDate, setDatePickerVisible]);
+
+  const renderConfirmButtonContent = useCallback(
+    (style: {backgroundColor: ColorValue | undefined; textColor: ColorValue}) => (
+      <HStack space={4} alignItems="center">
+        <Ionicons name="checkmark" color={style.textColor} size={bodySize} />
+        <Body color={style.textColor}>Confirm</Body>
+      </HStack>
+    ),
+    [],
+  );
 
   const toggleDatePicker = useCallback(() => {
     setDatePickerVisible(!datePickerVisible);
@@ -39,10 +59,12 @@ export const DateField: React.FC<DateFieldProps> = ({name, label, minimumDate, m
       if (datePickerVisible) {
         void DateTimePickerAndroid.dismiss('date');
       } else {
-        void DateTimePickerAndroid.open({mode: 'date', display: 'default', onChange: onDateSelected, value: value ?? new Date(), minimumDate, maximumDate});
+        void DateTimePickerAndroid.open({mode: 'date', display: 'default', onChange: onDateSelectedAndroid, value: value ?? new Date(), minimumDate, maximumDate});
       }
+    } else if (!datePickerVisible) {
+      setPendingDate(value ?? new Date());
     }
-  }, [datePickerVisible, setDatePickerVisible, onDateSelected, value, minimumDate, maximumDate]);
+  }, [datePickerVisible, setDatePickerVisible, onDateSelectedAndroid, value, minimumDate, maximumDate]);
 
   return (
     <VStack width="100%" space={4} {...props}>
@@ -59,16 +81,19 @@ export const DateField: React.FC<DateFieldProps> = ({name, label, minimumDate, m
       </TouchableOpacity>
 
       {datePickerVisible && Platform.OS === 'ios' && (
-        <DateTimePicker
-          value={value || new Date()}
-          mode="date"
-          display="inline"
-          themeVariant="light"
-          onChange={onDateSelected}
-          minimumDate={minimumDate}
-          maximumDate={maximumDate}
-          disabled={disabled}
-        />
+        <VStack space={8}>
+          <DateTimePicker
+            value={pendingDate}
+            mode="date"
+            display="inline"
+            themeVariant="light"
+            onValueChange={onDateSelectedIOS}
+            minimumDate={minimumDate}
+            maximumDate={maximumDate}
+            disabled={disabled}
+          />
+          <Button onPress={confirmDateIOS} buttonStyle="primary" alignSelf="flex-end" px={16} py={8} disabled={disabled} renderChildren={renderConfirmButtonContent} />
+        </VStack>
       )}
     </VStack>
   );

--- a/components/observations/ObservationsFilterForm.test.ts
+++ b/components/observations/ObservationsFilterForm.test.ts
@@ -1,0 +1,147 @@
+import {ObservationFilterConfig, createDefaultFilterConfig, filtersForConfig, matchesFilters, matchesZone} from 'components/observations/ObservationsFilterForm';
+import {DangerLevel, MapLayerFeature, ObservationFragment, ObservationZonesFeature, PartnerType, Position} from 'types/nationalAvalancheCenter';
+
+const bboxRing = (west: number, east: number, south: number, north: number): Position[][] => [
+  [
+    [west, south],
+    [east, south],
+    [east, north],
+    [west, north],
+    [west, south],
+  ],
+];
+
+const forecastZone = (id: number, name: string, west: number, east: number, south: number, north: number): MapLayerFeature => ({
+  type: 'Feature',
+  id,
+  geometry: {type: 'Polygon', coordinates: bboxRing(west, east, south, north)},
+  properties: {
+    name,
+    center_id: 'SNFAC',
+    center_link: 'https://www.sawtoothavalanche.com/',
+    state: 'ID',
+    link: 'https://www.sawtoothavalanche.com/forecasts/avalanche/',
+    off_season: true,
+    travel_advice: '',
+    danger: 'no rating',
+    danger_level: DangerLevel.GeneralInformation,
+    start_date: null,
+    end_date: null,
+    warning: {product: null},
+    color: '#888888',
+    stroke: '#104efb',
+    font_color: '#ffffff',
+    fillOpacity: 0.5,
+    fillIncrement: 0.1,
+  },
+});
+
+const alternateZone = (id: number, name: string, west: number, east: number, south: number, north: number): ObservationZonesFeature => ({
+  type: 'Feature',
+  id,
+  geometry: {type: 'Polygon', coordinates: bboxRing(west, east, south, north)},
+  properties: {name, center_id: 'SNFAC'},
+});
+
+// Deliberately non-overlapping boxes so that every fixture observation resolves to exactly one zone
+const FORECAST_ZONES: MapLayerFeature[] = [forecastZone(1, 'Galena Summit', -115, -114, 43, 44), forecastZone(2, 'Banner Summit', -114, -113, 43, 44)];
+
+const ALTERNATE_ZONES: ObservationZonesFeature[] = [alternateZone(-1, 'Boise Mountains', -117, -116, 43, 44), alternateZone(-2, 'Twin Falls Area', -113, -112, 41, 42)];
+
+const observation = (id: string, lng: number, lat: number, observerType: PartnerType): ObservationFragment => ({
+  id,
+  observerType,
+  name: id,
+  startDate: '2026-01-15T12:00:00Z',
+  locationPoint: {lng, lat},
+  locationName: id,
+  instability: {},
+  observationSummary: '',
+  media: [],
+});
+
+const GALENA = observation('galena', -114.5, 43.5, PartnerType.Forecaster);
+const BANNER = observation('banner', -113.5, 43.5, PartnerType.Public);
+const BOISE = observation('boise', -116.5, 43.5, PartnerType.Public);
+const TWIN_FALLS = observation('twinFalls', -112.5, 41.5, PartnerType.Forecaster);
+const NOWHERE = observation('nowhere', -100, 40, PartnerType.Public);
+
+const OBSERVATIONS = [GALENA, BANNER, BOISE, TWIN_FALLS, NOWHERE];
+
+const matchingIds = (config: Partial<ObservationFilterConfig>, additionalFilters?: Partial<ObservationFilterConfig>): string[] => {
+  const filters = filtersForConfig(FORECAST_ZONES, createDefaultFilterConfig(config), additionalFilters, ALTERNATE_ZONES);
+  return OBSERVATIONS.filter(o => matchesFilters(o, filters)).map(o => o.id);
+};
+
+describe('matchesZone', () => {
+  it('resolves an observation to its forecast zone', () => {
+    expect(matchesZone(FORECAST_ZONES, GALENA.locationPoint.lat, GALENA.locationPoint.lng, ALTERNATE_ZONES)).toEqual('Galena Summit');
+  });
+
+  it('falls back to an observation-only zone when no forecast zone matches', () => {
+    expect(matchesZone(FORECAST_ZONES, BOISE.locationPoint.lat, BOISE.locationPoint.lng, ALTERNATE_ZONES)).toEqual('Boise Mountains');
+  });
+
+  it('returns Unknown Zone when nothing matches', () => {
+    expect(matchesZone(FORECAST_ZONES, NOWHERE.locationPoint.lat, NOWHERE.locationPoint.lng, ALTERNATE_ZONES)).toEqual('Unknown Zone');
+  });
+});
+
+describe('matchesFilters', () => {
+  it('passes everything when no filters are configured', () => {
+    expect(matchingIds({})).toEqual(['galena', 'banner', 'boise', 'twinFalls', 'nowhere']);
+  });
+
+  it('filters by forecast zone alone', () => {
+    expect(matchingIds({zones: ['Galena Summit']})).toEqual(['galena']);
+  });
+
+  it('filters by other region alone', () => {
+    expect(matchingIds({otherRegions: ['Boise Mountains']})).toEqual(['boise']);
+  });
+
+  it('ORs zones together', () => {
+    expect(matchingIds({zones: ['Galena Summit', 'Banner Summit']})).toEqual(['galena', 'banner']);
+  });
+
+  // Regression: zones and otherRegions are one logical dimension. matchesZone resolves an observation
+  // to exactly one name, so AND-ing these two would always produce an empty list.
+  it('ORs zones with other regions rather than AND-ing them', () => {
+    expect(matchingIds({zones: ['Galena Summit'], otherRegions: ['Boise Mountains']})).toEqual(['galena', 'boise']);
+  });
+
+  it('ANDs the location group against other filter groups', () => {
+    expect(matchingIds({zones: ['Galena Summit'], observerTypes: [PartnerType.Forecaster]})).toEqual(['galena']);
+    expect(matchingIds({zones: ['Banner Summit'], observerTypes: [PartnerType.Forecaster]})).toEqual([]);
+  });
+
+  it('applies observer type across an OR-ed location group', () => {
+    expect(matchingIds({zones: ['Galena Summit'], otherRegions: ['Twin Falls Area'], observerTypes: [PartnerType.Forecaster]})).toEqual(['galena', 'twinFalls']);
+    expect(matchingIds({zones: ['Galena Summit'], otherRegions: ['Boise Mountains'], observerTypes: [PartnerType.Forecaster]})).toEqual(['galena']);
+  });
+
+  it('ANDs independent filters with each other', () => {
+    expect(matchingIds({observerTypes: [PartnerType.Forecaster], avalanches: ['observed']})).toEqual([]);
+  });
+});
+
+describe('filtersForConfig', () => {
+  it('groups zones and other regions into the location group', () => {
+    const filters = filtersForConfig(FORECAST_ZONES, createDefaultFilterConfig({zones: ['Galena Summit'], otherRegions: ['Boise Mountains']}), undefined, ALTERNATE_ZONES);
+    expect(filters.map(({type, group}) => ({type, group}))).toEqual([
+      {type: 'zone', group: 'location'},
+      {type: 'otherRegions', group: 'location'},
+    ]);
+  });
+
+  it('emits a separately removable pill for each of zones and other regions', () => {
+    const filters = filtersForConfig(FORECAST_ZONES, createDefaultFilterConfig({zones: ['Galena Summit'], otherRegions: ['Boise Mountains']}), undefined, ALTERNATE_ZONES);
+    expect(filters.map(({label}) => label)).toEqual(['Galena Summit', 'Boise Mountains']);
+    expect(filters.every(({removeFilter}) => removeFilter !== undefined)).toBe(true);
+  });
+
+  it('locks the zone pill when the zone comes from additionalFilters', () => {
+    const filters = filtersForConfig(FORECAST_ZONES, createDefaultFilterConfig({zones: ['Galena Summit']}), {zones: ['Galena Summit']}, ALTERNATE_ZONES);
+    expect(filters.map(({type, removeFilter}) => [type, removeFilter !== undefined])).toEqual([['zone', false]]);
+  });
+});

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -31,7 +31,7 @@ type avalancheInstability = z.infer<typeof avalancheInstabilitySchema>;
 
 const observationFilterConfigSchema = z.object({
   zones: z.array(z.string()),
-  otherRegions: z.array(z.string()),
+  otherRegions: z.array(z.string()).default([]),
   dates: z
     .object({
       from: z.date(),
@@ -104,12 +104,32 @@ const matchesAvalanches = (avalanches: avalancheInstability[], observation: Obse
   });
 };
 
-interface FilterListItem {
+type FilterGroup = 'none' | 'location';
+
+export interface FilterListItem {
   type: 'date' | 'zone' | 'observer' | 'instability' | 'avalanche' | 'otherRegions';
+  group: FilterGroup;
   filter: FilterFunction;
   label: string;
   removeFilter?: (config: ObservationFilterConfig) => ObservationFilterConfig;
 }
+
+// Filters sharing a group are OR'd together; groups are AND'd against each other. A filter in the
+// 'none' group stands alone, so it always AND's with everything else.
+export const matchesFilters = (observation: ObservationFragment, filters: FilterListItem[]): boolean => {
+  const groups = new Map<string, FilterFunction[]>();
+  filters.forEach(({group, type, filter}) => {
+    const key = group === 'none' ? type : group;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(filter);
+    } else {
+      groups.set(key, [filter]);
+    }
+  });
+  return Array.from(groups.values()).every(groupFilters => groupFilters.some(filter => filter(observation)));
+};
+
 export const filtersForConfig = (
   mapLayerFeatures: MapLayerFeature[],
   config: ObservationFilterConfig,
@@ -124,6 +144,7 @@ export const filtersForConfig = (
   if (config.dates && config.dates.from && config.dates.to) {
     filterFuncs.push({
       type: 'date',
+      group: 'none',
       filter: matchesDates(config.dates),
       label: dateLabelForFilterConfig(config.dates),
       removeFilter: (config: ObservationFilterConfig) => ({...config, dates: null}),
@@ -133,6 +154,7 @@ export const filtersForConfig = (
   if (config.zones.length > 0) {
     filterFuncs.push({
       type: 'zone',
+      group: 'location',
       filter: (observation: ObservationFragment) =>
         config.zones.includes(matchesZone(mapLayerFeatures, observation.locationPoint?.lat, observation.locationPoint?.lng, alternateObservationZoneFeatures)),
       removeFilter: additionalFilters?.zones ? undefined : (config: ObservationFilterConfig) => ({...config, zones: []}),
@@ -143,9 +165,10 @@ export const filtersForConfig = (
   if (config.otherRegions.length > 0) {
     filterFuncs.push({
       type: 'otherRegions',
+      group: 'location',
       filter: (observation: ObservationFragment) =>
         config.otherRegions.includes(matchesZone(mapLayerFeatures, observation.locationPoint?.lat, observation.locationPoint?.lng, alternateObservationZoneFeatures)),
-      removeFilter: additionalFilters?.zones ? undefined : (config: ObservationFilterConfig) => ({...config, otherRegions: []}),
+      removeFilter: additionalFilters?.otherRegions ? undefined : (config: ObservationFilterConfig) => ({...config, otherRegions: []}),
       label: config.otherRegions.join(', '),
     });
   }
@@ -153,6 +176,7 @@ export const filtersForConfig = (
   if (config.observerTypes.length > 0) {
     filterFuncs.push({
       type: 'observer',
+      group: 'none',
       filter: (observation: ObservationFragment) => config.observerTypes.includes(observation.observerType),
       removeFilter: (config: ObservationFilterConfig) => ({...config, observerTypes: []}),
       label: config.observerTypes.map(startCase).join(', '),
@@ -162,6 +186,7 @@ export const filtersForConfig = (
   if (config.avalanches.length > 0) {
     filterFuncs.push({
       type: 'avalanche',
+      group: 'none',
       filter: (observation: ObservationFragment) => matchesAvalanches(config.avalanches, observation),
       removeFilter: (config: ObservationFilterConfig) => ({...config, avalanches: []}),
       label: config.avalanches.map(startCase).join(', '),
@@ -179,6 +204,7 @@ export const filtersForConfig = (
 
     filterFuncs.push({
       type: 'instability',
+      group: 'none',
       filter: observation => matchesInstability(config, observation),
       label: labelStrings.map(startCase).join(', '),
       removeFilter: config => ({...config, cracking: false, collapsing: false}),
@@ -363,7 +389,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
                             ? initialFilterConfig.otherRegions.map(z => ({label: z, value: z}))
                             : alternateObservationZoneFeatures.map(feature => ({label: feature.properties.name, value: feature.properties.name}))
                         }
-                        disabled={initialFilterConfig.otherRegions.length > 0}
+                        disabled={initialFilterConfig.zones.length > 0 || initialFilterConfig.otherRegions.length > 0}
                         px={16}
                       />
                     </>

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -11,7 +11,14 @@ import {NotFound, QueryState, incompleteQueryState} from 'components/content/Que
 import {NetworkImage} from 'components/content/carousel/NetworkImage';
 import {Center, Divider, HStack, VStack, View} from 'components/core';
 import {NACAvalancheIcon} from 'components/icons/nac-icons';
-import {ObservationFilterConfig, ObservationsFilterForm, createDefaultFilterConfig, filtersForConfig, matchesZone} from 'components/observations/ObservationsFilterForm';
+import {
+  ObservationFilterConfig,
+  ObservationsFilterForm,
+  createDefaultFilterConfig,
+  filtersForConfig,
+  matchesFilters,
+  matchesZone,
+} from 'components/observations/ObservationsFilterForm';
 import {usePendingObservations} from 'components/observations/uploader/usePendingObservations';
 import {Body, BodyBlack, BodySm, BodySmBlack, BodyXSm, Caption1Semibold, bodySize, bodyXSmSize} from 'components/text';
 import {compareDesc, formatDuration, isBefore, parseISO, sub} from 'date-fns';
@@ -150,8 +157,9 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const {isRefreshing, refresh} = useRefresh(observationsResult.refetch);
   const refreshWrapper = useCallback(() => void refresh(), [refresh]);
 
-  // the displayed observations need to match all filters - for instance, if a user chooses a zone *and*
-  // an observer type, we only show observations that match both of those at the same time
+  // the displayed observations need to match every filter group - for instance, if a user chooses a zone *and*
+  // an observer type, we only show observations that match both of those at the same time. A group is satisfied
+  // by any one of its filters, so zone and other regions - which share the 'location' group - are OR'd together.
   const resolvedFilters = useMemo(
     () => filtersForConfig(mapFeatures, filterConfig, additionalFilters, filteredAlternateObservationZoneFeatures),
     [mapFeatures, filterConfig, additionalFilters, filteredAlternateObservationZoneFeatures],
@@ -177,7 +185,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         if (!pageResult.hasNextPage) {
           break;
         }
-        const fetchCount = pageResult.data?.pages.at(-1)?.data?.filter(observation => resolvedFilters.every(({filter}) => filter(observation))).length ?? 0;
+        const fetchCount = pageResult.data?.pages.at(-1)?.data?.filter(observation => matchesFilters(observation, resolvedFilters)).length ?? 0;
         if (fetchCount > 0) {
           logger.debug('fetchMoreData exiting because of fetchCount');
           break;
@@ -230,7 +238,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
     () => ({
       title: 'Published Results',
       data: observations
-        .filter(observation => resolvedFilters.every(({filter}) => filter(observation)))
+        .filter(observation => matchesFilters(observation, resolvedFilters))
         .map(
           observation =>
             ({

--- a/components/screens/navigation/BottomTabs.tsx
+++ b/components/screens/navigation/BottomTabs.tsx
@@ -138,7 +138,7 @@ const ObservationsListScreen = ({route}: NativeStackScreenProps<TabNavigatorPara
   const {center_id, requestedTime} = route.params;
 
   return (
-    <View style={{...styles.fullScreen, backgroundColor: 'white'}}>
+    <View style={{...styles.fullScreen, backgroundColor: 'white'}} key={`${center_id}_observations`}>
       <BottomTabBarHeightContext.Consumer>
         {tabBarHeight => <ObservationsListView center_id={center_id} requestedTime={parseRequestedTimeString(requestedTime)} tabBarHeight={tabBarHeight} />}
       </BottomTabBarHeightContext.Consumer>


### PR DESCRIPTION
#1218 Introduced a breaking change to the ObservationFilterForm in centers that do not have "Other Regions". This PR fixes that bug as well as changes how the filters are applied to observations.

## Changes to filters
A new concept of a `FilterGroup` and a new helper function `matchesFilters` were introduced to allow for filters of different types to be OR'd together instead of AND'd together. Before, all distinct filter types filtered observations by an AND operation of all of the filters that the user selected. However, "Zones" and "Other Regions" are presented as different types to match web, but really these filters should be OR'd together. `FilterGroups` allows us to flag that certain filters are filtering the same thing which is OR-ing them together

## Update to `DateTimePicker`
@rustynwac pointed out in #1224 that the picker isn't working properly when changing the year. This is because changing the year/month with the scroll picker (seen in the video from the issue) triggers a `onValueChange` event. There's no way to determine if that value was an intermittent change or the final decision from the user, so we take that value, update the field, and close the picker. This isn't a great experience, and DateTimePicker does not have a built in solution for this, so I added a "Confirm" button to accomplish this

<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-01 at 12 28 11" src="https://github.com/user-attachments/assets/2dc09328-b8e6-4118-b736-ee715ea6dc35" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790884011&installation_model_id=426131&pr_number=1226&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1226&signature=3fee64b93fb84ac131cad36c69a5a3a2f9cc876b8ec4ed4701393f35aa871035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->