### PR TITLE
Update metric naming

### DIFF
--- a/FeatureFlags.tsx
+++ b/FeatureFlags.tsx
@@ -71,7 +71,8 @@ export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({child
         buildNumber: Number.parseInt(Application.nativeBuildVersion || '0'),
         updateGroupId: getUpdateGroupId(),
         updateBuildTime: process.env.EXPO_PUBLIC_GIT_REVISION as string,
-        channel: Updates.channel || 'development',
+        environment: Updates.channel || 'development',
+        source: 'nwacus/avy',
       });
       logger.debug('registered user');
       setRegistered(true);

--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, ReactNode, useCallback, useEffect, useState} from 'react';
+import React, {PropsWithChildren, ReactNode, useCallback, useState} from 'react';
 
 import {Collapsible} from 'components/content/Collapsible';
 import {ColorValue, TouchableOpacity, ViewStyle} from 'react-native';
@@ -6,7 +6,7 @@ import {ColorValue, TouchableOpacity, ViewStyle} from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 import {Divider, HStack, View, ViewProps, VStack} from 'components/core';
-import {usePostHog} from 'posthog-react-native';
+import {useAnalytics} from 'hooks/useAnalytics';
 import {colorLookup} from 'theme';
 
 export interface CardProps extends ViewProps {
@@ -134,16 +134,12 @@ export interface CollapsibleCardProps extends CardProps {
 export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<CollapsibleCardProps>> = ({identifier, startsCollapsed, header, children, noDivider, ...props}) => {
   const [isCollapsed, setIsCollapsed] = useState(startsCollapsed);
   const textColor = colorLookup('text');
+  const analytics = useAnalytics();
   const pressHandler = useCallback(() => {
-    setIsCollapsed(!isCollapsed);
-  }, [isCollapsed]);
-  const postHog = usePostHog();
-  useEffect(() => {
-    if (postHog && identifier && isCollapsed !== startsCollapsed) {
-      // capture the even when the user decided to interact with the card, don't send something without interaction
-      postHog.capture('card', {identifier: identifier, isCollapsed: isCollapsed});
-    }
-  }, [identifier, postHog, isCollapsed, startsCollapsed]);
+    const newValue = !isCollapsed;
+    analytics.capture('collapsible_card_tapped', {identifier: identifier, is_collapsed_old_value: isCollapsed, is_collapsed_new_value: newValue});
+    setIsCollapsed(newValue);
+  }, [analytics, identifier, isCollapsed]);
 
   return (
     <Card

--- a/components/content/carousel/MediaViewerModal/MediaContentView.tsx
+++ b/components/content/carousel/MediaViewerModal/MediaContentView.tsx
@@ -3,7 +3,7 @@ import {PDFView} from 'components/content/carousel/MediaViewerModal/PDFView';
 import {WebVideoView} from 'components/content/carousel/MediaViewerModal/WebVideoView';
 import {View} from 'components/core';
 import {BodySm} from 'components/text';
-import {usePostHog} from 'posthog-react-native';
+import {useAnalytics} from 'hooks/useAnalytics';
 import React, {useEffect} from 'react';
 import {useWindowDimensions} from 'react-native';
 import {NativeGesture} from 'react-native-gesture-handler';
@@ -16,7 +16,7 @@ interface MediaContentProps {
 }
 
 export const MediaContentView: React.FunctionComponent<MediaContentProps> = ({item, isVisible, nativeGesture}) => {
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
   const dimensions = useWindowDimensions();
 
   let content: React.JSX.Element;
@@ -34,10 +34,10 @@ export const MediaContentView: React.FunctionComponent<MediaContentProps> = ({it
   }
 
   useEffect(() => {
-    if (postHog && !isMediaSupported) {
-      postHog.capture('mediaContentView-UnsupportedMedia', {mediaType: item.type});
+    if (!isMediaSupported) {
+      analytics.capture('unsupported_media_found', {mediaType: item.type});
     }
-  }, [postHog, isMediaSupported, item]);
+  }, [analytics, isMediaSupported, item]);
 
   return <View style={{width: dimensions.width, flex: 1}}>{content}</View>;
 };

--- a/components/content/carousel/MediaViewerModal/PDFView.tsx
+++ b/components/content/carousel/MediaViewerModal/PDFView.tsx
@@ -1,5 +1,5 @@
 import {WebMediaView} from 'components/content/carousel/MediaViewerModal/WebMediaView';
-import {usePostHog} from 'posthog-react-native';
+import {useAnalytics} from 'hooks/useAnalytics';
 import React, {useEffect} from 'react';
 import {Platform} from 'react-native';
 import {WebViewSource} from 'react-native-webview/lib/WebViewTypes';
@@ -16,13 +16,11 @@ const getPdfSource = (item: PDFMediaItem): WebViewSource => ({
 });
 
 export const PDFView: React.FunctionComponent<PDFViewProps> = ({item}: PDFViewProps) => {
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   useEffect(() => {
-    if (postHog) {
-      postHog.capture('pdfView-Opened', {url: item.url.original});
-    }
-  }, [postHog, item.url.original]);
+    analytics.capture('pdf_opened', {url: item.url.original});
+  }, [analytics, item.url.original]);
 
   return <WebMediaView source={getPdfSource(item)} heightFraction={0.7} errorMessage="An error occurred loading the PDF. Please try again" scalesPageToFit />;
 };

--- a/components/content/carousel/MediaViewerModal/WebVideoView.tsx
+++ b/components/content/carousel/MediaViewerModal/WebVideoView.tsx
@@ -2,7 +2,7 @@ import {WebMediaView, WebMediaViewHandle} from 'components/content/carousel/Medi
 import {Center} from 'components/core';
 import {BodySm} from 'components/text';
 import Constants from 'expo-constants';
-import {usePostHog} from 'posthog-react-native';
+import {useAnalytics} from 'hooks/useAnalytics';
 import React, {useEffect, useRef} from 'react';
 import {Platform} from 'react-native';
 import {WebViewSource} from 'react-native-webview/lib/WebViewTypes';
@@ -47,7 +47,7 @@ const refererValue = (bundleID: string) => `https://${bundleID}`;
 
 export const WebVideoView: React.FunctionComponent<WebVideoViewProps> = ({item, isVisible}: WebVideoViewProps) => {
   const handleRef = useRef<WebMediaViewHandle>(null);
-  const postHog = usePostHog();
+  const analytics = useAnalytics();
 
   useEffect(() => {
     if (!isVisible) {
@@ -56,16 +56,14 @@ export const WebVideoView: React.FunctionComponent<WebVideoViewProps> = ({item, 
   }, [isVisible]);
 
   useEffect(() => {
-    if (postHog) {
-      let properties: {[key: string]: string} = {};
-      if (typeof item.url === 'string') {
-        properties = {url: item.url};
-      } else if ('external_link' in item.url) {
-        properties = {url: item.url.external_link};
-      }
-      postHog.capture('webVideoView-UnsupportedVideoUrl', properties);
+    let properties: {[key: string]: string} = {};
+    if (typeof item.url === 'string') {
+      properties = {url: item.url};
+    } else if ('external_link' in item.url) {
+      properties = {url: item.url.external_link};
     }
-  }, [postHog, item.url]);
+    analytics.capture('unsupported_video_url_received', properties);
+  }, [analytics, item.url]);
 
   let sourceData: WebViewSource;
   try {

--- a/components/content/navigation/NavigationHeader.tsx
+++ b/components/content/navigation/NavigationHeader.tsx
@@ -72,7 +72,7 @@ export const NavigationHeader: React.FunctionComponent<NativeStackHeaderProps> =
       return;
     }
 
-    analytics.capture('shareButtonPressed', {presentedFrom: getPresentedFromForAnalytics(navigation)});
+    analytics.capture('share_button_pressed', {presentedFrom: getPresentedFromForAnalytics(navigation)});
 
     Share.share({
       message: shareUrl,

--- a/components/observations/ObservationForm.tsx
+++ b/components/observations/ObservationForm.tsx
@@ -241,7 +241,7 @@ export const ObservationForm: React.FC<{
         formContext.setValue('avalanches', []);
       }
 
-      analytics.capture('submitObsButtonPressed', {presentedFrom: getPresentedFromForAnalytics(navigation)});
+      analytics.capture('submit_obs_button_pressed', {presentedFrom: getPresentedFromForAnalytics(navigation)});
       // Force validation errors to show up on fields that haven't been visited yet
       await formContext.trigger();
       // Then try to submit the form

--- a/components/screens/navigation/Drawer.tsx
+++ b/components/screens/navigation/Drawer.tsx
@@ -123,7 +123,7 @@ const DrawerMenu: React.FunctionComponent<DrawerMenuProps> = ({navigation, avala
   }, [navigation, staging, setStaging]);
 
   const openSponsorDrawer = useCallback(() => {
-    analytics.capture('sponsorSectionTapped');
+    analytics.capture('sponsor_section_tapped');
     setShowSponsorDrawer(true);
   }, [setShowSponsorDrawer, analytics]);
 
@@ -238,7 +238,7 @@ const SponsorDrawer: React.FunctionComponent<{visible: boolean; onDismiss: () =>
   const logoStyle = useMemo(() => sponsorLogoSize(sponsor.logoOnLight, SPONSOR_LOGO_WIDTH), [sponsor.logoOnLight]);
 
   const visitSponsor = useCallback(() => {
-    analytics.capture('vistSponsorURLTapped');
+    analytics.capture('vist_sponsor_url_tapped');
     WebBrowser.openBrowserAsync(sponsor.campaignUrl).catch((e: unknown) => {
       logger.error({error: e}, 'Failed to open title sponsor URL');
       Alert.alert('Unable to Open Web Browser', 'An error occured when trying to open the web browser. Please try again.', [

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -50,7 +50,7 @@ export const createAnalytics = (postHog: PostHog | undefined, logger: Logger): A
     postHog?.capture(...args);
   },
   captureCenterSwitch: (switchedFrom, switchedTo, origin) => {
-    postHog?.capture('centerSwitch', {switchedFrom: switchedFrom, switchedTo: switchedTo, eventOrigin: origin});
+    postHog?.capture('center_switched', {switchedFrom: switchedFrom, switchedTo: switchedTo, eventOrigin: origin});
   },
   identify: (...args) => {
     postHog?.identify(...args);


### PR DESCRIPTION
Changes custom metrics to match the agreed upon snake casing, adds `source` to the super properties, and updates `channel` to `environment`

### Updated names in production:
- `card` -> `collapsible_card_tapped`
    - new properties: `is_collapsed_old_value` and `is_collapsed_new_value`
- `mediaContentView-UnsupportedMedia` -> `unsupported_media_found`
- `pdfView-Opened` -> `pdf_opened`
- `webVideoView-UnsupportedVideoUrl` -> `unsupported_video_url_received`
- `shareButtonPressed` -> `share_button_pressed`
- `submitObsButtonPressed` -> `submit_obs_button_pressed`
- `centerSwitch` -> `center_switched`

### Sponsor metrics
- `sponsor_section_tapped`
- `vist_sponsor_url_tapped`

A follow-up PR will add the center id to all of the events captured through our analytics

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071347&installation_model_id=426131&pr_number=1231&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1231&signature=39756f4e55c34ab80529603320e819f358125fe86317a0e15fcbb9af7a26441d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->