### PR TITLE
Hide CAIC in release

### DIFF
--- a/hooks/useAllMapLayers.ts
+++ b/hooks/useAllMapLayers.ts
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/react-native';
 import {Logger} from 'browser-bunyan';
 import {ClientContext, ClientProps} from 'clientContext';
 import {formatDistanceToNowStrict} from 'date-fns';
+import * as Updates from 'expo-updates';
 import {safeFetch} from 'hooks/fetch';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {MapLayer, mapLayerSchema} from 'types/nationalAvalancheCenter';
@@ -88,10 +89,15 @@ const fetchAllMapLayers = async (nationalAvalancheCenterHost: string, requestedT
       throw cbacResult.error;
     } else {
       // CAIC and CBAC overlap on the map. The following modifies the CAIC polygons so that they do not overlap with CBAC
-      const caicFeatures = parseResult.data.features.filter(f => f.properties.center_id === 'CAIC');
-      const otherFeatures = parseResult.data.features.filter(f => f.properties.center_id !== 'CAIC');
-      const carvedCAIC = carvePolygonFeatures(caicFeatures, cbacResult.data.features, thisLogger);
-      parseResult.data.features = otherFeatures.concat(carvedCAIC, cbacResult.data.features);
+      // In release CAIC should be completely hidden for now.
+      const caicRemovedFeatures = parseResult.data.features.filter(f => f.properties.center_id !== 'CAIC');
+      if (Updates.channel === 'release') {
+        parseResult.data.features = caicRemovedFeatures.concat(cbacResult.data.features);
+      } else {
+        const caicFeatures = parseResult.data.features.filter(f => f.properties.center_id === 'CAIC');
+        const carvedCAIC = carvePolygonFeatures(caicFeatures, cbacResult.data.features, thisLogger);
+        parseResult.data.features = caicRemovedFeatures.concat(carvedCAIC, cbacResult.data.features);
+      }
       return parseResult.data;
     }
   }


### PR DESCRIPTION
Until #1150 is in, CAIC will be hidden in `release` builds. I'm leaving it in in Preview for testing purposed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791072106&installation_model_id=426131&pr_number=1232&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1232&signature=f7550ec098b6a92ec14bc2061a6613353f4c30b860396c377282b53b339c879b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->