### PR TITLE
Improve SponsorSection CTA

### DIFF
--- a/components/screens/navigation/Drawer.tsx
+++ b/components/screens/navigation/Drawer.tsx
@@ -225,6 +225,10 @@ const SponsorSection: React.FunctionComponent<{onPress: () => void}> = ({onPress
           <Center>
             <Image source={sponsor.logoOnLight} resizeMode="contain" style={logoStyle} />
           </Center>
+          <HStack space={4} alignItems="center" justifyContent="center" paddingTop={4}>
+            <Body color={colorLookup('primary')}>Why we partner with {sponsor.displayName}</Body>
+            <Ionicons name="chevron-forward" size={bodySize} color={colorLookup('primary')} />
+          </HStack>
         </VStack>
       </TouchableOpacity>
     </VStack>


### PR DESCRIPTION
Improves the CTA in the `SponsorSection` of `Drawer.tsx`

<img width="230" height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-08 at 15 37 41" src="https://github.com/user-attachments/assets/308de65c-2709-4572-800c-aadd80cd8b51" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/avy/pr/1234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791499275&installation_model_id=426131&pr_number=1234&repository=NWACus%2Favy&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Favy%2Fpull%2F1234&signature=047f177ffed3e40f844917813c1cbab92fc2e208b2cf5ac013fbd843c28e5a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->